### PR TITLE
Add maxpool summary option for alpha earth embeddings

### DIFF
--- a/experimental/overhead_matching/swag/model/swag_config_types.py
+++ b/experimental/overhead_matching/swag/model/swag_config_types.py
@@ -17,6 +17,7 @@ class AlphaEarthExtractorConfig(msgspec.Struct, **STRUCT_OPTS):
     auxiliary_info_key: str
     version: str
     patch_size: tuple[int, int]
+    summarize_with_maxpool: bool = False
 
 
 class SemanticNullExtractorConfig(msgspec.Struct, **STRUCT_OPTS):


### PR DESCRIPTION
Apologies the branch name is incorrect, these are not multi-resolution. 

Performance improved over not using maxpool summary (using token per pixel) for training, but validation converged to the same because of overfitting. 
<img width="2824" height="914" alt="image" src="https://github.com/user-attachments/assets/cac090ed-ce44-45be-a9f8-a2cf9b35e7d7" />


<img width="2860" height="960" alt="image" src="https://github.com/user-attachments/assets/e3e663ee-113c-4af4-87c9-b55367a19252" />
