### PR TITLE
Add dash tool for rollout visualization

### DIFF
--- a/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
+++ b/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
@@ -290,8 +290,8 @@ def run_inference_on_path(
         if return_intermediates:
             log_particle_weights.append(wag_observation_result.log_particle_weights.cpu().clone())
             particle_history_pre_move.append(particle_state.cpu().clone())
-            dual_mcl_particles.append(wag_observation_result.dual_mcl_particles.cpu().clone())
-            dual_log_particle_weights.append(wag_observation_result.dual_log_particle_weights.cpu().clone())
+            dual_mcl_particles.append(wag_observation_result.dual_mcl_particles.cpu().clone() if wag_observation_result.dual_mcl_particles is not None else None)
+            dual_log_particle_weights.append(wag_observation_result.dual_log_particle_weights.cpu().clone() if wag_observation_result.dual_log_particle_weights is not None else None)
             num_dual_particles.append(wag_observation_result.num_dual_particles)
 
         # move
@@ -310,8 +310,8 @@ def run_inference_on_path(
     if return_intermediates:
         log_particle_weights.append(wag_observation_result.log_particle_weights.cpu().clone())
         particle_history_pre_move.append(particle_state.cpu().clone())
-        dual_mcl_particles.append(wag_observation_result.dual_mcl_particles.cpu().clone())
-        dual_log_particle_weights.append(wag_observation_result.dual_log_particle_weights.cpu().clone())
+        dual_mcl_particles.append(wag_observation_result.dual_mcl_particles.cpu().clone() if wag_observation_result.dual_mcl_particles is not None else None)
+        dual_log_particle_weights.append(wag_observation_result.dual_log_particle_weights.cpu().clone() if wag_observation_result.dual_log_particle_weights is not None else None)
         num_dual_particles.append(wag_observation_result.num_dual_particles)
 
     particle_history.append(wag_observation_result.resampled_particles.cpu().clone())
@@ -321,8 +321,8 @@ def run_inference_on_path(
             particle_history=torch.stack(particle_history),  # N+1, +1 from final particle state
             log_particle_weights=torch.stack(log_particle_weights),  # N
             particle_history_pre_move=torch.stack(particle_history_pre_move),
-            dual_mcl_particles=torch.stack(dual_mcl_particles),
-            dual_log_particle_weights=torch.stack(dual_log_particle_weights),
+            dual_mcl_particles=torch.stack(dual_mcl_particles) if dual_mcl_particles[0] is not None else None,
+            dual_log_particle_weights=torch.stack(dual_log_particle_weights) if dual_log_particle_weights[0] is not None else None,
             num_dual_particles=torch.tensor(num_dual_particles))
     else:
         return PathInferenceResult(

--- a/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
+++ b/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
@@ -21,13 +21,30 @@ from typing import Callable
 class PathInferenceResult:
     # sequence is start -> particle_history[0] = log_particle_weights[0] ->
     #  observe_wag -> particle_history_pre_move[0] -> move_wag -> particle_history[1]
-    # path_length x N x state_dim
-    particle_history: torch.Tensor
-    log_particle_weights: torch.Tensor | None
-    particle_history_pre_move: torch.Tensor | None
-    dual_mcl_particles: torch.Tensor | None
-    dual_log_particle_weights: torch.Tensor | None
-    num_dual_particles: torch.Tensor | None
+    particle_history: torch.Tensor  # path_length x num_particles x state_dim
+    log_particle_weights: torch.Tensor | None   # path_length x num_particles
+    particle_history_pre_move: torch.Tensor | None # path_length x num_particles x state_dim
+    num_dual_particles: int | None # 
+
+    def get_dual_particle_history(self)->torch.Tensor | None:
+        if self.num_dual_particles is None or self.num_dual_particles == 0:
+            return None
+        assert self.num_dual_particles <= self.particle_history.shape[1]
+        return self.particle_history[:, -self.num_dual_particles:, :]
+    def get_dual_log_particle_weights(self)->torch.Tensor | None:
+        if self.num_dual_particles is None or self.log_particle_weights is None or self.num_dual_particles == 0:
+            return None
+        assert self.num_dual_particles <= self.log_particle_weights.shape[1]
+        return self.log_particle_weights[:, -self.num_dual_particles:]
+    def get_dual_particle_history_pre_move(self)->torch.Tensor | None:
+        if self.num_dual_particles is None or self.particle_history_pre_move is None or self.num_dual_particles == 0:
+            return None
+        assert self.num_dual_particles <= self.particle_history_pre_move.shape[1]
+        return self.particle_history_pre_move[:, -self.num_dual_particles:]
+
+
+        
+
 
 
 def hash_model(model: torch.nn.Module):
@@ -270,8 +287,6 @@ def run_inference_on_path(
     particle_history = []
     log_particle_weights = []
     particle_history_pre_move = []  # the particle state history before move_wag but after observe_wag
-    dual_mcl_particles = []
-    dual_log_particle_weights = []
     num_dual_particles = []
     for likelihood_value, motion_delta in zip(patch_similarity_for_path[:-1], motion_deltas):
         particle_history.append(particle_state.cpu().clone())
@@ -290,8 +305,6 @@ def run_inference_on_path(
         if return_intermediates:
             log_particle_weights.append(wag_observation_result.log_particle_weights.cpu().clone())
             particle_history_pre_move.append(particle_state.cpu().clone())
-            dual_mcl_particles.append(wag_observation_result.dual_mcl_particles.cpu().clone() if wag_observation_result.dual_mcl_particles is not None else None)
-            dual_log_particle_weights.append(wag_observation_result.dual_log_particle_weights.cpu().clone() if wag_observation_result.dual_log_particle_weights is not None else None)
             num_dual_particles.append(wag_observation_result.num_dual_particles)
 
         # move
@@ -310,27 +323,25 @@ def run_inference_on_path(
     if return_intermediates:
         log_particle_weights.append(wag_observation_result.log_particle_weights.cpu().clone())
         particle_history_pre_move.append(particle_state.cpu().clone())
-        dual_mcl_particles.append(wag_observation_result.dual_mcl_particles.cpu().clone() if wag_observation_result.dual_mcl_particles is not None else None)
-        dual_log_particle_weights.append(wag_observation_result.dual_log_particle_weights.cpu().clone() if wag_observation_result.dual_log_particle_weights is not None else None)
         num_dual_particles.append(wag_observation_result.num_dual_particles)
 
     particle_history.append(wag_observation_result.resampled_particles.cpu().clone())
 
     if return_intermediates:
+        num_dual_particles = torch.tensor(num_dual_particles)
+        if len(num_dual_particles) > 0:
+            assert torch.all(num_dual_particles[0] == num_dual_particles) 
         return PathInferenceResult(
             particle_history=torch.stack(particle_history),  # N+1, +1 from final particle state
             log_particle_weights=torch.stack(log_particle_weights),  # N
             particle_history_pre_move=torch.stack(particle_history_pre_move),
-            dual_mcl_particles=torch.stack(dual_mcl_particles) if dual_mcl_particles[0] is not None else None,
-            dual_log_particle_weights=torch.stack(dual_log_particle_weights) if dual_log_particle_weights[0] is not None else None,
-            num_dual_particles=torch.tensor(num_dual_particles))
+            num_dual_particles=num_dual_particles[0],
+        )
     else:
         return PathInferenceResult(
             particle_history=torch.stack(particle_history),
             log_particle_weights=None,
             particle_history_pre_move=None,
-            dual_mcl_particles=None,
-            dual_log_particle_weights=None,
             num_dual_particles=None)
 
 

--- a/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
+++ b/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
@@ -334,7 +334,7 @@ def run_inference_on_path(
             num_dual_particles=None)
 
 
-def construct_inputs_and_evalulate_path(
+def construct_inputs_and_evaluate_path(
     vigor_dataset: vd.VigorDataset,
     path: list[int],
     path_similarity_values: torch.Tensor,
@@ -389,7 +389,7 @@ def evaluate_model_on_paths(
             path_similarity_values = all_similarity[path]
             generator_seed = seed * i
 
-            path_inference_result = construct_inputs_and_evalulate_path(
+            path_inference_result = construct_inputs_and_evaluate_path(
                 vigor_dataset=vigor_dataset,
                 path=path,
                 path_similarity_values=path_similarity_values,

--- a/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
+++ b/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
@@ -334,7 +334,6 @@ def construct_inputs_and_evalulate_path(
                                  generator,
                                  return_intermediates)
 
-
 def evaluate_model_on_paths(
     vigor_dataset: vd.VigorDataset,
     sat_model: torch.nn.Module,

--- a/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
+++ b/experimental/overhead_matching/swag/evaluation/evaluate_swag.py
@@ -328,14 +328,18 @@ def run_inference_on_path(
     particle_history.append(wag_observation_result.resampled_particles.cpu().clone())
 
     if return_intermediates:
-        num_dual_particles = torch.tensor(num_dual_particles)
         if len(num_dual_particles) > 0:
+            num_dual_particles = torch.tensor(num_dual_particles)
             assert torch.all(num_dual_particles[0] == num_dual_particles) 
+            num_dual_particles = num_dual_particles[0]
+        else:
+            num_dual_particles=None
+
         return PathInferenceResult(
             particle_history=torch.stack(particle_history),  # N+1, +1 from final particle state
             log_particle_weights=torch.stack(log_particle_weights),  # N
             particle_history_pre_move=torch.stack(particle_history_pre_move),
-            num_dual_particles=num_dual_particles[0],
+            num_dual_particles=num_dual_particles,
         )
     else:
         return PathInferenceResult(

--- a/experimental/overhead_matching/swag/evaluation/swag_algorithm.py
+++ b/experimental/overhead_matching/swag/evaluation/swag_algorithm.py
@@ -107,8 +107,8 @@ def measurement_wag(
                 resampled_particles=resampled_particles,
                 num_dual_particles=num_dual_mcl_samples,
                 log_particle_weights=log_particle_weights,
-                dual_mcl_particles=dual_mcl_particles,
-                dual_log_particle_weights=dual_log_particle_weights)
+                dual_mcl_particles=dual_mcl_particles if num_dual_mcl_samples else None,
+                dual_log_particle_weights=dual_log_particle_weights if num_dual_mcl_samples else None)
     return WagMeasurementResult(
             resampled_particles=resampled_particles,
             num_dual_particles=num_dual_mcl_samples,

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -87,3 +87,21 @@ py_binary(
     ":train",
   ]
 )
+
+py_binary(
+  name="step_through_filter",
+  srcs=["step_through_filter.py"],
+  deps=[
+    ":evaluate_model_on_paths",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/evaluation:swag_algorithm",
+    "//experimental/overhead_matching/swag/evaluation:wag_config_proto_py",
+    "//experimental/overhead_matching/swag/evaluation:evaluate_swag",
+    "//experimental/overhead_matching/swag/model:patch_embedding",
+    requirement("torch"),
+    requirement("dash"),
+    requirement("tqdm"),
+    requirement("opencv-python"),
+    "//common/torch:load_torch_deps",
+  ]
+)

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -100,17 +100,6 @@ py_binary(
 )
 
 py_binary(
-  name = "extract_landmarks_for_vigor_dataset",
-  srcs = ["extract_landmarks_for_vigor_dataset.py"],
-  deps = [
-    requirement("osmnx"),
-    requirement("pandas"),
-    "//experimental/overhead_matching/swag/data:vigor_dataset",
-    "//common/gps:web_mercator",
-  ]
-)
-
-py_binary(
   name="step_through_filter",
   srcs=["step_through_filter.py"],
   deps=[

--- a/experimental/overhead_matching/swag/scripts/step_through_filter.py
+++ b/experimental/overhead_matching/swag/scripts/step_through_filter.py
@@ -1,0 +1,473 @@
+"""
+Given a single path evaluation, we want to be able to see...
+-What is the observation?
+-What areas of the satellite image are marked as likly (laid over rgb)
+-Where are the particles, and how likely are they? (e.g., be able to filter by a minimum/maximum likleihood)
+    - They get their liklihood from the closest patch. Hovering over a patch should give its liklihood, same with hovering over a particle
+    - Need to be able to turn on/off patches/particels
+-Need to be able to step through liklihood calculation, movement, and resampling
+
+Questions to answer:
+- Why do the similarity patterns update as they do? Can we tell what the model is latching onto, or not 
+- Why do the particles act as they do. Why were they creating a line? 
+    - why do they get the liklihoods they do (based on the patches)
+    - why do they move the way they do
+
+Step 1: visualize dataset
+    - 
+Step 2: visualize particles during observation step
+Step 3: visualize particles during move step
+"""
+
+from dash import Dash, dcc, html, Input, Output, State, callback_context
+import common.torch.load_torch_deps
+import torch
+import pandas as pd
+from pathlib import Path
+import numpy as np
+import pickle
+import math
+import base64
+import argparse
+import cv2
+import json
+import enum
+from experimental.overhead_matching.swag.scripts.evaluate_model_on_paths import construct_path_eval_inputs_from_args
+from experimental.overhead_matching.swag.evaluation.evaluate_swag import construct_inputs_and_evalulate_path
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.evaluation.wag_config_pb2 import WagConfig
+from google.protobuf import text_format
+from torch_kdtree import build_kd_tree
+
+DEVICE="cuda:0"
+
+
+# CLI args
+parser = argparse.ArgumentParser(description='Dataset visualizer for radial bins on costmap')
+parser.add_argument('--path-eval-path', type=str, required=True, help='Path to path eval you would like to visualize')
+args = parser.parse_args()
+args.path_eval_path = Path(args.path_eval_path)
+
+with open(args.path_eval_path.parent / "args.json", 'r') as f:
+    path_eval_args = json.load(f)
+with open(args.path_eval_path / "other_info.json", 'r') as f:
+    aux_info = json.load(f)
+
+path = torch.load(args.path_eval_path / 'path.pt', weights_only=True)
+
+vigor_dataset, sat_model, pano_model, paths_data = construct_path_eval_inputs_from_args(
+    sat_model_path=path_eval_args['sat_path'],
+    pano_model_path=path_eval_args['pano_path'],
+    dataset_path=path_eval_args['dataset_path'],
+    paths_path=path_eval_args['paths_path'],
+    panorama_neighbor_radius_deg=path_eval_args['panorama_neighbor_radius_deg'],
+)
+with open(args.path_eval_path.parent / "wag_config.pbtxt", 'r') as f:
+    wag_config = WagConfig()
+    wag_config = text_format.Parse(f.read(), wag_config)
+
+sat_data_view = vigor_dataset.get_sat_patch_view()
+sat_data_view_loader = vd.get_dataloader(sat_data_view, batch_size=64, num_workers=16)
+pano_data_view = vigor_dataset.get_pano_view()
+pano_data_view_loader = vd.get_dataloader(pano_data_view, batch_size=64, num_workers=16)
+
+sat_patch_positions = vigor_dataset.get_patch_positions().to(DEVICE)
+sat_patch_kdtree = build_kd_tree(sat_patch_positions)
+
+path_similarity_values = torch.load(args.path_eval_path / "similarity.pt", weights_only=True)
+
+particle_histories = construct_inputs_and_evalulate_path(
+    device=DEVICE,
+    generator_seed=aux_info['seed'],
+    path=path,
+    sat_patch_kdtree=sat_patch_kdtree,
+    vigor_dataset=vigor_dataset,
+    path_similarity_values=path_similarity_values,
+    wag_config=wag_config
+)
+
+# # Crop to valid region (data>=0)
+# data = grid.data
+# # flip data upside down
+# data = np.flipud(data)
+# mask = data >= 0
+# rows = np.any(mask,axis=1)
+# cols = np.any(mask,axis=0)
+# min_r, max_r = np.where(rows)[0][[0,-1]]
+# min_c, max_c = np.where(cols)[0][[0,-1]]
+# buf_px = int(np.ceil(args.buffer / grid.resolution))
+# min_r = max(min_r-buf_px,0)
+# max_r = min(max_r+buf_px,data.shape[0]-1)
+# min_c = max(min_c-buf_px,0)
+# max_c = min(max_c+buf_px,data.shape[1]-1)
+# cropped = data[min_r:max_r+1, min_c:max_c+1]
+# h,w = cropped.shape
+# # compute spatial origin
+# x0 = grid.x_lim_meters[0] + min_c*grid.resolution
+# y0 = grid.y_lim_meters[0] + min_r*grid.resolution
+# print(f"Cropped region: shape={cropped.shape}, x0={x0}, y1={y0}")
+
+# # Scale speeds to max_speed
+# speed_map = 1 / cropped
+# actual_max = np.nanmax(speed_map) + 0.5
+# scale = min(1.0, args.max_speed/actual_max) if actual_max>0 else 1.0
+# if actual_max>args.max_speed:
+#     print(f"Warning: actual_max {actual_max:.2f} > max_speed {args.max_speed:.2f}, scaling by {scale:.3f}")
+# speed_map = (speed_map + 0.5) * scale
+# speed_map[speed_map < 0] = 0
+
+# # Build greyscale image
+# grey = np.clip(speed_map/args.max_speed,0,1)
+# img = (255*(1-grey)).astype(np.uint8)
+# # convert single channel to BGR for PNG
+# png = cv2.imencode('.png', img)[1].tobytes()
+# b64 = base64.b64encode(png).decode('ascii')
+# data_uri = f"data:image/png;base64,{b64}"
+
+# # Build figure
+# from plotly.graph_objects import Figure, Image, Scattergl, Scatter
+
+# # Setup Dash
+# dd_options = [{'label':t, 'value':t} for t in topics]
+# app = Dash(__name__)
+# app.layout = html.Div([
+#     html.Div([
+#         html.Div(
+#             dcc.Dropdown(id='topic-dropdown', options=dd_options, value=topics[0], clearable=False),
+#             style={'width':'20%', 'display':'inline-block'}
+#         ),
+#         html.Div([
+#             html.Button('Play', id='play-button', n_clicks=0, style={'margin': '5px'}),
+#             html.Div(id='animation-status', children='Paused', style={'display': 'inline-block', 'margin': '10px'}),
+#             dcc.Slider(
+#                 id='frame-slider',
+#                 min=0,
+#                 max=100,  # Will be updated dynamically
+#                 step=1,
+#                 value=0,
+#                 marks=None,
+#                 tooltip={"placement": "bottom", "always_visible": True}
+#             ),
+#             dcc.Input(
+#                 id='step-size',
+#                 type='number',
+#                 min=1,
+#                 max=20,
+#                 step=1,
+#                 value=5,
+#                 style={'width': '60px', 'margin': '10px'}
+#             ),
+#             html.Label('Step Size', style={'margin-left': '5px'})
+#         ], style={'width': '70%', 'margin': '10px'}),
+#         dcc.Graph(id='graph', style={'height':'80vh', 'width': '70%', 'display': 'inline-block'}),
+#         html.Div(id='image-panel', style={'width': '28%', 'display': 'inline-block', 'vertical-align': 'top', 'padding': '10px'}),
+#         # Interval component for animation
+#         dcc.Interval(
+#             id='animation-interval',
+#             interval=500,  # in milliseconds
+#             n_intervals=0,
+#             disabled=True
+#         ),
+#         # Store components to maintain state
+#         dcc.Store(id='animation-state', data={'playing': False, 'current_index': 0}),
+#         dcc.Store(id='topic-data', data={'current_topic': topics[0], 'num_points': 0})
+#     ])
+# ])
+
+# # Callback to update topic data when dropdown changes
+# @app.callback(
+#     Output('topic-data', 'data'),
+#     Output('frame-slider', 'max'),
+#     Output('frame-slider', 'value'),
+#     Input('topic-dropdown', 'value'),
+# )
+# def update_topic_data(topic):
+#     # Reset animation when topic changes
+#     sub_image_df = tbl[tbl['camera_name']==topic]
+#     num_points = len(sub_image_df)
+#     return {'current_topic': topic, 'num_points': num_points}, num_points-1, 0
+
+# # Callback for play/pause button
+# @app.callback(
+#     Output('animation-interval', 'disabled'),
+#     Output('animation-status', 'children'),
+#     Output('play-button', 'children'),
+#     Output('animation-state', 'data'),
+#     Input('play-button', 'n_clicks'),
+#     State('animation-state', 'data'),
+#     State('frame-slider', 'value'),
+# )
+# def toggle_animation(n_clicks, animation_state, current_slider_value):
+#     if n_clicks == 0:
+#         return True, 'Paused', 'Play', {'playing': False, 'current_index': current_slider_value}
+    
+#     # Toggle playing state
+#     playing = not animation_state['playing']
+    
+#     if playing:
+#         return False, 'Playing', 'Pause', {'playing': True, 'current_index': current_slider_value}
+#     else:
+#         return True, 'Paused', 'Play', {'playing': False, 'current_index': current_slider_value}
+
+# # Callback for animation interval
+# @app.callback(
+#     Output('frame-slider', 'value', allow_duplicate=True),
+#     Input('animation-interval', 'n_intervals'),
+#     State('animation-state', 'data'),
+#     State('frame-slider', 'value'),
+#     State('frame-slider', 'max'),
+#     State('step-size', 'value'),
+#     prevent_initial_call=True
+# )
+# def update_frame_on_interval(n_intervals, animation_state, current_value, max_value, step_size):
+#     if not animation_state['playing']:
+#         return current_value
+    
+#     # Calculate next frame value
+#     next_value = current_value + step_size
+    
+#     # Loop back to the beginning if we reach the end
+#     if next_value > max_value:
+#         next_value = 0
+    
+#     return next_value
+
+# # Single callback to update figure based on topic, click, and slider
+# @app.callback(
+#     Output('graph', 'figure'),
+#     Input('topic-dropdown', 'value'),
+#     Input('graph', 'clickData'),
+#     Input('frame-slider', 'value'),
+#     State('graph', 'figure'),
+#     State('topic-data', 'data')
+# )
+# def update_graph(topic, clickData, slider_value, current_fig, topic_data):
+#     # Create global variables to track the selected point and its bins
+#     global selected_point_idx, current_topic
+    
+#     # Determine what triggered the callback
+#     ctx = callback_context
+#     trigger_id = ctx.triggered[0]['prop_id'].split('.')[0] if ctx.triggered else None
+    
+#     # If topic changed, reset selection
+#     if current_topic != topic:
+#         current_topic = topic
+#         if 'selected_point_idx' in globals():
+#             del selected_point_idx
+    
+#     # Base figure
+#     fig = Figure()
+#     fig.add_trace(Image(source=data_uri, x0=x0+grid.resolution/2, y0=y0+grid.resolution/2,
+#                         dx=grid.resolution, dy=grid.resolution))
+    
+#     # Filter points by camera topic
+#     sub_image_df = tbl[tbl['camera_name']==current_topic]
+#     fig.add_trace(Scattergl(
+#         x=sub_image_df['x'], y=sub_image_df['y'], mode='markers', marker=dict(color='red', size=6),
+#         customdata=sub_image_df.index,
+#         name='pos', hovertemplate='idx:%{customdata}<br>(%{x:.2f},%{y:.2f})'
+#     ))
+    
+#     # Handle point selection from different sources
+#     if trigger_id == 'graph' and clickData and clickData['points'][0]['curveNumber'] == 1:
+#         # Selection via click
+#         idx = clickData['points'][0]['pointIndex']
+#         selected_point_idx = sub_image_df.index[idx]
+#         print(f"Selected via click: index {selected_point_idx}")
+#     elif trigger_id == 'frame-slider' and len(sub_image_df) > 0:
+#         # Selection via slider
+#         if slider_value < len(sub_image_df):
+#             selected_point_idx = sub_image_df.index[slider_value]
+#             print(f"Selected via slider: index {selected_point_idx}, slider value {slider_value}")
+    
+#     # Add bins if a point is selected
+#     if 'selected_point_idx' in globals():
+#         subset = df[df['location_idx'] == selected_point_idx]
+#         print(f"Selected point: {selected_point_idx}, subset size: {len(subset)}")
+#         for idx, row in subset.iterrows():
+#             x0r, y0r = row['x'], row['y']
+#             yl, yr = row['yaw_left'], row['yaw_right']
+#             if yl < yr:
+#                 yl += 2*math.pi
+#             thetas = np.linspace(yl, yr, 30)
+            
+#             for j in range(len(ranges)-1):
+#                 cov = row[f'coverage_{j}']
+#                 lbl = row[f'label_{j}']
+#                 r0, r1 = ranges[j], ranges[j+1]
+#                 xs_out = x0r + r1*np.cos(thetas)
+#                 ys_out = y0r + r1*np.sin(thetas)
+#                 xs_in  = x0r + r0*np.cos(thetas[::-1])
+#                 ys_in  = y0r + r0*np.sin(thetas[::-1])
+#                 xv = np.concatenate([xs_out, xs_in])
+#                 yv = np.concatenate([ys_out, ys_in])
+
+#                 # Style zero-coverage differently
+#                 if cov <= 0:
+#                     fillcol = 'lightgray'
+#                     opacity = 0.2
+#                     line_style = dict(color='gray', width=1, dash='dash')
+#                 elif "output_0" in row: # if there are model predictions present, color based on them
+#                     correct = row[f'output_{j}'] == lbl
+#                     fillcol = 'rgba(100, 255, 0, 0.3)' if correct else 'rgba(255, 100, 0, 0.3)'
+#                     opacity = 0.5
+#                     line_style = dict(width=1, color='green' if correct else 'red')
+#                 else:
+#                     if lbl == 0:
+#                         fillcol = 'rgba(255, 0, 0, 0.3)'
+#                         opacity = 0.5
+#                         line_style = dict(width=1, color='red')
+#                     elif lbl == 1:
+#                         fillcol = 'rgba(0, 255, 0, 0.3)'
+#                         opacity = 0.5
+#                         line_style = dict(width=1, color='green')
+#                     else:
+#                         raise ValueError(f"Unknown label {lbl} for bin {j} at index {idx}")
+#                 name = f'cov {cov:.2f} l{lbl}'
+#                 if "output_0" in row:
+#                     name += f' o{row[f"output_{j}"]}'
+#                 fig.add_trace(Scatter(
+#                     x=xv, y=yv,
+#                     fill='toself',
+#                     fillcolor=fillcol,
+#                     opacity=opacity,
+#                     line=line_style,
+#                     name=name,
+#                     customdata=[[selected_point_idx, j, lbl, cov, idx] for _ in range(len(xv))],
+#                     mode='lines',
+#                     hoverinfo='text',
+#                     hoveron='fills',
+#                     hovertemplate=(
+#                         'bin: %{customdata[1]}<br>'
+#                         'parent: %{customdata[0]}<br>'
+#                         'label: %{customdata[2]}<br>'
+#                         'coverage: %{customdata[3]}<extra></extra>'
+#                     )
+#                 ))
+
+#     # Highlight the currently selected point
+#     if 'selected_point_idx' in globals():
+#         # Find the position of the selected point
+#         selected_row = sub_image_df[sub_image_df.index == selected_point_idx]
+#         if not selected_row.empty:
+#             # Add a highlight circle
+#             fig.add_trace(Scatter(
+#                 x=[selected_row['x'].values[0]],
+#                 y=[selected_row['y'].values[0]],
+#                 mode='markers',
+#                 marker=dict(color='yellow', size=12, symbol='circle-open', line=dict(width=3)),
+#                 name='Selected',
+#                 hoverinfo='none'
+#             ))
+
+#     fig.update_layout(
+#         uirevision='constant',  # Keep view state consistent
+#         title=f'Topic: {topic} - Frame: {slider_value + 1}/{topic_data["num_points"]}', 
+#         clickmode='event+select',
+#         xaxis=dict(title='X (m)'),
+#         yaxis=dict(title='Y (m)', scaleanchor='x', autorange=True)
+#     )
+    
+#     return fig
+
+# # Update the image panel callback to also work with slider selection
+# @app.callback(
+#     Output('image-panel', 'children'),
+#     Input('graph', 'clickData'),
+#     Input('frame-slider', 'value'),
+#     State('topic-data', 'data')
+# )
+# def display_images(clickData, slider_value, topic_data):
+#     ctx = callback_context
+#     trigger_id = ctx.triggered[0]['prop_id'].split('.')[0] if ctx.triggered else None
+    
+#     # For slider selection, just show info about the point
+#     if trigger_id == 'frame-slider' and 'selected_point_idx' in globals():
+#         return [html.Div([
+#             html.H3(f"Point Information:"),
+#             html.P(f"Point Index: {selected_point_idx}"),
+#             html.P(f"Frame: {slider_value + 1} of {topic_data['num_points']}"),
+#             html.P("Click on a radial bin to view images")
+#         ])]
+    
+#     # Original behavior for bin clicks
+#     if not clickData:
+#         return [html.Div("Click on a position point then a radial bin to view images")]
+    
+#     pt = clickData['points'][0]
+    
+#     # For bin clicks (curve numbers > 1)
+#     if pt['curveNumber'] > 1:
+#         try:
+#             # Extract data from the clicked bin
+#             parent_idx, bin_idx, lbl, cov, dataset_idx = pt['customdata'][0]
+
+#             # Get dataset image and full image
+#             row = df.loc[dataset_idx]
+#             location_idx = row['location_idx']
+            
+#             # Create a header with bin information
+#             header = html.Div([
+#                 html.H3(f"Bin {bin_idx} Info:"),
+#                 html.P(f"Parent Point: {parent_idx}"),
+#                 html.P(f"Label: {lbl}"),
+#                 html.P(f"Coverage: {cov}")
+#             ])
+            
+#             # Get the dataset_image path
+#             if 'img_path' not in row:
+#                 return [header, html.Div("Dataset image path not available in data")]
+#             dataset_image_path = Path(args.dataset_csv).parent / row['img_path']
+#             if not dataset_image_path or pd.isna(dataset_image_path):
+#                 return [header, html.Div("Dataset image path not available")]
+            
+#             # Get the full image from tbl
+#             full_image_row = tbl.loc[location_idx] if location_idx < len(tbl) else None
+#             if full_image_row is None:
+#                 return [header, html.Div(f"Full image not found for location index {location_idx}")]
+            
+#             full_image_path = image_df_path.parent / full_image_row['img_path']
+#             if not full_image_path or pd.isna(full_image_path):
+#                 return [header, html.Div("Full image path not available")]
+            
+#             # Create image elements
+#             image_elements = [header]
+            
+#             # Add dataset image
+#             try:
+#                 with open(dataset_image_path, 'rb') as f:
+#                     dataset_img_data = base64.b64encode(f.read()).decode('utf-8')
+#                 image_elements.append(html.Div([
+#                     html.H4("Dataset Image"),
+#                     html.Img(src=f'data:image/png;base64,{dataset_img_data}', 
+#                              style={'max-width': '100%', 'margin': '5px'})
+#                 ]))
+#             except Exception as e:
+#                 image_elements.append(html.Div(f"Error loading dataset image: {str(e)}"))
+            
+#             # Add full image
+#             try:
+#                 with open(full_image_path, 'rb') as f:
+#                     full_img_data = base64.b64encode(f.read()).decode('utf-8')
+#                 image_elements.append(html.Div([
+#                     html.H4("Full Image"),
+#                     html.Img(src=f'data:image/png;base64,{full_img_data}', 
+#                              style={'max-width': '100%', 'margin': '5px'})
+#                 ]))
+#             except Exception as e:
+#                 image_elements.append(html.Div(f"Error loading full image: {str(e)}"))
+            
+#             return image_elements
+            
+#         except Exception as e:
+#             return [html.Div(f"Error processing bin click: {str(e)}")]
+    
+#     # For clicks on position points
+#     elif pt['curveNumber'] == 1:
+#         return [html.Div("Position point selected. Now click on a radial bin to view images.")]
+    
+#     return [html.Div("Click on a position point then a radial bin to view images")]
+
+# if __name__=='__main__':
+#     print("Starting server...")
+#     app.run(debug=True, port=8050)

--- a/experimental/overhead_matching/swag/scripts/step_through_filter.py
+++ b/experimental/overhead_matching/swag/scripts/step_through_filter.py
@@ -3,14 +3,14 @@ Given a single path evaluation, we want to be able to see...
 -What is the observation?
 -What areas of the satellite image are marked as likly (laid over rgb)
 -Where are the particles, and how likely are they? (e.g., be able to filter by a minimum/maximum likleihood)
-    - They get their liklihood from the closest patch. Hovering over a patch should give its liklihood, same with hovering over a particle
+    - They get their likelihood from the closest patch. Hovering over a patch should give its likelihood, same with hovering over a particle
     - Need to be able to turn on/off patches/particels
--Need to be able to step through liklihood calculation, movement, and resampling
+-Need to be able to step through likelihood calculation, movement, and resampling
 
 Questions to answer:
 - Why do the similarity patterns update as they do? Can we tell what the model is latching onto, or not 
 - Why do the particles act as they do. Why were they creating a line? 
-    - why do they get the liklihoods they do (based on the patches)
+    - why do they get the likelihoods they do (based on the patches)
     - why do they move the way they do
 
 
@@ -19,7 +19,7 @@ Understand why the particles do what they do.
 Workflow: 
 - See generally how the particles move across the map. Find a transition that we want to focus on
 - For that transition, activiate a particular feature we want to look at
-    - particle liklihood
+    - particle likelihood
     - Particle motion
     - 
 
@@ -49,7 +49,7 @@ from torch_kdtree import build_kd_tree
 DEVICE="cuda:0"
 
 # Add this near the top of the file with other global variables
-SHOW_LIKLIHOOD_WITH_OPACITY = False
+SHOW_LIKELIHOOD_WITH_OPACITY = False
 SHOW_SATELLITE_PATCHES = False
 
 
@@ -252,7 +252,7 @@ def toggle_opacity_checkbox(view_mode):
     else:
         return {'margin-top': '10px', 'display': 'none'}
 
-# Add a callback to update the SHOW_LIKLIHOOD_WITH_OPACITY variable
+# Add a callback to update the SHOW_LIKELIHOOD_WITH_OPACITY variable
 @app.callback(
     Output('graph', 'figure', allow_duplicate=True),
     Input('weight-opacity-toggle', 'value'),
@@ -261,8 +261,8 @@ def toggle_opacity_checkbox(view_mode):
     prevent_initial_call=True
 )
 def update_opacity_setting(toggle_value, view_mode, slider_value):
-    global SHOW_LIKLIHOOD_WITH_OPACITY
-    SHOW_LIKLIHOOD_WITH_OPACITY = 'enabled' in toggle_value
+    global SHOW_LIKELIHOOD_WITH_OPACITY
+    SHOW_LIKELIHOOD_WITH_OPACITY = 'enabled' in toggle_value
     
     # Trigger a redraw of the graph
     return update_graph(view_mode, None, slider_value, None, {'current_view_mode': view_mode, 'num_points': particle_histories.shape[0]})
@@ -379,7 +379,7 @@ def update_graph(view_mode, clickData, slider_value, current_fig, view_mode_data
             showlegend=True
         ))
 
-    if SHOW_LIKLIHOOD_WITH_OPACITY:
+    if SHOW_LIKELIHOOD_WITH_OPACITY:
         # Get particle positions and weights for current frame
         particles_x = particle_histories[slider_value, :, 1]
         particles_y = particle_histories[slider_value, :, 0]

--- a/experimental/overhead_matching/swag/scripts/step_through_filter.py
+++ b/experimental/overhead_matching/swag/scripts/step_through_filter.py
@@ -43,7 +43,7 @@ import cv2
 import json
 import enum
 from experimental.overhead_matching.swag.scripts.evaluate_model_on_paths import construct_path_eval_inputs_from_args
-from experimental.overhead_matching.swag.evaluation.evaluate_swag import construct_inputs_and_evalulate_path
+from experimental.overhead_matching.swag.evaluation.evaluate_swag import construct_inputs_and_evaluate_path
 import experimental.overhead_matching.swag.data.vigor_dataset as vd
 from experimental.overhead_matching.swag.evaluation.wag_config_pb2 import WagConfig
 from google.protobuf import text_format
@@ -90,7 +90,7 @@ sat_patch_kdtree = build_kd_tree(sat_patch_positions)
 
 path_similarity_values = torch.load(args.path_eval_path / "similarity.pt", weights_only=True)
 print("starting constructing particle histories")
-particle_histories, log_particle_weights, particle_histories_pre_move = construct_inputs_and_evalulate_path(
+particle_histories, log_particle_weights, particle_histories_pre_move = construct_inputs_and_evaluate_path(
     device=DEVICE,
     generator_seed=aux_info['seed'],
     path=gt_path_pano_indices,

--- a/experimental/overhead_matching/swag/scripts/step_through_filter.py
+++ b/experimental/overhead_matching/swag/scripts/step_through_filter.py
@@ -35,13 +35,10 @@ import torch
 import pandas as pd
 from pathlib import Path
 import numpy as np
-import pickle
-import math
 import base64
 import argparse
 import cv2
 import json
-import enum
 from experimental.overhead_matching.swag.scripts.evaluate_model_on_paths import construct_path_eval_inputs_from_args
 from experimental.overhead_matching.swag.evaluation.evaluate_swag import construct_inputs_and_evaluate_path
 import experimental.overhead_matching.swag.data.vigor_dataset as vd
@@ -107,43 +104,6 @@ log_particle_weights = inference_result.log_particle_weights.numpy()
 particle_histories_pre_move = inference_result.particle_history_pre_move.numpy()
 print(f"Calculated histories with shapes: {particle_histories.shape=}, {log_particle_weights.shape}, {particle_histories_pre_move.shape}")
 
-# # Crop to valid region (data>=0)
-# data = grid.data
-# # flip data upside down
-# data = np.flipud(data)
-# mask = data >= 0
-# rows = np.any(mask,axis=1)
-# cols = np.any(mask,axis=0)
-# min_r, max_r = np.where(rows)[0][[0,-1]]
-# min_c, max_c = np.where(cols)[0][[0,-1]]
-# buf_px = int(np.ceil(args.buffer / grid.resolution))
-# min_r = max(min_r-buf_px,0)
-# max_r = min(max_r+buf_px,data.shape[0]-1)
-# min_c = max(min_c-buf_px,0)
-# max_c = min(max_c+buf_px,data.shape[1]-1)
-# cropped = data[min_r:max_r+1, min_c:max_c+1]
-# h,w = cropped.shape
-# # compute spatial origin
-# x0 = grid.x_lim_meters[0] + min_c*grid.resolution
-# y0 = grid.y_lim_meters[0] + min_r*grid.resolution
-# print(f"Cropped region: shape={cropped.shape}, x0={x0}, y1={y0}")
-
-# # Scale speeds to max_speed
-# speed_map = 1 / cropped
-# actual_max = np.nanmax(speed_map) + 0.5
-# scale = min(1.0, args.max_speed/actual_max) if actual_max>0 else 1.0
-# if actual_max>args.max_speed:
-#     print(f"Warning: actual_max {actual_max:.2f} > max_speed {args.max_speed:.2f}, scaling by {scale:.3f}")
-# speed_map = (speed_map + 0.5) * scale
-# speed_map[speed_map < 0] = 0
-
-# # Build greyscale image
-# grey = np.clip(speed_map/args.max_speed,0,1)
-# img = (255*(1-grey)).astype(np.uint8)
-# # convert single channel to BGR for PNG
-# png = cv2.imencode('.png', img)[1].tobytes()
-# b64 = base64.b64encode(png).decode('ascii')
-# data_uri = f"data:image/png;base64,{b64}"
 
 # Build figure
 from plotly.graph_objects import Figure, Image, Scattergl, Scatter
@@ -157,8 +117,8 @@ app.layout = html.Div([
                 id='view-mode-dropdown',
                 options=[
                     {'label': 'View particles', 'value': 'particles'},
-                    {'label': 'View resampling', 'value': 'resampling'},
-                    {'label': 'View motion', 'value': 'motion'}
+                    {'label': 'View resampling (TODO)', 'value': 'resampling'},
+                    {'label': 'View motion (TODO)', 'value': 'motion'}
                 ],
                 value='particles',
                 clearable=False

--- a/third_party/python/requirements_3_12.in
+++ b/third_party/python/requirements_3_12.in
@@ -12,6 +12,7 @@ Wand==0.6.11
 torch==2.7.0+cu128
 setuptools==80.3.1
 ipdb==0.13.13
+dash==3.0.4
 ipympl==0.9.3
 beautifulsoup4==4.12.2
 line_profiler==4.0.3

--- a/third_party/python/requirements_3_12.txt
+++ b/third_party/python/requirements_3_12.txt
@@ -93,6 +93,10 @@ bleach[css]==6.2.0 \
     --hash=sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e \
     --hash=sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f
     # via nbconvert
+blinker==1.9.0 \
+    --hash=sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf \
+    --hash=sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc
+    # via flask
 casadi==3.7.0 \
     --hash=sha256:010c9de7f814a82d5a0ee41bf8284fb61e3824d9f4eef118a0cdbc71b9777137 \
     --hash=sha256:01bcbdb7c42a4b05cfe9c262903a67cb9d79cf4723b7ed80f92773dcf7021556 \
@@ -349,6 +353,7 @@ click==8.1.7 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
     # via
     #   -r third_party/python/requirements_3_12.in
+    #   flask
     #   marimo
     #   uvicorn
 colored==2.3.0 \
@@ -510,6 +515,10 @@ cycler==0.12.1 \
     --hash=sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30 \
     --hash=sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c
     # via matplotlib
+dash==3.0.4 \
+    --hash=sha256:177f8c3d1fa45555b18f2f670808eba7803c72a6b1cd6fd172fd538aca18eb1d \
+    --hash=sha256:4f9e62e9d8c5cd1b42dc6d6dcf211fe9498195f73ef0edb62a26e2a1b952a368
+    # via -r third_party/python/requirements_3_12.in
 debugpy==1.8.14 \
     --hash=sha256:0f920c7f9af409d90f5fd26e313e119d908b0dd2952c2393cd3247a462331f15 \
     --hash=sha256:1b2ac8c13b2645e0b1eaf30e816404990fbdb168e193322be8f545e8c01644a9 \
@@ -633,6 +642,10 @@ filelock==3.18.0 \
     #   huggingface-hub
     #   torch
     #   transformers
+flask==3.0.3 \
+    --hash=sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3 \
+    --hash=sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842
+    # via dash
 fonttools==4.57.0 \
     --hash=sha256:03290e818782e7edb159474144fca11e36a8ed6663d1fcbd5268eb550594fd8e \
     --hash=sha256:0425c2e052a5f1516c94e5855dbda706ae5a768631e9fcc34e57d074d1b65b92 \
@@ -824,6 +837,10 @@ imageio==2.37.0 \
     --hash=sha256:11efa15b87bc7871b61590326b2d635439acc321cf7f8ce996f812543ce10eed \
     --hash=sha256:71b57b3669666272c818497aebba2b4c5f20d5b37c81720e5e1a56d59c492996
     # via scikit-image
+importlib-metadata==8.7.0 \
+    --hash=sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000 \
+    --hash=sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd
+    # via dash
 iopath==0.1.10 \
     --hash=sha256:3311c16a4d9137223e20f141655759933e1eda24f8bff166af834af3c645ef01
     # via sam-2
@@ -862,7 +879,9 @@ isoduration==20.11.0 \
 itsdangerous==2.2.0 \
     --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \
     --hash=sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173
-    # via marimo
+    # via
+    #   flask
+    #   marimo
 jedi==0.19.2 \
     --hash=sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0 \
     --hash=sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9
@@ -874,6 +893,7 @@ jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   altair
+    #   flask
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
@@ -1396,7 +1416,9 @@ nbformat==5.10.4 \
 nest-asyncio==1.6.0 \
     --hash=sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe \
     --hash=sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
-    # via ipykernel
+    # via
+    #   dash
+    #   ipykernel
 networkx==3.4.2 \
     --hash=sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1 \
     --hash=sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f
@@ -1793,7 +1815,9 @@ platformdirs==4.3.7 \
 plotly==6.0.1 \
     --hash=sha256:4714db20fea57a435692c548a4eb4fae454f7daddf15f8d8ba7e1045681d7768 \
     --hash=sha256:dd8400229872b6e3c964b099be699f8d00c489a974f2cfccfad5e8240873366b
-    # via cert-tools
+    # via
+    #   cert-tools
+    #   dash
 # WARNING: pip install will require the following package to be hashed.
 # Consider using a hashable URL like https://github.com/jazzband/pip-tools/archive/SOMECOMMIT.zip
 poly-matrix @ git+https://github.com/utiasASRL/poly_matrix.git@671d6b7704fcc82817189dbbc87814c429b2e15d
@@ -2405,10 +2429,15 @@ requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
+    #   dash
     #   huggingface-hub
     #   jupyterlab-server
     #   supervision
     #   transformers
+retrying==1.3.4 \
+    --hash=sha256:345da8c5765bd982b1d1915deb9102fd3d1f7ad16bd84a9700b85f64d24e8f3e \
+    --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35
+    # via dash
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -2855,6 +2884,7 @@ six==1.17.0 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
     #   python-dateutil
+    #   retrying
     #   rfc3339-validator
     #   tensorboard
 sniffio==1.3.1 \
@@ -3069,6 +3099,7 @@ typing-extensions==4.13.2 \
     # via
     #   altair
     #   anyio
+    #   dash
     #   huggingface-hub
     #   iopath
     #   referencing
@@ -3179,14 +3210,21 @@ websockets==15.0.1 \
     --hash=sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f \
     --hash=sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7
     # via marimo
-werkzeug==3.1.3 \
-    --hash=sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e \
-    --hash=sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746
-    # via tensorboard
+werkzeug==3.0.6 \
+    --hash=sha256:1bc0c2310d2fbb07b1dd1105eba2f7af72f322e1e455f2f93c993bee8c8a5f17 \
+    --hash=sha256:a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d
+    # via
+    #   dash
+    #   flask
+    #   tensorboard
 widgetsnbextension==4.0.14 \
     --hash=sha256:4875a9eaf72fbf5079dc372a51a9f268fc38d46f767cbf85c43a36da5cb9b575 \
     --hash=sha256:a3629b04e3edb893212df862038c7232f62973373869db5084aed739b437b5af
     # via ipywidgets
+zipp==3.21.0 \
+    --hash=sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4 \
+    --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
+    # via importlib-metadata
 zstandard==0.23.0 \
     --hash=sha256:034b88913ecc1b097f528e42b539453fa82c3557e414b3de9d5632c80439a473 \
     --hash=sha256:0a7f0804bb3799414af278e9ad51be25edf67f78f916e08afdb983e74161b916 \
@@ -3293,6 +3331,7 @@ setuptools==80.3.1 \
     --hash=sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537
     # via
     #   -r third_party/python/requirements_3_12.in
+    #   dash
     #   osqp
     #   sparseqr
     #   tensorboard


### PR DESCRIPTION
Add a dash-based path evaluation viewer to see particle movement over time, likelihood, and see satellite patches

Down the road but not for this PR (probably, maybe belongs in a different visualization tool):
- [ ] visualize resampling steps
- [ ] Visualize movement of particles
- [ ] Be able to view a single particle over a certain number of steps
- [ ] Visualize the satellite RGB overhead
- [ ] Show the top-k matching satellite for the current panorama, where they are on the map and what they look like

Example execution:
```bazel run //experimental/overhead_matching/swag/scripts:step_through_filter -- --path-eval-path /tmp/evaluation_NewYork/0000000/```