### PR TITLE
Fix redheffer star order

### DIFF
--- a/common/math/redheffer_star.cc
+++ b/common/math/redheffer_star.cc
@@ -10,15 +10,14 @@ Eigen::MatrixXd scattering_from_transfer(const Eigen::MatrixXd &a) {
     // a = [[A B]
     //      [C D]]
     const int dim = a.rows() / 2;
-    const Eigen::MatrixXd A_11 = a.topLeftCorner(dim, dim);
-    const Eigen::MatrixXd A_12 = a.topRightCorner(dim, dim);
-    const Eigen::MatrixXd A_21 = a.bottomLeftCorner(dim, dim);
-    const Eigen::MatrixXd A_22 = a.bottomRightCorner(dim, dim);
+    const Eigen::MatrixXd A = a.topLeftCorner(dim, dim);
+    const Eigen::MatrixXd B = a.topRightCorner(dim, dim);
+    const Eigen::MatrixXd C = a.bottomLeftCorner(dim, dim);
+    const Eigen::MatrixXd D = a.bottomRightCorner(dim, dim);
 
-    const Eigen::MatrixXd A_11_inv = A_11.inverse();
+    const Eigen::MatrixXd A_inv = A.inverse();
 
-    return (Eigen::MatrixXd(2 * dim, 2 * dim) << A_11_inv, -A_11_inv * A_12, A_21 * A_11_inv,
-            A_22 - A_21 * A_11_inv * A_12)
+    return (Eigen::MatrixXd(2 * dim, 2 * dim) << A_inv, -A_inv * B, C * A_inv, D - C * A_inv * B)
         .finished();
 }
 

--- a/common/math/redheffer_star.cc
+++ b/common/math/redheffer_star.cc
@@ -45,12 +45,12 @@ Eigen::MatrixXd redheffer_star(const Eigen::MatrixXd &a, const Eigen::MatrixXd &
     const Eigen::MatrixXd Z = b.bottomRightCorner(dim, dim);
 
     const Eigen::MatrixXd I = Eigen::MatrixXd::Identity(dim, dim);
-    const Eigen::MatrixXd I_min_BY_inv = (I - B * Y).inverse();
-    const Eigen::MatrixXd I_min_YB_inv = (I - Y * B).inverse();
+    const Eigen::MatrixXd W_I_min_BY_inv = W * (I - B * Y).inverse();
+    const Eigen::MatrixXd D_I_min_YB_inv = D * (I - Y * B).inverse();
 
-    return (Eigen::MatrixXd(2 * dim, 2 * dim) << W * I_min_BY_inv * A,
-            X + W * I_min_BY_inv * B * Z,
-            C + D * I_min_YB_inv * Y * A, D * I_min_YB_inv * Z)
+    return (Eigen::MatrixXd(2 * dim, 2 * dim) << W_I_min_BY_inv * A,
+            X + W_I_min_BY_inv * B * Z,
+            C + D_I_min_YB_inv * Y * A, D_I_min_YB_inv * Z)
         .finished();
 }
 }  // namespace robot::math

--- a/common/math/redheffer_star.cc
+++ b/common/math/redheffer_star.cc
@@ -48,8 +48,7 @@ Eigen::MatrixXd redheffer_star(const Eigen::MatrixXd &a, const Eigen::MatrixXd &
     const Eigen::MatrixXd W_I_min_BY_inv = W * (I - B * Y).inverse();
     const Eigen::MatrixXd D_I_min_YB_inv = D * (I - Y * B).inverse();
 
-    return (Eigen::MatrixXd(2 * dim, 2 * dim) << W_I_min_BY_inv * A,
-            X + W_I_min_BY_inv * B * Z,
+    return (Eigen::MatrixXd(2 * dim, 2 * dim) << W_I_min_BY_inv * A, X + W_I_min_BY_inv * B * Z,
             C + D_I_min_YB_inv * Y * A, D_I_min_YB_inv * Z)
         .finished();
 }

--- a/common/math/redheffer_star.cc
+++ b/common/math/redheffer_star.cc
@@ -34,23 +34,23 @@ Eigen::MatrixXd redheffer_star(const Eigen::MatrixXd &a, const Eigen::MatrixXd &
     // b = [[W X]
     //      [Y Z]]
     const int dim = a.rows() / 2;
-    const Eigen::MatrixXd A_11 = a.topLeftCorner(dim, dim);
-    const Eigen::MatrixXd A_12 = a.topRightCorner(dim, dim);
-    const Eigen::MatrixXd A_21 = a.bottomLeftCorner(dim, dim);
-    const Eigen::MatrixXd A_22 = a.bottomRightCorner(dim, dim);
+    const Eigen::MatrixXd A = a.topLeftCorner(dim, dim);
+    const Eigen::MatrixXd B = a.topRightCorner(dim, dim);
+    const Eigen::MatrixXd C = a.bottomLeftCorner(dim, dim);
+    const Eigen::MatrixXd D = a.bottomRightCorner(dim, dim);
 
-    const Eigen::MatrixXd B_11 = b.topLeftCorner(dim, dim);
-    const Eigen::MatrixXd B_12 = b.topRightCorner(dim, dim);
-    const Eigen::MatrixXd B_21 = b.bottomLeftCorner(dim, dim);
-    const Eigen::MatrixXd B_22 = b.bottomRightCorner(dim, dim);
+    const Eigen::MatrixXd W = b.topLeftCorner(dim, dim);
+    const Eigen::MatrixXd X = b.topRightCorner(dim, dim);
+    const Eigen::MatrixXd Y = b.bottomLeftCorner(dim, dim);
+    const Eigen::MatrixXd Z = b.bottomRightCorner(dim, dim);
 
     const Eigen::MatrixXd I = Eigen::MatrixXd::Identity(dim, dim);
-    const Eigen::MatrixXd I_min_A_12_B_21_inv = (I - A_12 * B_21).inverse();
-    const Eigen::MatrixXd I_min_B_21_A_12_inv = (I - B_21 * A_12).inverse();
+    const Eigen::MatrixXd I_min_BY_inv = (I - B * Y).inverse();
+    const Eigen::MatrixXd I_min_YB_inv = (I - Y * B).inverse();
 
-    return (Eigen::MatrixXd(2 * dim, 2 * dim) << B_11 * I_min_A_12_B_21_inv * A_11,
-            B_12 + B_11 * I_min_A_12_B_21_inv * A_12 * B_22,
-            A_21 + A_22 * I_min_B_21_A_12_inv * B_21 * A_11, A_22 * I_min_B_21_A_12_inv * B_22)
+    return (Eigen::MatrixXd(2 * dim, 2 * dim) << W * I_min_BY_inv * A,
+            X + W * I_min_BY_inv * B * Z,
+            C + D * I_min_YB_inv * Y * A, D * I_min_YB_inv * Z)
         .finished();
 }
 }  // namespace robot::math

--- a/common/math/redheffer_star.cc
+++ b/common/math/redheffer_star.cc
@@ -10,14 +10,15 @@ Eigen::MatrixXd scattering_from_transfer(const Eigen::MatrixXd &a) {
     // a = [[A B]
     //      [C D]]
     const int dim = a.rows() / 2;
-    const Eigen::MatrixXd A = a.topLeftCorner(dim, dim);
-    const Eigen::MatrixXd B = a.topRightCorner(dim, dim);
-    const Eigen::MatrixXd C = a.bottomLeftCorner(dim, dim);
-    const Eigen::MatrixXd D = a.bottomRightCorner(dim, dim);
+    const Eigen::MatrixXd A_11 = a.topLeftCorner(dim, dim);
+    const Eigen::MatrixXd A_12 = a.topRightCorner(dim, dim);
+    const Eigen::MatrixXd A_21 = a.bottomLeftCorner(dim, dim);
+    const Eigen::MatrixXd A_22 = a.bottomRightCorner(dim, dim);
 
-    const Eigen::MatrixXd D_inv = D.inverse();
+    const Eigen::MatrixXd A_11_inv = A_11.inverse();
 
-    return (Eigen::MatrixXd(2 * dim, 2 * dim) << A - B * D_inv * C, B * D_inv, -D_inv * C, D_inv)
+    return (Eigen::MatrixXd(2 * dim, 2 * dim) << A_11_inv, -A_11_inv * A_12, A_21 * A_11_inv,
+            A_22 - A_21 * A_11_inv * A_12)
         .finished();
 }
 
@@ -33,23 +34,23 @@ Eigen::MatrixXd redheffer_star(const Eigen::MatrixXd &a, const Eigen::MatrixXd &
     // b = [[W X]
     //      [Y Z]]
     const int dim = a.rows() / 2;
-    const Eigen::MatrixXd A = a.topLeftCorner(dim, dim);
-    const Eigen::MatrixXd B = a.topRightCorner(dim, dim);
-    const Eigen::MatrixXd C = a.bottomLeftCorner(dim, dim);
-    const Eigen::MatrixXd D = a.bottomRightCorner(dim, dim);
+    const Eigen::MatrixXd A_11 = a.topLeftCorner(dim, dim);
+    const Eigen::MatrixXd A_12 = a.topRightCorner(dim, dim);
+    const Eigen::MatrixXd A_21 = a.bottomLeftCorner(dim, dim);
+    const Eigen::MatrixXd A_22 = a.bottomRightCorner(dim, dim);
 
-    const Eigen::MatrixXd W = b.topLeftCorner(dim, dim);
-    const Eigen::MatrixXd X = b.topRightCorner(dim, dim);
-    const Eigen::MatrixXd Y = b.bottomLeftCorner(dim, dim);
-    const Eigen::MatrixXd Z = b.bottomRightCorner(dim, dim);
+    const Eigen::MatrixXd B_11 = b.topLeftCorner(dim, dim);
+    const Eigen::MatrixXd B_12 = b.topRightCorner(dim, dim);
+    const Eigen::MatrixXd B_21 = b.bottomLeftCorner(dim, dim);
+    const Eigen::MatrixXd B_22 = b.bottomRightCorner(dim, dim);
 
-    const Eigen::MatrixXd W_I_min_BY_inv =
-        W * (Eigen::MatrixXd::Identity(dim, dim) - B * Y).inverse();
-    const Eigen::MatrixXd D_I_min_YB_inv =
-        D * (Eigen::MatrixXd::Identity(dim, dim) - Y * B).inverse();
+    const Eigen::MatrixXd I = Eigen::MatrixXd::Identity(dim, dim);
+    const Eigen::MatrixXd I_min_A_12_B_21_inv = (I - A_12 * B_21).inverse();
+    const Eigen::MatrixXd I_min_B_21_A_12_inv = (I - B_21 * A_12).inverse();
 
-    return (Eigen::MatrixXd(2 * dim, 2 * dim) << W_I_min_BY_inv * A, X + W_I_min_BY_inv * B * Z,
-            C + D_I_min_YB_inv * Y * A, D_I_min_YB_inv * Z)
+    return (Eigen::MatrixXd(2 * dim, 2 * dim) << B_11 * I_min_A_12_B_21_inv * A_11,
+            B_12 + B_11 * I_min_A_12_B_21_inv * A_12 * B_22,
+            A_21 + A_22 * I_min_B_21_A_12_inv * B_21 * A_11, A_22 * I_min_B_21_A_12_inv * B_22)
         .finished();
 }
 }  // namespace robot::math

--- a/common/math/redheffer_star_test.cc
+++ b/common/math/redheffer_star_test.cc
@@ -19,8 +19,8 @@ TEST(RedhefferStarTest, simple_test) {
 
     // Setup
     constexpr double TOL = 1e-6;
-    const Eigen::Matrix2d A{{0.1, 0.2}, {0.3, 0.4}};
-    const Eigen::Matrix2d B{{0.5, 0.6}, {0.7, 0.8}};
+    const Eigen::Matrix2d A{{1.0, 2.0}, {3.0, 4.0}};
+    const Eigen::Matrix2d B{{5.0, 6.0}, {7.0, 8.0}};
     const Eigen::Vector2d input{2, 3};
     const Eigen::Vector2d output = B * A * input;
 

--- a/common/math/redheffer_star_test.cc
+++ b/common/math/redheffer_star_test.cc
@@ -21,7 +21,7 @@ TEST(RedhefferStarTest, simple_test) {
     constexpr double TOL = 1e-6;
     const Eigen::Matrix2d A{{1.0, 2.0}, {3.0, 4.0}};
     const Eigen::Matrix2d B{{5.0, 6.0}, {7.0, 8.0}};
-    const Eigen::Vector2d input{2, 3};
+    const Eigen::Vector2d input{0.2, 0.3};
     const Eigen::Vector2d output = B * A * input;
 
     // Action

--- a/common/math/redheffer_star_test.cc
+++ b/common/math/redheffer_star_test.cc
@@ -21,7 +21,7 @@ TEST(RedhefferStarTest, simple_test) {
     constexpr double TOL = 1e-6;
     const Eigen::Matrix2d A{{1.0, 2.0}, {3.0, 4.0}};
     const Eigen::Matrix2d B{{5.0, 6.0}, {7.0, 8.0}};
-    const Eigen::Vector2d input{0.2, 0.3};
+    const Eigen::Vector2d input{0.1, 0.2};
     const Eigen::Vector2d output = B * A * input;
 
     // Action

--- a/common/math/redheffer_star_test.cc
+++ b/common/math/redheffer_star_test.cc
@@ -12,27 +12,27 @@ TEST(RedhefferStarTest, simple_test) {
     // [c] = B * A [a]
     // [d]         [b]
     // The scattering forms of the equations are:
-    // [c] = B' * A' [a]
-    // [b]           [d]
+    // [a] = B' * A' [c]
+    // [d]           [b]
     // Where A' and B' are the scattering forms of the transfer matrices A and B.
     // We check to see that given [[a], [d]], the scattering form produces [[c], [b]]
 
     // Setup
     constexpr double TOL = 1e-6;
-    const Eigen::Matrix2d A{{1.0, 2.0}, {3.0, 4.0}};
-    const Eigen::Matrix2d B{{5.0, 6.0}, {7.0, 8.0}};
-    const Eigen::Vector2d input{0.1, 0.2};
+    const Eigen::Matrix2d A{{0.1, 0.2}, {0.3, 0.4}};
+    const Eigen::Matrix2d B{{0.5, 0.6}, {0.7, 0.8}};
+    const Eigen::Vector2d input{2, 3};
     const Eigen::Vector2d output = B * A * input;
 
     // Action
     const Eigen::Matrix2d A_scatter = scattering_from_transfer(A);
     const Eigen::Matrix2d B_scatter = scattering_from_transfer(B);
-    const Eigen::Matrix2d combined = redheffer_star(A_scatter, B_scatter);
-    const Eigen::Vector2d scatter_input{input.x(), output.y()};
+    const Eigen::Matrix2d combined = redheffer_star(B_scatter, A_scatter);
+    const Eigen::Vector2d scatter_input{output.x(), input.y()};
     const Eigen::Vector2d scatter_output = combined * scatter_input;
 
     // Verification
-    EXPECT_NEAR(output.x(), scatter_output.x(), TOL);
-    EXPECT_NEAR(input.y(), scatter_output.y(), TOL);
+    EXPECT_NEAR(input.x(), scatter_output.x(), TOL);
+    EXPECT_NEAR(output.y(), scatter_output.y(), TOL);
 }
 }  // namespace robot::math

--- a/experimental/beacon_sim/belief_road_map_planner_test.cc
+++ b/experimental/beacon_sim/belief_road_map_planner_test.cc
@@ -151,6 +151,7 @@ TEST(BeliefRoadMapPlannerTest, diamond_road_map_with_uncorrelated_beacons) {
         .max_sensor_range_m = 3.0,
         .num_start_connections = 1,
         .num_goal_connections = 1,
+        .uncertainty_tolerance = std::nullopt,
         .max_num_edge_transforms = 10000,
     };
 
@@ -162,7 +163,6 @@ TEST(BeliefRoadMapPlannerTest, diamond_road_map_with_uncorrelated_beacons) {
     EXPECT_TRUE(maybe_plan.has_value());
     const auto &plan = maybe_plan.value();
     for (const int node_id : plan.nodes) {
-        std::cout << "node id: " << node_id << std::endl;
         EXPECT_NE(node_id, 1);
     }
 }
@@ -193,6 +193,7 @@ TEST(BeliefRoadMapPlannerTest, diamond_road_map_with_correlated_beacons) {
         .max_sensor_range_m = 3.0,
         .num_start_connections = 1,
         .num_goal_connections = 1,
+        .uncertainty_tolerance = std::nullopt,
         .max_num_edge_transforms = 1000,
     };
 

--- a/experimental/beacon_sim/belief_road_map_planner_test.cc
+++ b/experimental/beacon_sim/belief_road_map_planner_test.cc
@@ -151,7 +151,6 @@ TEST(BeliefRoadMapPlannerTest, diamond_road_map_with_uncorrelated_beacons) {
         .max_sensor_range_m = 3.0,
         .num_start_connections = 1,
         .num_goal_connections = 1,
-        .uncertainty_tolerance = 1e-2,
         .max_num_edge_transforms = 10000,
     };
 
@@ -163,6 +162,7 @@ TEST(BeliefRoadMapPlannerTest, diamond_road_map_with_uncorrelated_beacons) {
     EXPECT_TRUE(maybe_plan.has_value());
     const auto &plan = maybe_plan.value();
     for (const int node_id : plan.nodes) {
+        std::cout << "node id: " << node_id << std::endl;
         EXPECT_NE(node_id, 1);
     }
 }
@@ -193,7 +193,6 @@ TEST(BeliefRoadMapPlannerTest, diamond_road_map_with_correlated_beacons) {
         .max_sensor_range_m = 3.0,
         .num_start_connections = 1,
         .num_goal_connections = 1,
-        .uncertainty_tolerance = 1e-2,
         .max_num_edge_transforms = 1000,
     };
 

--- a/experimental/beacon_sim/make_belief_updater.cc
+++ b/experimental/beacon_sim/make_belief_updater.cc
@@ -287,8 +287,8 @@ std::tuple<liegroups::SE2, EdgeTransform::Matrix> compute_edge_belief_transform(
         const EdgeTransform::Matrix measurement_transform = compute_measurement_transform(
             local_from_new_robot, ekf_config, ekf_estimate, available_beacons, max_sensor_range_m);
 
-        scattering_transform = math::redheffer_star(measurement_transform, scattering_transform);
-        scattering_transform = math::redheffer_star(process_transform, scattering_transform);
+        scattering_transform = math::redheffer_star(scattering_transform, process_transform);
+        scattering_transform = math::redheffer_star(scattering_transform, measurement_transform);
     }
 
     return std::make_tuple(liegroups::SE2(local_from_new_robot.so2().log(), end_state_in_local),


### PR DESCRIPTION
For some reason the unit test wouldn't pass if I put the arguments in the opposite order than I would expect. The issue was that I had the implemented `scattering_from_transfer()` by swapping the wrong elements. This fixes `transfer_from scattering()` and the calls to `redheffer_star()`.