### PR TITLE
ignore generated .bazelrc_noble file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ __pycache__
 .virtual_documents/
 
 .bazelrc_ubuntu
+.bazelrc_noble
 
 __marimo__


### PR DESCRIPTION
my desktop generated a .bazelrc_noble, identical to an already-existing .bazelrc_ubuntu which is already ignored