### PR TITLE
Add mouse callback

### DIFF
--- a/visualization/gl_window/gl_window.hh
+++ b/visualization/gl_window/gl_window.hh
@@ -56,6 +56,8 @@ class GlWindow {
 
     using RenderCallback = std::function<void()>;
     using MousePosCallback = std::function<void(const double x, const double y)>;
+    using MouseButtonCallback =
+        std::function<void(const int button, const int action, const int mods)>;
     using KeyboardCallback =
         std::function<void(const int key, const int scancode, const int action, const int mods)>;
     using ResizeCallback = std::function<void(const int width, const int height)>;
@@ -66,11 +68,14 @@ class GlWindow {
     // so ensure proper synchonization is used.
     void register_render_callback(RenderCallback f);
     void register_mouse_pos_callback(MousePosCallback f);
+    void register_mouse_button_callback(MouseButtonCallback f);
     void register_keyboard_callback(KeyboardCallback f);
     void register_window_resize_callback(ResizeCallback f);
 
     // Request to close the window and blocks until the ui thread exits
     void close();
+
+    bool is_window_open() const;
 
     WindowDims get_window_dims() const;
 


### PR DESCRIPTION
Add the ability to register a mouse callback.
Additionally, to prevent getting window size before the data has been populated, add a condition variable on the contents.