### PR TITLE
Start landmark correspondence classifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ See `common/python/README.md` for detailed instructions on adding new Python ver
 
 ### Python Testing
 
-Python tests use pytest-style tests but are defined as `py_test` targets in BUILD files. Tests typically have the suffix `_test.py`.
+Python tests use `unittest.TestCase` and are defined as `py_test` targets in BUILD files. Tests typically have the suffix `_test.py`.
 
 ## Overhead Matching (SWAG) Project
 

--- a/common/python/BUILD
+++ b/common/python/BUILD
@@ -43,6 +43,10 @@ py_binary(
     "//experimental/overhead_matching/swag/model:patch_embedding",
     "//experimental/overhead_matching/swag/model:swag_patch_embedding",
     "//experimental/overhead_matching/swag/model:semantic_landmark_utils",
+    "//experimental/overhead_matching/swag/data:landmark_correspondence_dataset",
+    "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
+    requirement("plotly"),
+    requirement("scikit-learn"),
   ]
 )
 

--- a/experimental/overhead_matching/swag/data/BUILD
+++ b/experimental/overhead_matching/swag/data/BUILD
@@ -153,6 +153,7 @@ py_library(
   ],
   deps = [
     requirement("torch"),
+    "//common/torch:load_torch_deps",
     "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
   ],
 )

--- a/experimental/overhead_matching/swag/data/BUILD
+++ b/experimental/overhead_matching/swag/data/BUILD
@@ -143,3 +143,26 @@ py_library(
     "//experimental/overhead_matching/swag/model:semantic_landmark_utils",
   ],
 )
+
+py_library(
+  name = "landmark_correspondence_dataset",
+  srcs = ["landmark_correspondence_dataset.py"],
+  visibility = [
+    "//experimental/overhead_matching/swag:__subpackages__",
+    "//common/python:__subpackages__",
+  ],
+  deps = [
+    requirement("torch"),
+    "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
+  ],
+)
+
+py_test(
+  name = "landmark_correspondence_dataset_test",
+  srcs = ["landmark_correspondence_dataset_test.py"],
+  deps = [
+    requirement("torch"),
+    "//common/torch:load_torch_deps",
+    ":landmark_correspondence_dataset",
+  ],
+)

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -18,6 +18,8 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
+import common.torch.load_torch_deps  # noqa: F401 - Must import before torch
+
 import torch
 import torch.nn.functional as F
 from torch.utils.data import Dataset

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -26,11 +26,13 @@ from torch.utils.data import Dataset
 
 from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
     BOOLEAN_KEYS,
+    BooleanValue,
     HOUSENUMBER_KEY,
     NUMERIC_KEYS,
     NUM_TAG_KEYS,
     PRIMARY_CATEGORY_KEYS,
     TAG_KEY_TO_IDX,
+    ValueType,
     encode_housenumber_value,
     encode_numeric_value,
     key_type,
@@ -102,7 +104,7 @@ class CorrespondencePair:
     osm_tags: dict[str, str]
     label: float  # 1.0 = positive, 0.0 = negative
     difficulty: str  # "positive", "hard", "easy"
-    uniqueness_score: int  # 1-5, from Gemini
+    uniqueness_score: int | None  # 1-5, from Gemini; None if not provided
     pano_id: str
 
 
@@ -136,7 +138,7 @@ def parse_jsonl_line(line_data: dict) -> list[CorrespondencePair]:
             continue
 
         pano_tags = set1_landmarks[set1_id]
-        uniqueness = match.get("uniqueness_score", 0)
+        uniqueness = match.get("uniqueness_score", None)
 
         # Positive pairs
         for set2_id in match.get("set_2_matches", []):
@@ -156,7 +158,9 @@ def parse_jsonl_line(line_data: dict) -> list[CorrespondencePair]:
             set2_id = neg.get("set_2_id")
             if set2_id is None or set2_id < 0 or set2_id >= len(set2_landmarks):
                 continue
-            difficulty = neg.get("difficulty", "easy")
+            difficulty = neg.get("difficulty")
+            if difficulty is None:
+                continue
             pairs.append(CorrespondencePair(
                 pano_tags=pano_tags,
                 osm_tags=set2_landmarks[set2_id],
@@ -210,8 +214,8 @@ def compute_cross_features(
       - Exact value match count / 10 (1)
       - Primary category match: building, amenity, highway, shop (4)
       - Text cosine similarity: max, mean, name-specific (3)
-      - Numeric proximity per numeric key (6: building:levels, levels, lanes,
-        maxspeed, maxheight, heritage)
+      - Numeric proximity per numeric key (6, sorted: building:levels, heritage,
+        lanes, levels, maxheight, maxspeed)
       - Housenumber range overlap (1)
     """
     pano_keys = set(pano_tags.keys())
@@ -244,7 +248,7 @@ def compute_cross_features(
         text_sims = []
         name_sim = 0.0
         for k in shared_keys:
-            if key_type(k) != "text":
+            if key_type(k) != ValueType.TEXT:
                 continue
             pv = pano_tags[k]
             ov = osm_tags[k]
@@ -262,12 +266,15 @@ def compute_cross_features(
         features.extend([0.0, 0.0, 0.0])
 
     # Numeric proximity (6 features, one per numeric key)
-    numeric_keys_ordered = ["building:levels", "levels", "lanes", "maxspeed", "maxheight", "heritage"]
+    numeric_keys_ordered = sorted(NUMERIC_KEYS)
     for nk in numeric_keys_ordered:
         if nk in pano_tags and nk in osm_tags:
-            parser = parse_maxheight if nk == "maxheight" else parse_numeric
-            a = parser(pano_tags[nk])
-            b = parser(osm_tags[nk])
+            if nk == "maxheight":
+                a = parse_maxheight(pano_tags[nk])
+                b = parse_maxheight(osm_tags[nk])
+            else:
+                a, _ = parse_numeric(pano_tags[nk], key=nk)
+                b, _ = parse_numeric(osm_tags[nk], key=nk)
             if not (math.isnan(a) or math.isnan(b)):
                 scale = 10.0 if nk in ("maxspeed",) else 2.0
                 features.append(math.exp(-abs(a - b) / scale))
@@ -306,9 +313,9 @@ def encode_tag_bundle(
 
     Returns dict with:
       key_indices: list[int]
-      value_types: list[int]  (0=bool, 1=numeric, 2=housenumber, 3=text)
-      boolean_values: list[int]  (0=true, 1=false, 2=unknown)
-      numeric_values: list[list[float]]  (each is 3-dim)
+      value_types: list[int]  (ValueType enum: 0=bool, 1=numeric, 2=housenumber, 3=text)
+      boolean_values: list[int]  (BooleanValue enum: 0=true, 1=false, 2=unknown)
+      numeric_values: list[list[float]]  (each is 4-dim)
       numeric_nan_mask: list[bool]
       housenumber_values: list[list[float]]  (each is 4-dim)
       housenumber_nan_mask: list[bool]
@@ -332,43 +339,57 @@ def encode_tag_bundle(
         key_indices.append(TAG_KEY_TO_IDX[k])
         kt = key_type(k)
 
-        if kt == "boolean":
-            value_types.append(0)
+        if kt == ValueType.BOOLEAN:
+            value_types.append(ValueType.BOOLEAN)
             bval = parse_boolean(v)
-            boolean_values.append(0 if bval > 0.7 else (1 if bval < 0.3 else 2))
-            numeric_values.append([0.0, 0.0, 0.0])
+            boolean_values.append(
+                BooleanValue.TRUE if bval > 0.7
+                else (BooleanValue.FALSE if bval < 0.3 else BooleanValue.UNKNOWN)
+            )
+            numeric_values.append([0.0, 0.0, 0.0, 0.0])
             numeric_nan_masks.append(False)
             housenumber_vals.append([0.0, 0.0, 0.0, 0.0])
             housenumber_nan_masks.append(False)
             text_embs.append(zero_text)
 
-        elif kt == "numeric":
-            value_types.append(1)
-            boolean_values.append(2)
-            parser = parse_maxheight if k == "maxheight" else parse_numeric
-            x = parser(v)
+        elif kt == ValueType.NUMERIC:
+            value_types.append(ValueType.NUMERIC)
+            boolean_values.append(BooleanValue.UNKNOWN)
+            if k == "maxheight":
+                x = parse_maxheight(v)
+                is_lower_bound = False
+            else:
+                x, is_lower_bound = parse_numeric(v, key=k)
             is_nan = math.isnan(x)
-            numeric_values.append(encode_numeric_value(x))
+            enc = encode_numeric_value(x, is_lower_bound)
+            assert all(abs(e) <= 30 for e in enc), (
+                f"Numeric encoding magnitude >30 for key={k!r}, value={v!r}: {enc}"
+            )
+            numeric_values.append(enc)
             numeric_nan_masks.append(is_nan)
             housenumber_vals.append([0.0, 0.0, 0.0, 0.0])
             housenumber_nan_masks.append(False)
             text_embs.append(zero_text)
 
-        elif kt == "housenumber":
-            value_types.append(2)
-            boolean_values.append(2)
-            numeric_values.append([0.0, 0.0, 0.0])
+        elif kt == ValueType.HOUSENUMBER:
+            value_types.append(ValueType.HOUSENUMBER)
+            boolean_values.append(BooleanValue.UNKNOWN)
+            numeric_values.append([0.0, 0.0, 0.0, 0.0])
             numeric_nan_masks.append(False)
             lo, hi = parse_housenumber(v)
             is_nan = math.isnan(lo) or math.isnan(hi)
-            housenumber_vals.append(encode_housenumber_value(lo, hi))
+            enc = encode_housenumber_value(lo, hi)
+            assert all(abs(e) <= 30 for e in enc), (
+                f"Housenumber encoding magnitude >30 for value={v!r}: {enc}"
+            )
+            housenumber_vals.append(enc)
             housenumber_nan_masks.append(is_nan)
             text_embs.append(zero_text)
 
         else:  # text
-            value_types.append(3)
-            boolean_values.append(2)
-            numeric_values.append([0.0, 0.0, 0.0])
+            value_types.append(ValueType.TEXT)
+            boolean_values.append(BooleanValue.UNKNOWN)
+            numeric_values.append([0.0, 0.0, 0.0, 0.0])
             numeric_nan_masks.append(False)
             housenumber_vals.append([0.0, 0.0, 0.0, 0.0])
             housenumber_nan_masks.append(False)
@@ -500,7 +521,7 @@ def _pad_encoded(encoded_list: list[dict], text_input_dim: int) -> dict[str, tor
     key_indices = torch.zeros(B, max_tags, dtype=torch.long)
     value_types = torch.zeros(B, max_tags, dtype=torch.long)
     boolean_values = torch.full((B, max_tags), 2, dtype=torch.long)  # default: unknown
-    numeric_values = torch.zeros(B, max_tags, 3)
+    numeric_values = torch.zeros(B, max_tags, 4)
     numeric_nan_mask = torch.zeros(B, max_tags, dtype=torch.bool)
     housenumber_values = torch.zeros(B, max_tags, 4)
     housenumber_nan_mask = torch.zeros(B, max_tags, dtype=torch.bool)
@@ -537,13 +558,25 @@ def _pad_encoded(encoded_list: list[dict], text_input_dim: int) -> dict[str, tor
 
 def collate_correspondence(samples: list[dict]) -> CorrespondenceBatch:
     """Collate function for DataLoader."""
-    text_input_dim = 768
-    # Infer dim from first sample with text embeddings
+    # Infer text embedding dim from first sample with a text embedding
+    text_input_dim = None
     for s in samples:
         for emb in s["pano"]["text_embeddings"]:
             if emb.shape[0] > 0:
                 text_input_dim = emb.shape[0]
                 break
+        if text_input_dim is not None:
+            break
+        for emb in s["osm"]["text_embeddings"]:
+            if emb.shape[0] > 0:
+                text_input_dim = emb.shape[0]
+                break
+        if text_input_dim is not None:
+            break
+    if text_input_dim is None:
+        raise ValueError(
+            "Cannot infer text_input_dim: no samples have text embeddings"
+        )
 
     pano_encoded = [s["pano"] for s in samples]
     osm_encoded = [s["osm"] for s in samples]
@@ -635,7 +668,7 @@ def scan_parse_failures(
 
                 kt = key_type(k)
 
-                if kt == "boolean":
+                if kt == ValueType.BOOLEAN:
                     parsed = parse_boolean(v)
                     if parsed == 0.5:
                         failures.append(ParseFailure(
@@ -643,16 +676,18 @@ def scan_parse_failures(
                             failure_reason="unknown_boolean",
                         ))
 
-                elif kt == "numeric":
-                    parser = parse_maxheight if k == "maxheight" else parse_numeric
-                    parsed = parser(v)
+                elif kt == ValueType.NUMERIC:
+                    if k == "maxheight":
+                        parsed = parse_maxheight(v)
+                    else:
+                        parsed, _ = parse_numeric(v, key=k)
                     if math.isnan(parsed):
                         failures.append(ParseFailure(
                             key=k, raw_value=v, key_type_str="numeric",
                             failure_reason="nan",
                         ))
 
-                elif kt == "housenumber":
+                elif kt == ValueType.HOUSENUMBER:
                     lo, hi = parse_housenumber(v)
                     if math.isnan(lo) or math.isnan(hi):
                         failures.append(ParseFailure(
@@ -660,7 +695,7 @@ def scan_parse_failures(
                             failure_reason="nan",
                         ))
 
-                elif kt == "text":
+                elif kt == ValueType.TEXT:
                     if text_embeddings is not None and v not in text_embeddings:
                         failures.append(ParseFailure(
                             key=k, raw_value=v, key_type_str="text",

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -201,18 +201,23 @@ def load_pairs_from_directory(data_dir: Path) -> list[CorrespondencePair]:
 # Cross-pair feature computation
 # ---------------------------------------------------------------------------
 
+NUM_CROSS_FEATURES_WITH_CATEGORY = 17
+NUM_CROSS_FEATURES_WITHOUT_CATEGORY = 13
+
+
 def compute_cross_features(
     pano_tags: dict[str, str],
     osm_tags: dict[str, str],
     text_embeddings: dict[str, torch.Tensor] | None = None,
+    include_category_features: bool = True,
 ) -> list[float]:
     """Compute cross-pair features between two tag bundles.
 
-    Features (17 total):
+    Features (17 with category, 13 without):
       - Key Jaccard similarity (1)
       - Number of shared keys / 10 (1)
       - Exact value match count / 10 (1)
-      - Primary category match: building, amenity, highway, shop (4)
+      - Primary category match: building, amenity, highway, shop (4) [optional]
       - Text cosine similarity: max, mean, name-specific (3)
       - Numeric proximity per numeric key (6, sorted: building:levels, heritage,
         lanes, levels, maxheight, maxspeed)
@@ -236,12 +241,13 @@ def compute_cross_features(
     exact_matches = sum(1 for k in shared_keys if pano_tags[k] == osm_tags[k])
     features.append(exact_matches / 10.0)
 
-    # Primary category matches (4 binary features)
-    for cat_key in PRIMARY_CATEGORY_KEYS:
-        if cat_key in pano_tags and cat_key in osm_tags:
-            features.append(1.0 if pano_tags[cat_key] == osm_tags[cat_key] else 0.0)
-        else:
-            features.append(0.0)
+    # Primary category matches (4 binary features, optional)
+    if include_category_features:
+        for cat_key in PRIMARY_CATEGORY_KEYS:
+            if cat_key in pano_tags and cat_key in osm_tags:
+                features.append(1.0 if pano_tags[cat_key] == osm_tags[cat_key] else 0.0)
+            else:
+                features.append(0.0)
 
     # Text cosine similarities (3 features)
     if text_embeddings is not None:
@@ -296,7 +302,8 @@ def compute_cross_features(
     else:
         features.append(0.0)
 
-    assert len(features) == 17, f"Expected 17 cross features, got {len(features)}"
+    expected = NUM_CROSS_FEATURES_WITH_CATEGORY if include_category_features else NUM_CROSS_FEATURES_WITHOUT_CATEGORY
+    assert len(features) == expected, f"Expected {expected} cross features, got {len(features)}"
     return features
 
 
@@ -393,10 +400,17 @@ def encode_tag_bundle(
             numeric_nan_masks.append(False)
             housenumber_vals.append([0.0, 0.0, 0.0, 0.0])
             housenumber_nan_masks.append(False)
-            if text_embeddings is not None and v in text_embeddings:
-                text_embs.append(text_embeddings[v])
-            else:
-                text_embs.append(zero_text)
+            if text_embeddings is None:
+                raise ValueError(
+                    f"text_embeddings is required but not provided "
+                    f"(key={k!r}, value={v!r})"
+                )
+            if v not in text_embeddings:
+                raise KeyError(
+                    f"Text value {v!r} for key {k!r} not found in "
+                    f"text_embeddings ({len(text_embeddings)} entries)"
+                )
+            text_embs.append(text_embeddings[v])
 
     return {
         "key_indices": key_indices,
@@ -423,6 +437,7 @@ class LandmarkCorrespondenceDataset(Dataset):
         text_embeddings: dict[str, torch.Tensor] | None = None,
         text_input_dim: int = 768,
         include_difficulties: tuple[str, ...] = ("positive", "easy"),
+        include_category_features: bool = True,
     ):
         """Initialize dataset.
 
@@ -431,10 +446,12 @@ class LandmarkCorrespondenceDataset(Dataset):
             text_embeddings: Pre-computed {value_string: tensor} for text keys
             text_input_dim: Dimension of pre-computed text embeddings
             include_difficulties: Which pair types to include
+            include_category_features: Whether to include primary category match features
         """
         self.pairs = [p for p in pairs if p.difficulty in include_difficulties]
         self.text_embeddings = text_embeddings
         self.text_input_dim = text_input_dim
+        self.include_category_features = include_category_features
 
     def __len__(self) -> int:
         return len(self.pairs)
@@ -448,7 +465,8 @@ class LandmarkCorrespondenceDataset(Dataset):
             pair.osm_tags, self.text_embeddings, self.text_input_dim
         )
         cross_feats = compute_cross_features(
-            pair.pano_tags, pair.osm_tags, self.text_embeddings
+            pair.pano_tags, pair.osm_tags, self.text_embeddings,
+            self.include_category_features,
         )
         return {
             "pano": pano_encoded,

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -1,0 +1,740 @@
+"""Dataset for landmark correspondence classification.
+
+Parses Gemini batch JSONL responses to extract (pano_tags, osm_tags, label) pairs.
+Each JSONL line contains a prompt with Set 1 (pano) and Set 2 (OSM) tag bundles,
+plus a Gemini response identifying matches and negatives.
+
+Yields:
+  - Positive pairs: pano landmark matched to OSM landmark
+  - Hard negatives: same category but different landmark
+  - Easy negatives: completely different type
+"""
+
+import json
+import math
+import pickle
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import Dataset
+
+from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
+    BOOLEAN_KEYS,
+    HOUSENUMBER_KEY,
+    NUMERIC_KEYS,
+    NUM_TAG_KEYS,
+    PRIMARY_CATEGORY_KEYS,
+    TAG_KEY_TO_IDX,
+    encode_housenumber_value,
+    encode_numeric_value,
+    key_type,
+    parse_boolean,
+    parse_housenumber,
+    parse_maxheight,
+    parse_numeric,
+)
+
+
+# ---------------------------------------------------------------------------
+# JSONL parsing
+# ---------------------------------------------------------------------------
+
+def parse_tag_string(tag_str: str) -> dict[str, str]:
+    """Parse 'key=value; key=value' into a dict."""
+    tags = {}
+    for part in tag_str.split("; "):
+        part = part.strip()
+        if "=" in part:
+            k, v = part.split("=", 1)
+            tags[k.strip()] = v.strip()
+    return tags
+
+
+def parse_prompt_landmarks(prompt_text: str) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Parse the prompt to extract Set 1 and Set 2 landmark tag bundles.
+
+    The prompt format is:
+        Set 1 (street-level observations):
+         0. key=value; key=value
+         1. key=value
+        ...
+        Set 2 (map database):
+         0. key=value; key=value
+        ...
+
+    Returns: (set1_landmarks, set2_landmarks) where each is a list of tag dicts.
+    """
+    # Split into Set 1 and Set 2 sections
+    set2_marker = "\n\nSet 2 (map database):\n"
+    if set2_marker not in prompt_text:
+        raise ValueError("Could not find Set 2 marker in prompt")
+
+    set1_text, set2_text = prompt_text.split(set2_marker, 1)
+
+    # Remove Set 1 header
+    set1_header = "Set 1 (street-level observations):\n"
+    if set1_text.startswith(set1_header):
+        set1_text = set1_text[len(set1_header):]
+
+    def parse_landmarks(text: str) -> list[dict[str, str]]:
+        landmarks = []
+        for line in text.strip().split("\n"):
+            line = line.strip()
+            # Match " N. tags..." pattern
+            match = re.match(r"\d+\.\s+(.*)", line)
+            if match:
+                landmarks.append(parse_tag_string(match.group(1)))
+        return landmarks
+
+    return parse_landmarks(set1_text), parse_landmarks(set2_text)
+
+
+@dataclass
+class CorrespondencePair:
+    """A single training pair."""
+    pano_tags: dict[str, str]
+    osm_tags: dict[str, str]
+    label: float  # 1.0 = positive, 0.0 = negative
+    difficulty: str  # "positive", "hard", "easy"
+    uniqueness_score: int  # 1-5, from Gemini
+    pano_id: str
+
+
+def parse_jsonl_line(line_data: dict) -> list[CorrespondencePair]:
+    """Parse one JSONL line into correspondence pairs.
+
+    Returns list of CorrespondencePair for all matches and negatives.
+    """
+    pano_id = line_data["key"]
+
+    # Parse prompt to get tag bundles
+    prompt_text = line_data["request"]["contents"][0]["parts"][0]["text"]
+    set1_landmarks, set2_landmarks = parse_prompt_landmarks(prompt_text)
+
+    # Parse response
+    response = line_data.get("response", {})
+    candidates = response.get("candidates", [])
+    if not candidates:
+        return []
+
+    try:
+        resp_text = candidates[0]["content"]["parts"][0]["text"]
+        resp = json.loads(resp_text)
+    except (KeyError, IndexError, json.JSONDecodeError):
+        return []
+
+    pairs = []
+    for match in resp.get("matches", []):
+        set1_id = match.get("set_1_id")
+        if set1_id is None or set1_id < 0 or set1_id >= len(set1_landmarks):
+            continue
+
+        pano_tags = set1_landmarks[set1_id]
+        uniqueness = match.get("uniqueness_score", 0)
+
+        # Positive pairs
+        for set2_id in match.get("set_2_matches", []):
+            if set2_id < 0 or set2_id >= len(set2_landmarks):
+                continue
+            pairs.append(CorrespondencePair(
+                pano_tags=pano_tags,
+                osm_tags=set2_landmarks[set2_id],
+                label=1.0,
+                difficulty="positive",
+                uniqueness_score=uniqueness,
+                pano_id=pano_id,
+            ))
+
+        # Negative pairs
+        for neg in match.get("negatives", []):
+            set2_id = neg.get("set_2_id")
+            if set2_id is None or set2_id < 0 or set2_id >= len(set2_landmarks):
+                continue
+            difficulty = neg.get("difficulty", "easy")
+            pairs.append(CorrespondencePair(
+                pano_tags=pano_tags,
+                osm_tags=set2_landmarks[set2_id],
+                label=0.0,
+                difficulty=difficulty,
+                uniqueness_score=uniqueness,
+                pano_id=pano_id,
+            ))
+
+    return pairs
+
+
+def load_pairs_from_directory(data_dir: Path) -> list[CorrespondencePair]:
+    """Load all correspondence pairs from a city's response directory.
+
+    Recursively finds all predictions.jsonl files under data_dir.
+    """
+    pairs = []
+    jsonl_files = list(data_dir.rglob("predictions.jsonl"))
+    if not jsonl_files:
+        jsonl_files = list(data_dir.rglob("*.jsonl"))
+
+    for jsonl_path in jsonl_files:
+        with open(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                    pairs.extend(parse_jsonl_line(data))
+                except (json.JSONDecodeError, ValueError):
+                    continue
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Cross-pair feature computation
+# ---------------------------------------------------------------------------
+
+def compute_cross_features(
+    pano_tags: dict[str, str],
+    osm_tags: dict[str, str],
+    text_embeddings: dict[str, torch.Tensor] | None = None,
+) -> list[float]:
+    """Compute cross-pair features between two tag bundles.
+
+    Features (17 total):
+      - Key Jaccard similarity (1)
+      - Number of shared keys / 10 (1)
+      - Exact value match count / 10 (1)
+      - Primary category match: building, amenity, highway, shop (4)
+      - Text cosine similarity: max, mean, name-specific (3)
+      - Numeric proximity per numeric key (6: building:levels, levels, lanes,
+        maxspeed, maxheight, heritage)
+      - Housenumber range overlap (1)
+    """
+    pano_keys = set(pano_tags.keys())
+    osm_keys = set(osm_tags.keys())
+    shared_keys = pano_keys & osm_keys
+    union_keys = pano_keys | osm_keys
+
+    features = []
+
+    # Jaccard similarity
+    jaccard = len(shared_keys) / max(len(union_keys), 1)
+    features.append(jaccard)
+
+    # Shared key count (normalized)
+    features.append(len(shared_keys) / 10.0)
+
+    # Exact value match count
+    exact_matches = sum(1 for k in shared_keys if pano_tags[k] == osm_tags[k])
+    features.append(exact_matches / 10.0)
+
+    # Primary category matches (4 binary features)
+    for cat_key in PRIMARY_CATEGORY_KEYS:
+        if cat_key in pano_tags and cat_key in osm_tags:
+            features.append(1.0 if pano_tags[cat_key] == osm_tags[cat_key] else 0.0)
+        else:
+            features.append(0.0)
+
+    # Text cosine similarities (3 features)
+    if text_embeddings is not None:
+        text_sims = []
+        name_sim = 0.0
+        for k in shared_keys:
+            if key_type(k) != "text":
+                continue
+            pv = pano_tags[k]
+            ov = osm_tags[k]
+            if pv in text_embeddings and ov in text_embeddings:
+                pe = text_embeddings[pv]
+                oe = text_embeddings[ov]
+                sim = F.cosine_similarity(pe.unsqueeze(0), oe.unsqueeze(0)).item()
+                text_sims.append(sim)
+                if k == "name":
+                    name_sim = sim
+        features.append(max(text_sims) if text_sims else 0.0)  # max
+        features.append(sum(text_sims) / max(len(text_sims), 1) if text_sims else 0.0)  # mean
+        features.append(name_sim)  # name-specific
+    else:
+        features.extend([0.0, 0.0, 0.0])
+
+    # Numeric proximity (6 features, one per numeric key)
+    numeric_keys_ordered = ["building:levels", "levels", "lanes", "maxspeed", "maxheight", "heritage"]
+    for nk in numeric_keys_ordered:
+        if nk in pano_tags and nk in osm_tags:
+            parser = parse_maxheight if nk == "maxheight" else parse_numeric
+            a = parser(pano_tags[nk])
+            b = parser(osm_tags[nk])
+            if not (math.isnan(a) or math.isnan(b)):
+                scale = 10.0 if nk in ("maxspeed",) else 2.0
+                features.append(math.exp(-abs(a - b) / scale))
+            else:
+                features.append(0.0)
+        else:
+            features.append(0.0)
+
+    # Housenumber range overlap (1 feature)
+    if HOUSENUMBER_KEY in pano_tags and HOUSENUMBER_KEY in osm_tags:
+        plo, phi = parse_housenumber(pano_tags[HOUSENUMBER_KEY])
+        olo, ohi = parse_housenumber(osm_tags[HOUSENUMBER_KEY])
+        if not any(math.isnan(x) for x in (plo, phi, olo, ohi)):
+            # Check if either number falls in the other's range
+            overlap = (plo >= olo and plo <= ohi) or (olo >= plo and olo <= phi)
+            features.append(1.0 if overlap else 0.0)
+        else:
+            features.append(0.0)
+    else:
+        features.append(0.0)
+
+    assert len(features) == 17, f"Expected 17 cross features, got {len(features)}"
+    return features
+
+
+# ---------------------------------------------------------------------------
+# Tag encoding for model input
+# ---------------------------------------------------------------------------
+
+def encode_tag_bundle(
+    tags: dict[str, str],
+    text_embeddings: dict[str, torch.Tensor] | None,
+    text_input_dim: int = 768,
+) -> dict:
+    """Encode a tag bundle into tensors for TagBundleEncoder.
+
+    Returns dict with:
+      key_indices: list[int]
+      value_types: list[int]  (0=bool, 1=numeric, 2=housenumber, 3=text)
+      boolean_values: list[int]  (0=true, 1=false, 2=unknown)
+      numeric_values: list[list[float]]  (each is 3-dim)
+      numeric_nan_mask: list[bool]
+      housenumber_values: list[list[float]]  (each is 4-dim)
+      housenumber_nan_mask: list[bool]
+      text_embeddings: list[torch.Tensor]  (each is text_input_dim-dim)
+    """
+    key_indices = []
+    value_types = []
+    boolean_values = []
+    numeric_values = []
+    numeric_nan_masks = []
+    housenumber_vals = []
+    housenumber_nan_masks = []
+    text_embs = []
+
+    zero_text = torch.zeros(text_input_dim)
+
+    for k, v in tags.items():
+        if k not in TAG_KEY_TO_IDX:
+            continue
+
+        key_indices.append(TAG_KEY_TO_IDX[k])
+        kt = key_type(k)
+
+        if kt == "boolean":
+            value_types.append(0)
+            bval = parse_boolean(v)
+            boolean_values.append(0 if bval > 0.7 else (1 if bval < 0.3 else 2))
+            numeric_values.append([0.0, 0.0, 0.0])
+            numeric_nan_masks.append(False)
+            housenumber_vals.append([0.0, 0.0, 0.0, 0.0])
+            housenumber_nan_masks.append(False)
+            text_embs.append(zero_text)
+
+        elif kt == "numeric":
+            value_types.append(1)
+            boolean_values.append(2)
+            parser = parse_maxheight if k == "maxheight" else parse_numeric
+            x = parser(v)
+            is_nan = math.isnan(x)
+            numeric_values.append(encode_numeric_value(x))
+            numeric_nan_masks.append(is_nan)
+            housenumber_vals.append([0.0, 0.0, 0.0, 0.0])
+            housenumber_nan_masks.append(False)
+            text_embs.append(zero_text)
+
+        elif kt == "housenumber":
+            value_types.append(2)
+            boolean_values.append(2)
+            numeric_values.append([0.0, 0.0, 0.0])
+            numeric_nan_masks.append(False)
+            lo, hi = parse_housenumber(v)
+            is_nan = math.isnan(lo) or math.isnan(hi)
+            housenumber_vals.append(encode_housenumber_value(lo, hi))
+            housenumber_nan_masks.append(is_nan)
+            text_embs.append(zero_text)
+
+        else:  # text
+            value_types.append(3)
+            boolean_values.append(2)
+            numeric_values.append([0.0, 0.0, 0.0])
+            numeric_nan_masks.append(False)
+            housenumber_vals.append([0.0, 0.0, 0.0, 0.0])
+            housenumber_nan_masks.append(False)
+            if text_embeddings is not None and v in text_embeddings:
+                text_embs.append(text_embeddings[v])
+            else:
+                text_embs.append(zero_text)
+
+    return {
+        "key_indices": key_indices,
+        "value_types": value_types,
+        "boolean_values": boolean_values,
+        "numeric_values": numeric_values,
+        "numeric_nan_mask": numeric_nan_masks,
+        "housenumber_values": housenumber_vals,
+        "housenumber_nan_mask": housenumber_nan_masks,
+        "text_embeddings": text_embs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+class LandmarkCorrespondenceDataset(Dataset):
+    """PyTorch dataset yielding (pano_tags, osm_tags, label, difficulty) tuples."""
+
+    def __init__(
+        self,
+        pairs: list[CorrespondencePair],
+        text_embeddings: dict[str, torch.Tensor] | None = None,
+        text_input_dim: int = 768,
+        include_difficulties: tuple[str, ...] = ("positive", "easy"),
+    ):
+        """Initialize dataset.
+
+        Args:
+            pairs: List of CorrespondencePair from JSONL parsing
+            text_embeddings: Pre-computed {value_string: tensor} for text keys
+            text_input_dim: Dimension of pre-computed text embeddings
+            include_difficulties: Which pair types to include
+        """
+        self.pairs = [p for p in pairs if p.difficulty in include_difficulties]
+        self.text_embeddings = text_embeddings
+        self.text_input_dim = text_input_dim
+
+    def __len__(self) -> int:
+        return len(self.pairs)
+
+    def __getitem__(self, idx: int) -> dict:
+        pair = self.pairs[idx]
+        pano_encoded = encode_tag_bundle(
+            pair.pano_tags, self.text_embeddings, self.text_input_dim
+        )
+        osm_encoded = encode_tag_bundle(
+            pair.osm_tags, self.text_embeddings, self.text_input_dim
+        )
+        cross_feats = compute_cross_features(
+            pair.pano_tags, pair.osm_tags, self.text_embeddings
+        )
+        return {
+            "pano": pano_encoded,
+            "osm": osm_encoded,
+            "cross_features": cross_feats,
+            "label": pair.label,
+            "difficulty": pair.difficulty,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Batch collation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CorrespondenceBatch:
+    """Collated batch for CorrespondenceClassifier."""
+    # Pano side (all B × max_pano_tags)
+    pano_key_indices: torch.Tensor
+    pano_value_type: torch.Tensor
+    pano_boolean_values: torch.Tensor
+    pano_numeric_values: torch.Tensor
+    pano_numeric_nan_mask: torch.Tensor
+    pano_housenumber_values: torch.Tensor
+    pano_housenumber_nan_mask: torch.Tensor
+    pano_text_embeddings: torch.Tensor
+    pano_tag_mask: torch.Tensor
+    # OSM side (all B × max_osm_tags)
+    osm_key_indices: torch.Tensor
+    osm_value_type: torch.Tensor
+    osm_boolean_values: torch.Tensor
+    osm_numeric_values: torch.Tensor
+    osm_numeric_nan_mask: torch.Tensor
+    osm_housenumber_values: torch.Tensor
+    osm_housenumber_nan_mask: torch.Tensor
+    osm_text_embeddings: torch.Tensor
+    osm_tag_mask: torch.Tensor
+    # Cross features (B × num_cross)
+    cross_features: torch.Tensor
+    # Labels (B,)
+    labels: torch.Tensor
+
+    def to(self, device: torch.device) -> "CorrespondenceBatch":
+        """Move all tensors to device."""
+        return CorrespondenceBatch(**{
+            name: getattr(self, name).to(device) for name in self.__dataclass_fields__
+        })
+
+    def pin_memory(self) -> "CorrespondenceBatch":
+        """Pin all tensors to memory for faster GPU transfer."""
+        return CorrespondenceBatch(**{
+            name: getattr(self, name).pin_memory() for name in self.__dataclass_fields__
+        })
+
+
+def _pad_encoded(encoded_list: list[dict], text_input_dim: int) -> dict[str, torch.Tensor]:
+    """Pad and stack encoded tag bundles into batch tensors.
+
+    Args:
+        encoded_list: List of dicts from encode_tag_bundle
+        text_input_dim: Dimension of text embeddings
+
+    Returns:
+        Dict of tensors, all with shape (B, max_tags, ...)
+    """
+    B = len(encoded_list)
+    max_tags = max(len(e["key_indices"]) for e in encoded_list) if encoded_list else 1
+    max_tags = max(max_tags, 1)  # At least 1 to avoid empty tensors
+
+    key_indices = torch.zeros(B, max_tags, dtype=torch.long)
+    value_types = torch.zeros(B, max_tags, dtype=torch.long)
+    boolean_values = torch.full((B, max_tags), 2, dtype=torch.long)  # default: unknown
+    numeric_values = torch.zeros(B, max_tags, 3)
+    numeric_nan_mask = torch.zeros(B, max_tags, dtype=torch.bool)
+    housenumber_values = torch.zeros(B, max_tags, 4)
+    housenumber_nan_mask = torch.zeros(B, max_tags, dtype=torch.bool)
+    text_embeddings = torch.zeros(B, max_tags, text_input_dim)
+    tag_mask = torch.zeros(B, max_tags, dtype=torch.bool)
+
+    for i, enc in enumerate(encoded_list):
+        n = len(enc["key_indices"])
+        if n == 0:
+            continue
+        tag_mask[i, :n] = True
+        key_indices[i, :n] = torch.tensor(enc["key_indices"], dtype=torch.long)
+        value_types[i, :n] = torch.tensor(enc["value_types"], dtype=torch.long)
+        boolean_values[i, :n] = torch.tensor(enc["boolean_values"], dtype=torch.long)
+        numeric_values[i, :n] = torch.tensor(enc["numeric_values"], dtype=torch.float)
+        numeric_nan_mask[i, :n] = torch.tensor(enc["numeric_nan_mask"], dtype=torch.bool)
+        housenumber_values[i, :n] = torch.tensor(enc["housenumber_values"], dtype=torch.float)
+        housenumber_nan_mask[i, :n] = torch.tensor(enc["housenumber_nan_mask"], dtype=torch.bool)
+        if enc["text_embeddings"]:
+            text_embeddings[i, :n] = torch.stack(enc["text_embeddings"])
+
+    return {
+        "key_indices": key_indices,
+        "value_type": value_types,
+        "boolean_values": boolean_values,
+        "numeric_values": numeric_values,
+        "numeric_nan_mask": numeric_nan_mask,
+        "housenumber_values": housenumber_values,
+        "housenumber_nan_mask": housenumber_nan_mask,
+        "text_embeddings": text_embeddings,
+        "tag_mask": tag_mask,
+    }
+
+
+def collate_correspondence(samples: list[dict]) -> CorrespondenceBatch:
+    """Collate function for DataLoader."""
+    text_input_dim = 768
+    # Infer dim from first sample with text embeddings
+    for s in samples:
+        for emb in s["pano"]["text_embeddings"]:
+            if emb.shape[0] > 0:
+                text_input_dim = emb.shape[0]
+                break
+
+    pano_encoded = [s["pano"] for s in samples]
+    osm_encoded = [s["osm"] for s in samples]
+
+    pano_tensors = _pad_encoded(pano_encoded, text_input_dim)
+    osm_tensors = _pad_encoded(osm_encoded, text_input_dim)
+
+    cross_features = torch.tensor([s["cross_features"] for s in samples], dtype=torch.float)
+    labels = torch.tensor([s["label"] for s in samples], dtype=torch.float)
+
+    return CorrespondenceBatch(
+        pano_key_indices=pano_tensors["key_indices"],
+        pano_value_type=pano_tensors["value_type"],
+        pano_boolean_values=pano_tensors["boolean_values"],
+        pano_numeric_values=pano_tensors["numeric_values"],
+        pano_numeric_nan_mask=pano_tensors["numeric_nan_mask"],
+        pano_housenumber_values=pano_tensors["housenumber_values"],
+        pano_housenumber_nan_mask=pano_tensors["housenumber_nan_mask"],
+        pano_text_embeddings=pano_tensors["text_embeddings"],
+        pano_tag_mask=pano_tensors["tag_mask"],
+        osm_key_indices=osm_tensors["key_indices"],
+        osm_value_type=osm_tensors["value_type"],
+        osm_boolean_values=osm_tensors["boolean_values"],
+        osm_numeric_values=osm_tensors["numeric_values"],
+        osm_numeric_nan_mask=osm_tensors["numeric_nan_mask"],
+        osm_housenumber_values=osm_tensors["housenumber_values"],
+        osm_housenumber_nan_mask=osm_tensors["housenumber_nan_mask"],
+        osm_text_embeddings=osm_tensors["text_embeddings"],
+        osm_tag_mask=osm_tensors["tag_mask"],
+        cross_features=cross_features,
+        labels=labels,
+    )
+
+
+def load_text_embeddings(path: Path) -> dict[str, torch.Tensor]:
+    """Load pre-computed text embeddings from pickle file.
+
+    Expected format: {value_string: numpy_array_or_tensor}
+    """
+    with open(path, "rb") as f:
+        data = pickle.load(f)
+    # Convert numpy arrays to tensors if needed
+    result = {}
+    for k, v in data.items():
+        if isinstance(v, torch.Tensor):
+            result[k] = v
+        else:
+            result[k] = torch.tensor(v, dtype=torch.float32)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Parse failure reporting
+# ---------------------------------------------------------------------------
+
+PARSE_REPORT_PATH = Path("/tmp/landmark_correspondence_parse_report.txt")
+
+
+@dataclass
+class ParseFailure:
+    """A single parse failure."""
+    key: str
+    raw_value: str
+    key_type_str: str  # "boolean", "numeric", "housenumber"
+    failure_reason: str  # "nan", "unknown_boolean"
+
+
+def scan_parse_failures(
+    pairs: list[CorrespondencePair],
+    text_embeddings: dict[str, torch.Tensor] | None = None,
+) -> list[ParseFailure]:
+    """Scan all pairs and collect parse failures for non-text keys.
+
+    Failures are:
+      - Boolean: value parsed to 0.5 (unknown/unrecognized)
+      - Numeric: value parsed to NaN
+      - Housenumber: value parsed to (NaN, NaN)
+      - Text: value not in text_embeddings dict (missing embedding)
+    """
+    failures = []
+    seen = set()  # (key, raw_value) to avoid duplicate reports
+
+    for pair in pairs:
+        for tags in [pair.pano_tags, pair.osm_tags]:
+            for k, v in tags.items():
+                if (k, v) in seen:
+                    continue
+                seen.add((k, v))
+
+                kt = key_type(k)
+
+                if kt == "boolean":
+                    parsed = parse_boolean(v)
+                    if parsed == 0.5:
+                        failures.append(ParseFailure(
+                            key=k, raw_value=v, key_type_str="boolean",
+                            failure_reason="unknown_boolean",
+                        ))
+
+                elif kt == "numeric":
+                    parser = parse_maxheight if k == "maxheight" else parse_numeric
+                    parsed = parser(v)
+                    if math.isnan(parsed):
+                        failures.append(ParseFailure(
+                            key=k, raw_value=v, key_type_str="numeric",
+                            failure_reason="nan",
+                        ))
+
+                elif kt == "housenumber":
+                    lo, hi = parse_housenumber(v)
+                    if math.isnan(lo) or math.isnan(hi):
+                        failures.append(ParseFailure(
+                            key=k, raw_value=v, key_type_str="housenumber",
+                            failure_reason="nan",
+                        ))
+
+                elif kt == "text":
+                    if text_embeddings is not None and v not in text_embeddings:
+                        failures.append(ParseFailure(
+                            key=k, raw_value=v, key_type_str="text",
+                            failure_reason="missing_embedding",
+                        ))
+
+    return failures
+
+
+def write_parse_report(
+    failures: list[ParseFailure],
+    pairs: list[CorrespondencePair],
+    report_path: Path = PARSE_REPORT_PATH,
+) -> None:
+    """Write parse failure report to file.
+
+    Groups failures by key and type, shows raw values and counts.
+    """
+    # Count total values per key type to compute failure rates
+    type_counts: Counter = Counter()
+    key_value_counts: Counter = Counter()
+    seen = set()
+    for pair in pairs:
+        for tags in [pair.pano_tags, pair.osm_tags]:
+            for k, v in tags.items():
+                if (k, v) in seen:
+                    continue
+                seen.add((k, v))
+                kt = key_type(k)
+                type_counts[kt] += 1
+                key_value_counts[k] += 1
+
+    # Group failures
+    by_key: defaultdict[str, list[ParseFailure]] = defaultdict(list)
+    for f in failures:
+        by_key[f.key].append(f)
+
+    by_type: defaultdict[str, list[ParseFailure]] = defaultdict(list)
+    for f in failures:
+        by_type[f.key_type_str].append(f)
+
+    lines = []
+    lines.append("=" * 80)
+    lines.append("PARSE FAILURE REPORT")
+    lines.append("=" * 80)
+    lines.append("")
+
+    # Summary
+    lines.append("SUMMARY BY TYPE")
+    lines.append("-" * 40)
+    for kt in ["boolean", "numeric", "housenumber", "text"]:
+        n_fail = len(by_type.get(kt, []))
+        n_total = type_counts.get(kt, 0)
+        pct = (n_fail / n_total * 100) if n_total > 0 else 0
+        lines.append(f"  {kt:15s}: {n_fail:5d} / {n_total:5d} unique values failed ({pct:.1f}%)")
+    lines.append(f"  {'TOTAL':15s}: {len(failures):5d} / {sum(type_counts.values()):5d}")
+    lines.append("")
+
+    # Per-key breakdown
+    lines.append("FAILURES BY KEY")
+    lines.append("-" * 40)
+    for key in sorted(by_key.keys()):
+        key_failures = by_key[key]
+        n_total = key_value_counts.get(key, 0)
+        n_fail = len(key_failures)
+        pct = (n_fail / n_total * 100) if n_total > 0 else 0
+        lines.append(f"\n  {key} ({key_failures[0].key_type_str}): "
+                      f"{n_fail}/{n_total} failed ({pct:.1f}%)")
+
+        # Show all failing values (sorted by value)
+        for f in sorted(key_failures, key=lambda x: x.raw_value):
+            lines.append(f"    {f.failure_reason:20s}  {f.raw_value!r}")
+
+    lines.append("")
+    lines.append("=" * 80)
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text("\n".join(lines) + "\n")
+    print(f"Parse failure report written to {report_path}")

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -747,9 +747,13 @@ def write_parse_report(
     # Summary
     lines.append("SUMMARY BY TYPE")
     lines.append("-" * 40)
+    _type_name_to_enum = {
+        "boolean": ValueType.BOOLEAN, "numeric": ValueType.NUMERIC,
+        "housenumber": ValueType.HOUSENUMBER, "text": ValueType.TEXT,
+    }
     for kt in ["boolean", "numeric", "housenumber", "text"]:
         n_fail = len(by_type.get(kt, []))
-        n_total = type_counts.get(kt, 0)
+        n_total = type_counts.get(_type_name_to_enum[kt], 0)
         pct = (n_fail / n_total * 100) if n_total > 0 else 0
         lines.append(f"  {kt:15s}: {n_fail:5d} / {n_total:5d} unique values failed ({pct:.1f}%)")
     lines.append(f"  {'TOTAL':15s}: {len(failures):5d} / {sum(type_counts.values()):5d}")

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -30,7 +30,6 @@ from experimental.overhead_matching.swag.model.landmark_correspondence_model imp
     HOUSENUMBER_KEY,
     NUMERIC_KEYS,
     NUM_TAG_KEYS,
-    PRIMARY_CATEGORY_KEYS,
     TAG_KEY_TO_IDX,
     ValueType,
     encode_housenumber_value,
@@ -201,23 +200,20 @@ def load_pairs_from_directory(data_dir: Path) -> list[CorrespondencePair]:
 # Cross-pair feature computation
 # ---------------------------------------------------------------------------
 
-NUM_CROSS_FEATURES_WITH_CATEGORY = 17
-NUM_CROSS_FEATURES_WITHOUT_CATEGORY = 13
+NUM_CROSS_FEATURES = 13
 
 
 def compute_cross_features(
     pano_tags: dict[str, str],
     osm_tags: dict[str, str],
     text_embeddings: dict[str, torch.Tensor] | None = None,
-    include_category_features: bool = True,
 ) -> list[float]:
     """Compute cross-pair features between two tag bundles.
 
-    Features (17 with category, 13 without):
+    Features (13 total):
       - Key Jaccard similarity (1)
       - Number of shared keys / 10 (1)
       - Exact value match count / 10 (1)
-      - Primary category match: building, amenity, highway, shop (4) [optional]
       - Text cosine similarity: max, mean, name-specific (3)
       - Numeric proximity per numeric key (6, sorted: building:levels, heritage,
         lanes, levels, maxheight, maxspeed)
@@ -240,14 +236,6 @@ def compute_cross_features(
     # Exact value match count
     exact_matches = sum(1 for k in shared_keys if pano_tags[k] == osm_tags[k])
     features.append(exact_matches / 10.0)
-
-    # Primary category matches (4 binary features, optional)
-    if include_category_features:
-        for cat_key in PRIMARY_CATEGORY_KEYS:
-            if cat_key in pano_tags and cat_key in osm_tags:
-                features.append(1.0 if pano_tags[cat_key] == osm_tags[cat_key] else 0.0)
-            else:
-                features.append(0.0)
 
     # Text cosine similarities (3 features)
     if text_embeddings is not None:
@@ -302,8 +290,7 @@ def compute_cross_features(
     else:
         features.append(0.0)
 
-    expected = NUM_CROSS_FEATURES_WITH_CATEGORY if include_category_features else NUM_CROSS_FEATURES_WITHOUT_CATEGORY
-    assert len(features) == expected, f"Expected {expected} cross features, got {len(features)}"
+    assert len(features) == NUM_CROSS_FEATURES, f"Expected {NUM_CROSS_FEATURES} cross features, got {len(features)}"
     return features
 
 
@@ -437,7 +424,6 @@ class LandmarkCorrespondenceDataset(Dataset):
         text_embeddings: dict[str, torch.Tensor] | None = None,
         text_input_dim: int = 768,
         include_difficulties: tuple[str, ...] = ("positive", "easy"),
-        include_category_features: bool = True,
     ):
         """Initialize dataset.
 
@@ -446,12 +432,10 @@ class LandmarkCorrespondenceDataset(Dataset):
             text_embeddings: Pre-computed {value_string: tensor} for text keys
             text_input_dim: Dimension of pre-computed text embeddings
             include_difficulties: Which pair types to include
-            include_category_features: Whether to include primary category match features
         """
         self.pairs = [p for p in pairs if p.difficulty in include_difficulties]
         self.text_embeddings = text_embeddings
         self.text_input_dim = text_input_dim
-        self.include_category_features = include_category_features
 
     def __len__(self) -> int:
         return len(self.pairs)
@@ -466,7 +450,6 @@ class LandmarkCorrespondenceDataset(Dataset):
         )
         cross_feats = compute_cross_features(
             pair.pano_tags, pair.osm_tags, self.text_embeddings,
-            self.include_category_features,
         )
         return {
             "pano": pano_encoded,

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -182,6 +182,7 @@ def load_pairs_from_directory(data_dir: Path) -> list[CorrespondencePair]:
     if not jsonl_files:
         jsonl_files = list(data_dir.rglob("*.jsonl"))
 
+    skipped = 0
     for jsonl_path in jsonl_files:
         with open(jsonl_path) as f:
             for line in f:
@@ -192,7 +193,10 @@ def load_pairs_from_directory(data_dir: Path) -> list[CorrespondencePair]:
                     data = json.loads(line)
                     pairs.extend(parse_jsonl_line(data))
                 except (json.JSONDecodeError, ValueError):
+                    skipped += 1
                     continue
+    if skipped:
+        print(f"WARNING: Skipped {skipped} unparseable JSONL lines across {len(jsonl_files)} files")
     return pairs
 
 
@@ -416,7 +420,7 @@ def encode_tag_bundle(
 # ---------------------------------------------------------------------------
 
 class LandmarkCorrespondenceDataset(Dataset):
-    """PyTorch dataset yielding (pano_tags, osm_tags, label, difficulty) tuples."""
+    """PyTorch dataset yielding dicts with encoded pano/osm tag bundles, cross-features, label, and difficulty."""
 
     def __init__(
         self,

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
@@ -35,6 +35,10 @@ class TestTagStringParsing:
         tags = parse_tag_string("name=Route 66=Historic")
         assert tags == {"name": "Route 66=Historic"}
 
+    def test_duplicate_keys_last_wins(self):
+        tags = parse_tag_string("building=yes; building=commercial")
+        assert tags == {"building": "commercial"}
+
 
 class TestPromptParsing:
     SAMPLE_PROMPT = """Set 1 (street-level observations):
@@ -141,11 +145,36 @@ Set 2 (map database):
 
 
 class TestCrossFeatures:
+    # Feature layout (17 total):
+    #  [0]     Jaccard similarity
+    #  [1]     shared keys / 10
+    #  [2]     exact matches / 10
+    #  [3..6]  primary category match: building, amenity, highway, shop
+    #  [7..9]  text sim: max, mean, name
+    #  [10..15] numeric proximity in sorted key order:
+    #           building:levels, heritage, lanes, levels, maxheight, maxspeed
+    #  [16]    housenumber overlap
+
     def test_feature_count(self):
         pano = {"building": "yes", "name": "Library"}
         osm = {"building": "yes", "name": "Library"}
         feats = compute_cross_features(pano, osm)
         assert len(feats) == 17
+
+    def test_numeric_feature_order(self):
+        """Numeric proximity features must follow sorted(NUMERIC_KEYS) order."""
+        # building:levels is at index 10, lanes at 12, maxspeed at 15
+        pano = {"building:levels": "3", "lanes": "2", "maxspeed": "30 mph"}
+        osm = {"building:levels": "3", "lanes": "2", "maxspeed": "30 mph"}
+        feats = compute_cross_features(pano, osm)
+        # Exact matches → exp(0) = 1.0
+        assert feats[10] == 1.0, "building:levels should be at index 10"
+        assert feats[12] == 1.0, "lanes should be at index 12"
+        assert feats[15] == 1.0, "maxspeed should be at index 15"
+        # heritage (11), levels (13), maxheight (14) are absent → 0.0
+        assert feats[11] == 0.0, "heritage absent"
+        assert feats[13] == 0.0, "levels absent"
+        assert feats[14] == 0.0, "maxheight absent"
 
     def test_identical_tags_high_similarity(self):
         tags = {"building": "yes", "name": "Library", "amenity": "library"}

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
@@ -151,36 +151,35 @@ Set 2 (map database):
 
 
 class TestCrossFeatures(unittest.TestCase):
-    # Feature layout (17 total):
+    # Feature layout (13 total):
     #  [0]     Jaccard similarity
     #  [1]     shared keys / 10
     #  [2]     exact matches / 10
-    #  [3..6]  primary category match: building, amenity, highway, shop
-    #  [7..9]  text sim: max, mean, name
-    #  [10..15] numeric proximity in sorted key order:
-    #           building:levels, heritage, lanes, levels, maxheight, maxspeed
-    #  [16]    housenumber overlap
+    #  [3..5]  text sim: max, mean, name
+    #  [6..11] numeric proximity in sorted key order:
+    #          building:levels, heritage, lanes, levels, maxheight, maxspeed
+    #  [12]   housenumber overlap
 
     def test_feature_count(self):
         pano = {"building": "yes", "name": "Library"}
         osm = {"building": "yes", "name": "Library"}
         feats = compute_cross_features(pano, osm)
-        self.assertEqual(len(feats), 17)
+        self.assertEqual(len(feats), 13)
 
     def test_numeric_feature_order(self):
         """Numeric proximity features must follow sorted(NUMERIC_KEYS) order."""
-        # building:levels is at index 10, lanes at 12, maxspeed at 15
+        # building:levels is at index 6, lanes at 8, maxspeed at 11
         pano = {"building:levels": "3", "lanes": "2", "maxspeed": "30 mph"}
         osm = {"building:levels": "3", "lanes": "2", "maxspeed": "30 mph"}
         feats = compute_cross_features(pano, osm)
         # Exact matches → exp(0) = 1.0
-        self.assertEqual(feats[10], 1.0, "building:levels should be at index 10")
-        self.assertEqual(feats[12], 1.0, "lanes should be at index 12")
-        self.assertEqual(feats[15], 1.0, "maxspeed should be at index 15")
-        # heritage (11), levels (13), maxheight (14) are absent → 0.0
-        self.assertEqual(feats[11], 0.0, "heritage absent")
-        self.assertEqual(feats[13], 0.0, "levels absent")
-        self.assertEqual(feats[14], 0.0, "maxheight absent")
+        self.assertEqual(feats[6], 1.0, "building:levels should be at index 6")
+        self.assertEqual(feats[8], 1.0, "lanes should be at index 8")
+        self.assertEqual(feats[11], 1.0, "maxspeed should be at index 11")
+        # heritage (7), levels (9), maxheight (10) are absent → 0.0
+        self.assertEqual(feats[7], 0.0, "heritage absent")
+        self.assertEqual(feats[9], 0.0, "levels absent")
+        self.assertEqual(feats[10], 0.0, "maxheight absent")
 
     def test_identical_tags_high_similarity(self):
         tags = {"building": "yes", "name": "Library", "amenity": "library"}
@@ -281,7 +280,7 @@ class TestCollation(unittest.TestCase):
         self.assertEqual(batch.pano_key_indices.shape[0], 2)  # batch size
         self.assertEqual(batch.osm_key_indices.shape[0], 2)
         self.assertEqual(batch.labels.shape, (2,))
-        self.assertEqual(batch.cross_features.shape, (2, 17))
+        self.assertEqual(batch.cross_features.shape, (2, 13))
         self.assertEqual(batch.labels[0], 1.0)
         self.assertEqual(batch.labels[1], 0.0)
 

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
@@ -3,6 +3,7 @@
 import json
 import math
 import tempfile
+import unittest
 from pathlib import Path
 
 import common.torch.load_torch_deps  # noqa: F401
@@ -21,26 +22,31 @@ from experimental.overhead_matching.swag.data.landmark_correspondence_dataset im
 )
 
 
-class TestTagStringParsing:
+def _make_fake_text_embeddings(*values, dim=32):
+    """Create a fake text_embeddings dict mapping each value to a random tensor."""
+    return {v: torch.randn(dim) for v in values}
+
+
+class TestTagStringParsing(unittest.TestCase):
     def test_simple(self):
         tags = parse_tag_string("building=yes; name=Library")
-        assert tags == {"building": "yes", "name": "Library"}
+        self.assertEqual(tags, {"building": "yes", "name": "Library"})
 
     def test_single_tag(self):
         tags = parse_tag_string("highway=residential")
-        assert tags == {"highway": "residential"}
+        self.assertEqual(tags, {"highway": "residential"})
 
     def test_value_with_equals(self):
         # addr:housenumber=1252-1414 has no extra =, but test robustness
         tags = parse_tag_string("name=Route 66=Historic")
-        assert tags == {"name": "Route 66=Historic"}
+        self.assertEqual(tags, {"name": "Route 66=Historic"})
 
     def test_duplicate_keys_last_wins(self):
         tags = parse_tag_string("building=yes; building=commercial")
-        assert tags == {"building": "commercial"}
+        self.assertEqual(tags, {"building": "commercial"})
 
 
-class TestPromptParsing:
+class TestPromptParsing(unittest.TestCase):
     SAMPLE_PROMPT = """Set 1 (street-level observations):
  0. man_made=bridge; bridge=yes
  1. highway=sign; name=Exit 27C
@@ -51,18 +57,18 @@ Set 2 (map database):
 
     def test_parse_sets(self):
         set1, set2 = parse_prompt_landmarks(self.SAMPLE_PROMPT)
-        assert len(set1) == 2
-        assert len(set2) == 2
-        assert set1[0] == {"man_made": "bridge", "bridge": "yes"}
-        assert set2[1] == {"building": "yes", "building:levels": "3"}
+        self.assertEqual(len(set1), 2)
+        self.assertEqual(len(set2), 2)
+        self.assertEqual(set1[0], {"man_made": "bridge", "bridge": "yes"})
+        self.assertEqual(set2[1], {"building": "yes", "building:levels": "3"})
 
     def test_landmark_count(self):
         set1, set2 = parse_prompt_landmarks(self.SAMPLE_PROMPT)
-        assert len(set1) == 2
-        assert len(set2) == 2
+        self.assertEqual(len(set1), 2)
+        self.assertEqual(len(set2), 2)
 
 
-class TestJSONLParsing:
+class TestJSONLParsing(unittest.TestCase):
     def _make_jsonl_entry(self):
         return {
             "key": "test_pano_id",
@@ -101,22 +107,22 @@ Set 2 (map database):
     def test_parse_produces_pairs(self):
         entry = self._make_jsonl_entry()
         pairs = parse_jsonl_line(entry)
-        assert len(pairs) == 3  # 1 positive + 1 hard + 1 easy
+        self.assertEqual(len(pairs), 3)  # 1 positive + 1 hard + 1 easy
 
     def test_pair_labels(self):
         entry = self._make_jsonl_entry()
         pairs = parse_jsonl_line(entry)
         labels = {p.difficulty: p.label for p in pairs}
-        assert labels["positive"] == 1.0
-        assert labels["hard"] == 0.0
-        assert labels["easy"] == 0.0
+        self.assertEqual(labels["positive"], 1.0)
+        self.assertEqual(labels["hard"], 0.0)
+        self.assertEqual(labels["easy"], 0.0)
 
     def test_pair_tags(self):
         entry = self._make_jsonl_entry()
         pairs = parse_jsonl_line(entry)
         pos = [p for p in pairs if p.difficulty == "positive"][0]
-        assert pos.pano_tags["name"] == "Library"
-        assert pos.osm_tags["name"] == "Library"
+        self.assertEqual(pos.pano_tags["name"], "Library")
+        self.assertEqual(pos.osm_tags["name"], "Library")
 
     def test_out_of_bounds_ids_skipped(self):
         entry = self._make_jsonl_entry()
@@ -129,7 +135,7 @@ Set 2 (map database):
         pairs = parse_jsonl_line(entry)
         # Should skip the out-of-bounds positive, keep negatives
         pos_pairs = [p for p in pairs if p.difficulty == "positive"]
-        assert len(pos_pairs) == 0
+        self.assertEqual(len(pos_pairs), 0)
 
     def test_load_from_directory(self):
         entry = self._make_jsonl_entry()
@@ -141,10 +147,10 @@ Set 2 (map database):
             jsonl_path.write_text(json.dumps(entry) + "\n")
 
             pairs = load_pairs_from_directory(Path(tmpdir))
-            assert len(pairs) == 3
+            self.assertEqual(len(pairs), 3)
 
 
-class TestCrossFeatures:
+class TestCrossFeatures(unittest.TestCase):
     # Feature layout (17 total):
     #  [0]     Jaccard similarity
     #  [1]     shared keys / 10
@@ -159,7 +165,7 @@ class TestCrossFeatures:
         pano = {"building": "yes", "name": "Library"}
         osm = {"building": "yes", "name": "Library"}
         feats = compute_cross_features(pano, osm)
-        assert len(feats) == 17
+        self.assertEqual(len(feats), 17)
 
     def test_numeric_feature_order(self):
         """Numeric proximity features must follow sorted(NUMERIC_KEYS) order."""
@@ -168,76 +174,91 @@ class TestCrossFeatures:
         osm = {"building:levels": "3", "lanes": "2", "maxspeed": "30 mph"}
         feats = compute_cross_features(pano, osm)
         # Exact matches → exp(0) = 1.0
-        assert feats[10] == 1.0, "building:levels should be at index 10"
-        assert feats[12] == 1.0, "lanes should be at index 12"
-        assert feats[15] == 1.0, "maxspeed should be at index 15"
+        self.assertEqual(feats[10], 1.0, "building:levels should be at index 10")
+        self.assertEqual(feats[12], 1.0, "lanes should be at index 12")
+        self.assertEqual(feats[15], 1.0, "maxspeed should be at index 15")
         # heritage (11), levels (13), maxheight (14) are absent → 0.0
-        assert feats[11] == 0.0, "heritage absent"
-        assert feats[13] == 0.0, "levels absent"
-        assert feats[14] == 0.0, "maxheight absent"
+        self.assertEqual(feats[11], 0.0, "heritage absent")
+        self.assertEqual(feats[13], 0.0, "levels absent")
+        self.assertEqual(feats[14], 0.0, "maxheight absent")
 
     def test_identical_tags_high_similarity(self):
         tags = {"building": "yes", "name": "Library", "amenity": "library"}
         feats = compute_cross_features(tags, tags)
         # Jaccard should be 1.0
-        assert feats[0] == 1.0
+        self.assertEqual(feats[0], 1.0)
         # All exact matches
-        assert feats[2] > 0
+        self.assertGreater(feats[2], 0)
 
     def test_disjoint_tags_low_similarity(self):
         pano = {"building": "yes"}
         osm = {"highway": "residential"}
         feats = compute_cross_features(pano, osm)
         # Jaccard should be 0.0
-        assert feats[0] == 0.0
+        self.assertEqual(feats[0], 0.0)
 
     def test_housenumber_range_overlap(self):
         pano = {"addr:housenumber": "665"}
         osm = {"addr:housenumber": "660-670"}
         feats = compute_cross_features(pano, osm)
         # Last feature is housenumber overlap
-        assert feats[-1] == 1.0
+        self.assertEqual(feats[-1], 1.0)
 
     def test_housenumber_no_overlap(self):
         pano = {"addr:housenumber": "100"}
         osm = {"addr:housenumber": "660-670"}
         feats = compute_cross_features(pano, osm)
-        assert feats[-1] == 0.0
+        self.assertEqual(feats[-1], 0.0)
 
 
-class TestTagBundleEncoding:
+class TestTagBundleEncoding(unittest.TestCase):
     def test_text_tag_encoding(self):
         tags = {"name": "Library", "building": "yes"}
-        encoded = encode_tag_bundle(tags, None)
-        assert len(encoded["key_indices"]) == 2
-        assert all(vt == 3 for vt in encoded["value_types"])  # Both are text
+        text_embs = _make_fake_text_embeddings("Library", "yes")
+        encoded = encode_tag_bundle(tags, text_embs, text_input_dim=32)
+        self.assertEqual(len(encoded["key_indices"]), 2)
+        self.assertTrue(all(vt == 3 for vt in encoded["value_types"]))  # Both are text
+
+    def test_text_missing_embedding_raises(self):
+        tags = {"name": "Library"}
+        text_embs = _make_fake_text_embeddings()  # empty
+        with self.assertRaises(KeyError):
+            encode_tag_bundle(tags, text_embs)
+
+    def test_text_none_embeddings_raises(self):
+        tags = {"name": "Library"}
+        with self.assertRaises(ValueError):
+            encode_tag_bundle(tags, None)
 
     def test_boolean_tag_encoding(self):
         tags = {"covered": "yes"}
         encoded = encode_tag_bundle(tags, None)
-        assert encoded["value_types"][0] == 0  # boolean type
-        assert encoded["boolean_values"][0] == 0  # yes → 0 (true)
+        self.assertEqual(encoded["value_types"][0], 0)  # boolean type
+        self.assertEqual(encoded["boolean_values"][0], 0)  # yes → 0 (true)
 
     def test_numeric_tag_encoding(self):
         tags = {"building:levels": "5"}
         encoded = encode_tag_bundle(tags, None)
-        assert encoded["value_types"][0] == 1  # numeric type
-        assert not encoded["numeric_nan_mask"][0]
+        self.assertEqual(encoded["value_types"][0], 1)  # numeric type
+        self.assertFalse(encoded["numeric_nan_mask"][0])
 
     def test_housenumber_encoding(self):
         tags = {"addr:housenumber": "665-667"}
         encoded = encode_tag_bundle(tags, None)
-        assert encoded["value_types"][0] == 2  # housenumber type
-        assert not encoded["housenumber_nan_mask"][0]
+        self.assertEqual(encoded["value_types"][0], 2)  # housenumber type
+        self.assertFalse(encoded["housenumber_nan_mask"][0])
 
     def test_unknown_key_skipped(self):
         tags = {"unknown_key_xyz": "value"}
         encoded = encode_tag_bundle(tags, None)
-        assert len(encoded["key_indices"]) == 0
+        self.assertEqual(len(encoded["key_indices"]), 0)
 
 
-class TestCollation:
+class TestCollation(unittest.TestCase):
     def test_collate_batch(self):
+        text_embs = _make_fake_text_embeddings(
+            "yes", "Lib", "Library", "residential", "restaurant", "Portillos",
+        )
         pairs = [
             CorrespondencePair(
                 pano_tags={"building": "yes", "name": "Lib"},
@@ -251,19 +272,21 @@ class TestCollation:
             ),
         ]
         dataset = LandmarkCorrespondenceDataset(
-            pairs, text_embeddings=None, include_difficulties=("positive", "easy"),
+            pairs, text_embeddings=text_embs, text_input_dim=32,
+            include_difficulties=("positive", "easy"),
         )
         samples = [dataset[0], dataset[1]]
         batch = collate_correspondence(samples)
 
-        assert batch.pano_key_indices.shape[0] == 2  # batch size
-        assert batch.osm_key_indices.shape[0] == 2
-        assert batch.labels.shape == (2,)
-        assert batch.cross_features.shape == (2, 17)
-        assert batch.labels[0] == 1.0
-        assert batch.labels[1] == 0.0
+        self.assertEqual(batch.pano_key_indices.shape[0], 2)  # batch size
+        self.assertEqual(batch.osm_key_indices.shape[0], 2)
+        self.assertEqual(batch.labels.shape, (2,))
+        self.assertEqual(batch.cross_features.shape, (2, 17))
+        self.assertEqual(batch.labels[0], 1.0)
+        self.assertEqual(batch.labels[1], 0.0)
 
     def test_collate_to_device(self):
+        text_embs = _make_fake_text_embeddings("yes")
         pairs = [
             CorrespondencePair(
                 pano_tags={"building": "yes"},
@@ -272,8 +295,13 @@ class TestCollation:
             ),
         ]
         dataset = LandmarkCorrespondenceDataset(
-            pairs, include_difficulties=("positive",),
+            pairs, text_embeddings=text_embs, text_input_dim=32,
+            include_difficulties=("positive",),
         )
         batch = collate_correspondence([dataset[0]])
         batch_cpu = batch.to(torch.device("cpu"))
-        assert batch_cpu.labels.device.type == "cpu"
+        self.assertEqual(batch_cpu.labels.device.type, "cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
@@ -1,0 +1,250 @@
+"""Tests for landmark correspondence dataset parsing and collation."""
+
+import json
+import math
+import tempfile
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+
+from experimental.overhead_matching.swag.data.landmark_correspondence_dataset import (
+    CorrespondencePair,
+    LandmarkCorrespondenceDataset,
+    collate_correspondence,
+    compute_cross_features,
+    encode_tag_bundle,
+    load_pairs_from_directory,
+    parse_jsonl_line,
+    parse_prompt_landmarks,
+    parse_tag_string,
+)
+
+
+class TestTagStringParsing:
+    def test_simple(self):
+        tags = parse_tag_string("building=yes; name=Library")
+        assert tags == {"building": "yes", "name": "Library"}
+
+    def test_single_tag(self):
+        tags = parse_tag_string("highway=residential")
+        assert tags == {"highway": "residential"}
+
+    def test_value_with_equals(self):
+        # addr:housenumber=1252-1414 has no extra =, but test robustness
+        tags = parse_tag_string("name=Route 66=Historic")
+        assert tags == {"name": "Route 66=Historic"}
+
+
+class TestPromptParsing:
+    SAMPLE_PROMPT = """Set 1 (street-level observations):
+ 0. man_made=bridge; bridge=yes
+ 1. highway=sign; name=Exit 27C
+
+Set 2 (map database):
+ 0. amenity=parking; access=destination
+ 1. building=yes; building:levels=3"""
+
+    def test_parse_sets(self):
+        set1, set2 = parse_prompt_landmarks(self.SAMPLE_PROMPT)
+        assert len(set1) == 2
+        assert len(set2) == 2
+        assert set1[0] == {"man_made": "bridge", "bridge": "yes"}
+        assert set2[1] == {"building": "yes", "building:levels": "3"}
+
+    def test_landmark_count(self):
+        set1, set2 = parse_prompt_landmarks(self.SAMPLE_PROMPT)
+        assert len(set1) == 2
+        assert len(set2) == 2
+
+
+class TestJSONLParsing:
+    def _make_jsonl_entry(self):
+        return {
+            "key": "test_pano_id",
+            "request": {
+                "contents": [{
+                    "parts": [{"text": """Set 1 (street-level observations):
+ 0. building=yes; name=Library
+ 1. highway=residential
+
+Set 2 (map database):
+ 0. building=commercial; name=Library
+ 1. amenity=restaurant; name=Portillos
+ 2. highway=residential; name=Main St"""}],
+                    "role": "user",
+                }]
+            },
+            "response": {
+                "candidates": [{
+                    "content": {
+                        "parts": [{"text": json.dumps({
+                            "matches": [{
+                                "set_1_id": 0,
+                                "set_2_matches": [0],
+                                "uniqueness_score": 4,
+                                "negatives": [
+                                    {"set_2_id": 1, "difficulty": "hard"},
+                                    {"set_2_id": 2, "difficulty": "easy"},
+                                ]
+                            }]
+                        })}]
+                    }
+                }]
+            }
+        }
+
+    def test_parse_produces_pairs(self):
+        entry = self._make_jsonl_entry()
+        pairs = parse_jsonl_line(entry)
+        assert len(pairs) == 3  # 1 positive + 1 hard + 1 easy
+
+    def test_pair_labels(self):
+        entry = self._make_jsonl_entry()
+        pairs = parse_jsonl_line(entry)
+        labels = {p.difficulty: p.label for p in pairs}
+        assert labels["positive"] == 1.0
+        assert labels["hard"] == 0.0
+        assert labels["easy"] == 0.0
+
+    def test_pair_tags(self):
+        entry = self._make_jsonl_entry()
+        pairs = parse_jsonl_line(entry)
+        pos = [p for p in pairs if p.difficulty == "positive"][0]
+        assert pos.pano_tags["name"] == "Library"
+        assert pos.osm_tags["name"] == "Library"
+
+    def test_out_of_bounds_ids_skipped(self):
+        entry = self._make_jsonl_entry()
+        # Set an out-of-bounds match
+        resp = json.loads(
+            entry["response"]["candidates"][0]["content"]["parts"][0]["text"]
+        )
+        resp["matches"][0]["set_2_matches"] = [99]
+        entry["response"]["candidates"][0]["content"]["parts"][0]["text"] = json.dumps(resp)
+        pairs = parse_jsonl_line(entry)
+        # Should skip the out-of-bounds positive, keep negatives
+        pos_pairs = [p for p in pairs if p.difficulty == "positive"]
+        assert len(pos_pairs) == 0
+
+    def test_load_from_directory(self):
+        entry = self._make_jsonl_entry()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create nested structure matching real data
+            resp_dir = Path(tmpdir) / "responses" / "prediction-model-test"
+            resp_dir.mkdir(parents=True)
+            jsonl_path = resp_dir / "predictions.jsonl"
+            jsonl_path.write_text(json.dumps(entry) + "\n")
+
+            pairs = load_pairs_from_directory(Path(tmpdir))
+            assert len(pairs) == 3
+
+
+class TestCrossFeatures:
+    def test_feature_count(self):
+        pano = {"building": "yes", "name": "Library"}
+        osm = {"building": "yes", "name": "Library"}
+        feats = compute_cross_features(pano, osm)
+        assert len(feats) == 17
+
+    def test_identical_tags_high_similarity(self):
+        tags = {"building": "yes", "name": "Library", "amenity": "library"}
+        feats = compute_cross_features(tags, tags)
+        # Jaccard should be 1.0
+        assert feats[0] == 1.0
+        # All exact matches
+        assert feats[2] > 0
+
+    def test_disjoint_tags_low_similarity(self):
+        pano = {"building": "yes"}
+        osm = {"highway": "residential"}
+        feats = compute_cross_features(pano, osm)
+        # Jaccard should be 0.0
+        assert feats[0] == 0.0
+
+    def test_housenumber_range_overlap(self):
+        pano = {"addr:housenumber": "665"}
+        osm = {"addr:housenumber": "660-670"}
+        feats = compute_cross_features(pano, osm)
+        # Last feature is housenumber overlap
+        assert feats[-1] == 1.0
+
+    def test_housenumber_no_overlap(self):
+        pano = {"addr:housenumber": "100"}
+        osm = {"addr:housenumber": "660-670"}
+        feats = compute_cross_features(pano, osm)
+        assert feats[-1] == 0.0
+
+
+class TestTagBundleEncoding:
+    def test_text_tag_encoding(self):
+        tags = {"name": "Library", "building": "yes"}
+        encoded = encode_tag_bundle(tags, None)
+        assert len(encoded["key_indices"]) == 2
+        assert all(vt == 3 for vt in encoded["value_types"])  # Both are text
+
+    def test_boolean_tag_encoding(self):
+        tags = {"covered": "yes"}
+        encoded = encode_tag_bundle(tags, None)
+        assert encoded["value_types"][0] == 0  # boolean type
+        assert encoded["boolean_values"][0] == 0  # yes → 0 (true)
+
+    def test_numeric_tag_encoding(self):
+        tags = {"building:levels": "5"}
+        encoded = encode_tag_bundle(tags, None)
+        assert encoded["value_types"][0] == 1  # numeric type
+        assert not encoded["numeric_nan_mask"][0]
+
+    def test_housenumber_encoding(self):
+        tags = {"addr:housenumber": "665-667"}
+        encoded = encode_tag_bundle(tags, None)
+        assert encoded["value_types"][0] == 2  # housenumber type
+        assert not encoded["housenumber_nan_mask"][0]
+
+    def test_unknown_key_skipped(self):
+        tags = {"unknown_key_xyz": "value"}
+        encoded = encode_tag_bundle(tags, None)
+        assert len(encoded["key_indices"]) == 0
+
+
+class TestCollation:
+    def test_collate_batch(self):
+        pairs = [
+            CorrespondencePair(
+                pano_tags={"building": "yes", "name": "Lib"},
+                osm_tags={"building": "yes", "name": "Library"},
+                label=1.0, difficulty="positive", uniqueness_score=4, pano_id="p1",
+            ),
+            CorrespondencePair(
+                pano_tags={"highway": "residential"},
+                osm_tags={"amenity": "restaurant", "name": "Portillos"},
+                label=0.0, difficulty="easy", uniqueness_score=2, pano_id="p1",
+            ),
+        ]
+        dataset = LandmarkCorrespondenceDataset(
+            pairs, text_embeddings=None, include_difficulties=("positive", "easy"),
+        )
+        samples = [dataset[0], dataset[1]]
+        batch = collate_correspondence(samples)
+
+        assert batch.pano_key_indices.shape[0] == 2  # batch size
+        assert batch.osm_key_indices.shape[0] == 2
+        assert batch.labels.shape == (2,)
+        assert batch.cross_features.shape == (2, 17)
+        assert batch.labels[0] == 1.0
+        assert batch.labels[1] == 0.0
+
+    def test_collate_to_device(self):
+        pairs = [
+            CorrespondencePair(
+                pano_tags={"building": "yes"},
+                osm_tags={"building": "yes"},
+                label=1.0, difficulty="positive", uniqueness_score=3, pano_id="p1",
+            ),
+        ]
+        dataset = LandmarkCorrespondenceDataset(
+            pairs, include_difficulties=("positive",),
+        )
+        batch = collate_correspondence([dataset[0]])
+        batch_cpu = batch.to(torch.device("cpu"))
+        assert batch_cpu.labels.device.type == "cpu"

--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset_test.py
@@ -209,6 +209,33 @@ class TestCrossFeatures(unittest.TestCase):
         feats = compute_cross_features(pano, osm)
         self.assertEqual(feats[-1], 0.0)
 
+    def test_text_cosine_similarity_features(self):
+        """Text sim features (indices 3-5) should be non-zero when embeddings provided."""
+        lib_emb = torch.tensor([1.0, 0.0, 0.0])
+        library_emb = torch.tensor([0.9, 0.1, 0.0])
+        text_embs = {"Library": library_emb, "Lib": lib_emb, "yes": torch.randn(3)}
+        pano = {"name": "Lib", "building": "yes"}
+        osm = {"name": "Library", "building": "yes"}
+        feats = compute_cross_features(pano, osm, text_embeddings=text_embs)
+        expected_name_sim = torch.nn.functional.cosine_similarity(
+            lib_emb.unsqueeze(0), library_emb.unsqueeze(0)
+        ).item()
+        expected_building_sim = 1.0  # same value "yes"
+        # max text sim
+        self.assertAlmostEqual(feats[3], max(expected_name_sim, expected_building_sim), places=4)
+        # mean text sim
+        self.assertAlmostEqual(feats[4], (expected_name_sim + expected_building_sim) / 2, places=4)
+        # name-specific sim
+        self.assertAlmostEqual(feats[5], expected_name_sim, places=4)
+
+    def test_text_sim_zero_without_name_key(self):
+        """Name-specific sim (index 5) should be 0 when 'name' key not shared."""
+        text_embs = {"yes": torch.randn(3), "commercial": torch.randn(3)}
+        pano = {"building": "yes"}
+        osm = {"building": "commercial"}
+        feats = compute_cross_features(pano, osm, text_embeddings=text_embs)
+        self.assertEqual(feats[5], 0.0)
+
 
 class TestTagBundleEncoding(unittest.TestCase):
     def test_text_tag_encoding(self):
@@ -283,6 +310,30 @@ class TestCollation(unittest.TestCase):
         self.assertEqual(batch.cross_features.shape, (2, 13))
         self.assertEqual(batch.labels[0], 1.0)
         self.assertEqual(batch.labels[1], 0.0)
+
+    def test_collate_with_unknown_keys(self):
+        """Samples where all tag keys are unrecognized should not crash collation."""
+        text_embs = _make_fake_text_embeddings("yes")
+        pairs = [
+            CorrespondencePair(
+                pano_tags={"unknown_xyz": "val"},
+                osm_tags={"building": "yes"},
+                label=0.0, difficulty="easy", uniqueness_score=1, pano_id="p1",
+            ),
+            CorrespondencePair(
+                pano_tags={"building": "yes"},
+                osm_tags={"building": "yes"},
+                label=1.0, difficulty="positive", uniqueness_score=3, pano_id="p2",
+            ),
+        ]
+        dataset = LandmarkCorrespondenceDataset(
+            pairs, text_embeddings=text_embs, text_input_dim=32,
+            include_difficulties=("positive", "easy"),
+        )
+        batch = collate_correspondence([dataset[0], dataset[1]])
+        self.assertEqual(batch.pano_key_indices.shape[0], 2)
+        # First sample's pano side has no recognized keys → mask should be all False
+        self.assertFalse(batch.pano_tag_mask[0].any())
 
     def test_collate_to_device(self):
         text_embs = _make_fake_text_embeddings("yes")

--- a/experimental/overhead_matching/swag/evaluation/proper_noun_matcher_test.py
+++ b/experimental/overhead_matching/swag/evaluation/proper_noun_matcher_test.py
@@ -1,19 +1,21 @@
+import unittest
+
 import numpy as np
 
 from experimental.overhead_matching.swag.evaluation import proper_noun_matcher_python as pnm
 
 
-class TestComputeKeyedSubstringMatchesDetailed:
+class TestComputeKeyedSubstringMatchesDetailed(unittest.TestCase):
     def test_single_match(self):
         query_tags = [[("name", "starbucks")]]
         target_tags = [[("name", "Starbucks Coffee")]]
 
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
-        assert len(q) == 1
-        assert q[0] == 0
-        assert t[0] == 0
-        assert k[0] == 0
+        self.assertEqual(len(q), 1)
+        self.assertEqual(q[0], 0)
+        self.assertEqual(t[0], 0)
+        self.assertEqual(k[0], 0)
 
     def test_no_match_different_keys(self):
         query_tags = [[("name", "starbucks")]]
@@ -21,7 +23,7 @@ class TestComputeKeyedSubstringMatchesDetailed:
 
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
-        assert len(q) == 0
+        self.assertEqual(len(q), 0)
 
     def test_no_match_substring_not_found(self):
         query_tags = [[("name", "starbucks")]]
@@ -29,7 +31,7 @@ class TestComputeKeyedSubstringMatchesDetailed:
 
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
-        assert len(q) == 0
+        self.assertEqual(len(q), 0)
 
     def test_multiple_keys_match_independently(self):
         query_tags = [[("name", "central"), ("amenity", "cafe")]]
@@ -37,7 +39,7 @@ class TestComputeKeyedSubstringMatchesDetailed:
 
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
-        assert len(q) == 2
+        self.assertEqual(len(q), 2)
         np.testing.assert_array_equal(q, [0, 0])
         np.testing.assert_array_equal(t, [0, 0])
         np.testing.assert_array_equal(k, [0, 1])
@@ -56,7 +58,7 @@ class TestComputeKeyedSubstringMatchesDetailed:
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
         matches = set(zip(q.tolist(), t.tolist(), k.tolist()))
-        assert matches == {(0, 0, 0), (0, 2, 0), (1, 1, 0), (1, 2, 0)}
+        self.assertEqual(matches, {(0, 0, 0), (0, 2, 0), (1, 1, 0), (1, 2, 0)})
 
     def test_case_insensitive(self):
         query_tags = [[("name", "HELLO")]]
@@ -64,25 +66,25 @@ class TestComputeKeyedSubstringMatchesDetailed:
 
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
-        assert len(q) == 1
+        self.assertEqual(len(q), 1)
 
     def test_empty_inputs(self):
         q, t, k = pnm.compute_keyed_substring_matches_detailed([], [])
-        assert len(q) == 0
-        assert len(t) == 0
-        assert len(k) == 0
+        self.assertEqual(len(q), 0)
+        self.assertEqual(len(t), 0)
+        self.assertEqual(len(k), 0)
 
     def test_empty_query_tags(self):
         q, t, k = pnm.compute_keyed_substring_matches_detailed(
             [[]], [[("name", "foo")]]
         )
-        assert len(q) == 0
+        self.assertEqual(len(q), 0)
 
     def test_empty_target_tags(self):
         q, t, k = pnm.compute_keyed_substring_matches_detailed(
             [[("name", "foo")]], [[]]
         )
-        assert len(q) == 0
+        self.assertEqual(len(q), 0)
 
     def test_key_idx_reflects_query_position(self):
         query_tags = [[("addr", "main"), ("cuisine", "pizza"), ("name", "joe")]]
@@ -90,8 +92,8 @@ class TestComputeKeyedSubstringMatchesDetailed:
 
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
-        assert len(q) == 1
-        assert k[0] == 2  # "name" is at index 2 in the query
+        self.assertEqual(len(q), 1)
+        self.assertEqual(k[0], 2)  # "name" is at index 2 in the query
 
     def test_returns_int64_arrays(self):
         query_tags = [[("name", "test")]]
@@ -99,9 +101,9 @@ class TestComputeKeyedSubstringMatchesDetailed:
 
         q, t, k = pnm.compute_keyed_substring_matches_detailed(query_tags, target_tags)
 
-        assert q.dtype == np.int64
-        assert t.dtype == np.int64
-        assert k.dtype == np.int64
+        self.assertEqual(q.dtype, np.int64)
+        self.assertEqual(t.dtype, np.int64)
+        self.assertEqual(k.dtype, np.int64)
 
     def test_agrees_with_binary_version(self):
         """The set of (query, target) pairs with any match should equal the
@@ -126,3 +128,7 @@ class TestComputeKeyedSubstringMatchesDetailed:
             reconstructed[qi, ti] = 1.0
 
         np.testing.assert_array_equal(binary, reconstructed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/overhead_matching/swag/model/BUILD
+++ b/experimental/overhead_matching/swag/model/BUILD
@@ -339,6 +339,7 @@ py_library(
   ],
   deps = [
     requirement("torch"),
+    "//common/torch:load_torch_deps",
     ":semantic_landmark_utils",
   ]
 )

--- a/experimental/overhead_matching/swag/model/BUILD
+++ b/experimental/overhead_matching/swag/model/BUILD
@@ -351,5 +351,6 @@ py_test(
     requirement("torch"),
     "//common/torch:load_torch_deps",
     ":landmark_correspondence_model",
+    ":semantic_landmark_utils",
   ]
 )

--- a/experimental/overhead_matching/swag/model/BUILD
+++ b/experimental/overhead_matching/swag/model/BUILD
@@ -329,3 +329,26 @@ py_library(
     "//experimental/overhead_matching/swag/scripts:sentence_configs",
   ]
 )
+
+py_library(
+  name = "landmark_correspondence_model",
+  srcs = ["landmark_correspondence_model.py"],
+  visibility = [
+    "//experimental/overhead_matching/swag:__subpackages__",
+    "//common/python:__subpackages__",
+  ],
+  deps = [
+    requirement("torch"),
+    ":semantic_landmark_utils",
+  ]
+)
+
+py_test(
+  name = "landmark_correspondence_model_test",
+  srcs = ["landmark_correspondence_model_test.py"],
+  deps = [
+    requirement("torch"),
+    "//common/torch:load_torch_deps",
+    ":landmark_correspondence_model",
+  ]
+)

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
@@ -11,13 +11,14 @@ TagBundleEncoder processes each key=value tag in a bundle:
   1. Key embedding (learned, 112 keys × key_dim)
   2. Value encoding by type:
      - Boolean: single learned embedding (true/false/unknown → 8-dim)
-     - Numeric: [log(1+|x|), x/1000, 1.0] → linear → 16-dim
+     - Numeric: [log(1+|x|), x/1000, 1.0, is_lower_bound] → linear → 16-dim
      - Housenumber: [log(1+lo), log(1+hi), log(1+hi-lo), mean/2000] → linear → 16-dim
      - Text: pre-computed embedding → linear projection → text_proj_dim
   3. Per-tag MLP: concat(key_emb, value_emb) → 64-dim
   4. Pooling: mean + max → 128-dim representation
 """
 
+import enum
 import math
 from dataclasses import dataclass, field
 
@@ -30,6 +31,23 @@ import torch.nn.functional as F
 from experimental.overhead_matching.swag.model.semantic_landmark_utils import (
     _TAGS_TO_KEEP,
 )
+
+
+# ---------------------------------------------------------------------------
+# Enums for value types
+# ---------------------------------------------------------------------------
+
+class ValueType(enum.IntEnum):
+    BOOLEAN = 0
+    NUMERIC = 1
+    HOUSENUMBER = 2
+    TEXT = 3
+
+
+class BooleanValue(enum.IntEnum):
+    TRUE = 0
+    FALSE = 1
+    UNKNOWN = 2
 
 # ---------------------------------------------------------------------------
 # Tag key classification
@@ -56,15 +74,15 @@ NUM_TAG_KEYS = len(_TAGS_TO_KEEP)
 PRIMARY_CATEGORY_KEYS = ["building", "amenity", "highway", "shop"]
 
 
-def key_type(key: str) -> str:
+def key_type(key: str) -> ValueType:
     """Return the encoding type for a tag key."""
     if key == HOUSENUMBER_KEY:
-        return "housenumber"
+        return ValueType.HOUSENUMBER
     if key in BOOLEAN_KEYS:
-        return "boolean"
+        return ValueType.BOOLEAN
     if key in NUMERIC_KEYS:
-        return "numeric"
-    return "text"
+        return ValueType.NUMERIC
+    return ValueType.TEXT
 
 
 # ---------------------------------------------------------------------------
@@ -81,22 +99,35 @@ def parse_boolean(value: str) -> float:
     return 0.5
 
 
-def parse_numeric(value: str) -> float:
-    """Parse numeric tag value to float, handling units and text."""
+_LEVEL_KEYS = frozenset(["building:levels", "levels"])
+
+
+def parse_numeric(value: str, key: str | None = None) -> tuple[float, bool]:
+    """Parse numeric tag value to (float, is_lower_bound).
+
+    The is_lower_bound flag is True when the raw value had a '+' suffix
+    (e.g. "20+" means "20 or more").
+    """
     v = value.strip().lower()
     # Strip common suffixes
     for suffix in (" mph", " km/h", " m", " ft"):
         if v.endswith(suffix):
             v = v[:-len(suffix)]
-    # Handle special text values
-    v = v.strip("+")
-    special = {"high": 20.0, "multi": 5.0, "yes": 1.0, "no": 0.0}
+    # Detect and strip "+" (lower-bound indicator, e.g. "20+")
+    is_lower_bound = v.endswith("+")
+    if is_lower_bound:
+        v = v[:-1].strip()
+    # Key-aware special text values: "high"→20, "multi"→5 only for level keys
+    special: dict[str, float] = {"yes": 1.0, "no": 0.0}
+    if key is not None and key in _LEVEL_KEYS:
+        special["high"] = 20.0
+        special["multi"] = 5.0
     if v in special:
-        return special[v]
+        return (special[v], is_lower_bound)
     try:
-        return float(v)
+        return (float(v), is_lower_bound)
     except ValueError:
-        return float("nan")
+        return (float("nan"), False)
 
 
 def parse_maxheight(value: str) -> float:
@@ -142,11 +173,15 @@ def parse_housenumber(value: str) -> tuple[float, float]:
         return (float("nan"), float("nan"))
 
 
-def encode_numeric_value(x: float) -> list[float]:
-    """Encode numeric value as [log(1+|x|), x/1000, 1.0]."""
+def encode_numeric_value(x: float, is_lower_bound: bool = False) -> list[float]:
+    """Encode numeric value as [log(1+|x|), x/1000, 1.0, is_lower_bound].
+
+    The third element (1.0) is a presence flag: it distinguishes a valid zero
+    encoding [0, 0, 1.0, ...] from the NaN encoding [0, 0, 0, 0].
+    """
     if math.isnan(x):
-        return [0.0, 0.0, 0.0]  # Will use NaN embedding instead
-    return [math.log1p(abs(x)), x / 1000.0, 1.0]
+        return [0.0, 0.0, 0.0, 0.0]  # Will use NaN embedding instead
+    return [math.log1p(abs(x)), x / 1000.0, 1.0, 1.0 if is_lower_bound else 0.0]
 
 
 def encode_housenumber_value(lo: float, hi: float) -> list[float]:
@@ -208,8 +243,8 @@ class TagBundleEncoder(nn.Module):
         # Boolean encoder: 3 embeddings (true, false, unknown)
         self.boolean_embedding = nn.Embedding(3, config.boolean_dim)
 
-        # Numeric encoder: linear 3 → numeric_dim
-        self.numeric_linear = nn.Linear(3, config.numeric_dim)
+        # Numeric encoder: linear 4 → numeric_dim
+        self.numeric_linear = nn.Linear(4, config.numeric_dim)
         self.numeric_nan_embedding = nn.Parameter(torch.randn(config.numeric_dim) * 0.01)
 
         # Housenumber encoder: linear 4 → housenumber_dim
@@ -244,7 +279,7 @@ class TagBundleEncoder(nn.Module):
         key_indices: torch.Tensor,      # (B, max_tags) int
         value_type: torch.Tensor,        # (B, max_tags) int: 0=bool, 1=numeric, 2=housenum, 3=text
         boolean_values: torch.Tensor,    # (B, max_tags) int: 0=true, 1=false, 2=unknown
-        numeric_values: torch.Tensor,    # (B, max_tags, 3) float
+        numeric_values: torch.Tensor,    # (B, max_tags, 4) float
         numeric_nan_mask: torch.Tensor,  # (B, max_tags) bool: True if NaN
         housenumber_values: torch.Tensor,  # (B, max_tags, 4) float
         housenumber_nan_mask: torch.Tensor,  # (B, max_tags) bool: True if NaN
@@ -264,7 +299,7 @@ class TagBundleEncoder(nn.Module):
         # Boolean: (B, T, boolean_dim) → (B, T, max_value_dim)
         bool_emb = self.boolean_proj(self.boolean_embedding(boolean_values))
 
-        # Numeric: (B, T, 3) → (B, T, numeric_dim)
+        # Numeric: (B, T, 4) → (B, T, numeric_dim)
         num_emb = self.numeric_linear(numeric_values)
         # Replace NaN entries with learned NaN embedding
         nan_expand = self.numeric_nan_embedding.unsqueeze(0).unsqueeze(0).expand(B, T, -1)
@@ -374,6 +409,9 @@ class CorrespondenceClassifier(nn.Module):
             osm_text_embeddings, osm_tag_mask,
         )
 
+        # Elementwise product captures multiplicative interaction between pano
+        # and osm representations. Motivated by ESIM (Chen et al. 2016,
+        # arXiv:1609.06038) and InferSent (Conneau et al. 2017, arXiv:1705.02364).
         combined = torch.cat([
             pano_repr,
             osm_repr,

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
@@ -70,9 +70,6 @@ HOUSENUMBER_KEY = "addr:housenumber"
 TAG_KEY_TO_IDX: dict[str, int] = {k: i for i, k in enumerate(_TAGS_TO_KEEP)}
 NUM_TAG_KEYS = len(_TAGS_TO_KEEP)
 
-# Primary category keys used for cross-pair features
-PRIMARY_CATEGORY_KEYS = ["building", "amenity", "highway", "shop"]
-
 
 def key_type(key: str) -> ValueType:
     """Return the encoding type for a tag key."""
@@ -220,7 +217,7 @@ class CorrespondenceClassifierConfig:
     encoder: TagBundleEncoderConfig = field(default_factory=TagBundleEncoderConfig)
     mlp_hidden_dim: int = 128
     dropout: float = 0.1
-    num_cross_features: int = 17  # Jaccard(1) + shared_keys(1) + exact_matches(1) + category(4) + text_sim(3) + numeric(6) + housenumber(1)
+    num_cross_features: int = 13  # Jaccard(1) + shared_keys(1) + exact_matches(1) + text_sim(3) + numeric(6) + housenumber(1)
 
 
 # ---------------------------------------------------------------------------

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
@@ -21,6 +21,8 @@ TagBundleEncoder processes each key=value tag in a bundle:
 import math
 from dataclasses import dataclass, field
 
+import common.torch.load_torch_deps  # noqa: F401 - Must import before torch
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -171,7 +173,11 @@ class TagBundleEncoderConfig:
     text_input_dim: int = 768
     text_proj_dim: int = 128
     per_tag_dim: int = 64
-    repr_dim: int = 128  # Output: mean + max pool of per_tag_dim
+
+    @property
+    def repr_dim(self) -> int:
+        """Output dimension: mean + max pool of per_tag_dim."""
+        return 2 * self.per_tag_dim
 
 
 @dataclass

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
@@ -8,7 +8,7 @@ Architecture:
     OSM tags  → TagBundleEncoder → osm_repr  (D)
 
 TagBundleEncoder processes each key=value tag in a bundle:
-  1. Key embedding (learned, 112 keys × key_dim)
+  1. Key embedding (learned, NUM_TAG_KEYS × key_dim)
   2. Value encoding by type:
      - Boolean: single learned embedding (true/false/unknown → 8-dim)
      - Numeric: [log(1+|x|), x/1000, 1.0, is_lower_bound] → linear → 16-dim
@@ -252,9 +252,6 @@ class TagBundleEncoder(nn.Module):
 
         # Text encoder: linear projection from pre-computed embeddings
         self.text_projection = nn.Linear(config.text_input_dim, config.text_proj_dim)
-
-        # Absent value embeddings (one per type)
-        self.absent_embedding = nn.Parameter(torch.randn(config.text_proj_dim) * 0.01)
 
         # Per-tag MLP: concat(key_emb, value_emb) → per_tag_dim
         # Value dim varies by type; use the max (text_proj_dim) and pad smaller ones

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
@@ -1,0 +1,378 @@
+"""Landmark correspondence classifier: twin encoder + interaction classifier.
+
+Architecture:
+    Pano tags → TagBundleEncoder → pano_repr (D)
+                                                \
+                                  [pano; osm; pano*osm; cross_feats] → MLP → P(match)
+                                                /
+    OSM tags  → TagBundleEncoder → osm_repr  (D)
+
+TagBundleEncoder processes each key=value tag in a bundle:
+  1. Key embedding (learned, 112 keys × key_dim)
+  2. Value encoding by type:
+     - Boolean: single learned embedding (true/false/unknown → 8-dim)
+     - Numeric: [log(1+|x|), x/1000, 1.0] → linear → 16-dim
+     - Housenumber: [log(1+lo), log(1+hi), log(1+hi-lo), mean/2000] → linear → 16-dim
+     - Text: pre-computed embedding → linear projection → text_proj_dim
+  3. Per-tag MLP: concat(key_emb, value_emb) → 64-dim
+  4. Pooling: mean + max → 128-dim representation
+"""
+
+import math
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from experimental.overhead_matching.swag.model.semantic_landmark_utils import (
+    _TAGS_TO_KEEP,
+)
+
+# ---------------------------------------------------------------------------
+# Tag key classification
+# ---------------------------------------------------------------------------
+
+BOOLEAN_KEYS = frozenset([
+    "outdoor_seating", "drive_through", "embankment", "handrail",
+    "fire_escape", "fenced", "oneway", "covered",
+])
+
+NUMERIC_KEYS = frozenset([
+    "building:levels", "levels", "lanes", "maxspeed",
+    "maxheight", "heritage",
+])
+
+HOUSENUMBER_KEY = "addr:housenumber"
+
+# Everything else is TEXT
+# Build key → index mapping from _TAGS_TO_KEEP
+TAG_KEY_TO_IDX: dict[str, int] = {k: i for i, k in enumerate(_TAGS_TO_KEEP)}
+NUM_TAG_KEYS = len(_TAGS_TO_KEEP)
+
+# Primary category keys used for cross-pair features
+PRIMARY_CATEGORY_KEYS = ["building", "amenity", "highway", "shop"]
+
+
+def key_type(key: str) -> str:
+    """Return the encoding type for a tag key."""
+    if key == HOUSENUMBER_KEY:
+        return "housenumber"
+    if key in BOOLEAN_KEYS:
+        return "boolean"
+    if key in NUMERIC_KEYS:
+        return "numeric"
+    return "text"
+
+
+# ---------------------------------------------------------------------------
+# Value parsing utilities
+# ---------------------------------------------------------------------------
+
+def parse_boolean(value: str) -> float:
+    """Parse boolean tag value to float. yes→1.0, no→0.0, unknown→0.5."""
+    v = value.strip().lower()
+    if v in ("yes", "true", "1"):
+        return 1.0
+    if v in ("no", "false", "0", "-1"):
+        return 0.0
+    return 0.5
+
+
+def parse_numeric(value: str) -> float:
+    """Parse numeric tag value to float, handling units and text."""
+    v = value.strip().lower()
+    # Strip common suffixes
+    for suffix in (" mph", " km/h", " m", " ft"):
+        if v.endswith(suffix):
+            v = v[:-len(suffix)]
+    # Handle special text values
+    v = v.strip("+")
+    special = {"high": 20.0, "multi": 5.0, "yes": 1.0, "no": 0.0}
+    if v in special:
+        return special[v]
+    try:
+        return float(v)
+    except ValueError:
+        return float("nan")
+
+
+def parse_maxheight(value: str) -> float:
+    """Parse maxheight, handling feet'inches\" format."""
+    v = value.strip().lower()
+    if v in ("default", "none", "no_sign", "below_default", "no"):
+        return float("nan")
+    # Try feet'inches" format
+    if "'" in v:
+        parts = v.replace('"', '').split("'")
+        try:
+            feet = float(parts[0])
+            inches = float(parts[1]) if len(parts) > 1 and parts[1] else 0.0
+            return feet + inches / 12.0
+        except ValueError:
+            return float("nan")
+    try:
+        return float(v)
+    except ValueError:
+        return float("nan")
+
+
+def parse_housenumber(value: str) -> tuple[float, float]:
+    """Parse addr:housenumber to (low, high) range.
+
+    "665-667" → (665, 667)
+    "1858" → (1858, 1858)
+    Returns (nan, nan) on failure.
+    """
+    v = value.strip()
+    if "-" in v:
+        parts = v.split("-", 1)
+        try:
+            lo = float(parts[0].strip())
+            hi = float(parts[1].strip())
+            return (lo, hi)
+        except ValueError:
+            pass
+    try:
+        n = float(v)
+        return (n, n)
+    except ValueError:
+        return (float("nan"), float("nan"))
+
+
+def encode_numeric_value(x: float) -> list[float]:
+    """Encode numeric value as [log(1+|x|), x/1000, 1.0]."""
+    if math.isnan(x):
+        return [0.0, 0.0, 0.0]  # Will use NaN embedding instead
+    return [math.log1p(abs(x)), x / 1000.0, 1.0]
+
+
+def encode_housenumber_value(lo: float, hi: float) -> list[float]:
+    """Encode housenumber range as [log(1+lo), log(1+hi), log(1+hi-lo), mean/2000]."""
+    if math.isnan(lo) or math.isnan(hi):
+        return [0.0, 0.0, 0.0, 0.0]  # Will use NaN embedding instead
+    # Ensure lo <= hi and both non-negative for log1p
+    lo, hi = max(lo, 0.0), max(hi, 0.0)
+    if lo > hi:
+        lo, hi = hi, lo
+    return [math.log1p(lo), math.log1p(hi), math.log1p(hi - lo), (lo + hi) / 4000.0]
+
+
+# ---------------------------------------------------------------------------
+# Model configs
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TagBundleEncoderConfig:
+    key_dim: int = 32
+    boolean_dim: int = 8
+    numeric_dim: int = 16
+    housenumber_dim: int = 16
+    text_input_dim: int = 768
+    text_proj_dim: int = 128
+    per_tag_dim: int = 64
+    repr_dim: int = 128  # Output: mean + max pool of per_tag_dim
+
+
+@dataclass
+class CorrespondenceClassifierConfig:
+    encoder: TagBundleEncoderConfig = field(default_factory=TagBundleEncoderConfig)
+    mlp_hidden_dim: int = 128
+    dropout: float = 0.1
+    num_cross_features: int = 17  # Jaccard(1) + shared_keys(1) + exact_matches(1) + category(4) + text_sim(3) + numeric(6) + housenumber(1)
+
+
+# ---------------------------------------------------------------------------
+# Model modules
+# ---------------------------------------------------------------------------
+
+class TagBundleEncoder(nn.Module):
+    """Encode a bundle of key=value tags into a fixed-size representation.
+
+    Processes each tag independently, then pools over all tags.
+    """
+
+    def __init__(self, config: TagBundleEncoderConfig):
+        super().__init__()
+        self.config = config
+
+        # Key embeddings
+        self.key_embedding = nn.Embedding(NUM_TAG_KEYS, config.key_dim)
+
+        # Boolean encoder: 3 embeddings (true, false, unknown)
+        self.boolean_embedding = nn.Embedding(3, config.boolean_dim)
+
+        # Numeric encoder: linear 3 → numeric_dim
+        self.numeric_linear = nn.Linear(3, config.numeric_dim)
+        self.numeric_nan_embedding = nn.Parameter(torch.randn(config.numeric_dim) * 0.01)
+
+        # Housenumber encoder: linear 4 → housenumber_dim
+        self.housenumber_linear = nn.Linear(4, config.housenumber_dim)
+        self.housenumber_nan_embedding = nn.Parameter(
+            torch.randn(config.housenumber_dim) * 0.01
+        )
+
+        # Text encoder: linear projection from pre-computed embeddings
+        self.text_projection = nn.Linear(config.text_input_dim, config.text_proj_dim)
+
+        # Absent value embeddings (one per type)
+        self.absent_embedding = nn.Parameter(torch.randn(config.text_proj_dim) * 0.01)
+
+        # Per-tag MLP: concat(key_emb, value_emb) → per_tag_dim
+        # Value dim varies by type; use the max (text_proj_dim) and pad smaller ones
+        max_value_dim = config.text_proj_dim
+        self.per_tag_mlp = nn.Sequential(
+            nn.Linear(config.key_dim + max_value_dim, config.per_tag_dim),
+            nn.ReLU(),
+            nn.Linear(config.per_tag_dim, config.per_tag_dim),
+        )
+
+        # Value dim adapters: project each type's value to max_value_dim
+        self.boolean_proj = nn.Linear(config.boolean_dim, max_value_dim)
+        self.numeric_proj = nn.Linear(config.numeric_dim, max_value_dim)
+        self.housenumber_proj = nn.Linear(config.housenumber_dim, max_value_dim)
+        # text_projection already outputs text_proj_dim = max_value_dim
+
+    def forward(
+        self,
+        key_indices: torch.Tensor,      # (B, max_tags) int
+        value_type: torch.Tensor,        # (B, max_tags) int: 0=bool, 1=numeric, 2=housenum, 3=text
+        boolean_values: torch.Tensor,    # (B, max_tags) int: 0=true, 1=false, 2=unknown
+        numeric_values: torch.Tensor,    # (B, max_tags, 3) float
+        numeric_nan_mask: torch.Tensor,  # (B, max_tags) bool: True if NaN
+        housenumber_values: torch.Tensor,  # (B, max_tags, 4) float
+        housenumber_nan_mask: torch.Tensor,  # (B, max_tags) bool: True if NaN
+        text_embeddings: torch.Tensor,   # (B, max_tags, text_input_dim) float
+        tag_mask: torch.Tensor,          # (B, max_tags) bool: True for real tags
+    ) -> torch.Tensor:
+        """Encode tag bundles to fixed-size representations.
+
+        Returns: (B, repr_dim) tensor
+        """
+        B, T = key_indices.shape
+
+        # 1. Key embeddings: (B, T, key_dim)
+        key_emb = self.key_embedding(key_indices)
+
+        # 2. Value embeddings by type
+        # Boolean: (B, T, boolean_dim) → (B, T, max_value_dim)
+        bool_emb = self.boolean_proj(self.boolean_embedding(boolean_values))
+
+        # Numeric: (B, T, 3) → (B, T, numeric_dim)
+        num_emb = self.numeric_linear(numeric_values)
+        # Replace NaN entries with learned NaN embedding
+        nan_expand = self.numeric_nan_embedding.unsqueeze(0).unsqueeze(0).expand(B, T, -1)
+        num_emb = torch.where(numeric_nan_mask.unsqueeze(-1), nan_expand, num_emb)
+        num_emb = self.numeric_proj(num_emb)  # → (B, T, max_value_dim)
+
+        # Housenumber: (B, T, 4) → (B, T, housenumber_dim)
+        hn_emb = self.housenumber_linear(housenumber_values)
+        hn_nan_expand = self.housenumber_nan_embedding.unsqueeze(0).unsqueeze(0).expand(B, T, -1)
+        hn_emb = torch.where(housenumber_nan_mask.unsqueeze(-1), hn_nan_expand, hn_emb)
+        hn_emb = self.housenumber_proj(hn_emb)  # → (B, T, max_value_dim)
+
+        # Text: (B, T, text_input_dim) → (B, T, text_proj_dim = max_value_dim)
+        txt_emb = self.text_projection(text_embeddings)
+
+        # Select value embedding based on type
+        # type: 0=bool, 1=numeric, 2=housenumber, 3=text
+        type_expanded = value_type.unsqueeze(-1)  # (B, T, 1)
+        max_vd = bool_emb.shape[-1]
+        value_emb = torch.zeros(B, T, max_vd, device=key_emb.device, dtype=key_emb.dtype)
+        value_emb = torch.where(type_expanded == 0, bool_emb, value_emb)
+        value_emb = torch.where(type_expanded == 1, num_emb, value_emb)
+        value_emb = torch.where(type_expanded == 2, hn_emb, value_emb)
+        value_emb = torch.where(type_expanded == 3, txt_emb, value_emb)
+
+        # 3. Per-tag representation: concat(key, value) → MLP
+        tag_repr = self.per_tag_mlp(torch.cat([key_emb, value_emb], dim=-1))  # (B, T, per_tag_dim)
+
+        # 4. Masked pooling: mean + max → repr_dim
+        # Mask out padding
+        mask_f = tag_mask.unsqueeze(-1).float()  # (B, T, 1)
+        tag_repr_masked = tag_repr * mask_f
+
+        # Mean pool
+        tag_count = mask_f.sum(dim=1).clamp(min=1)  # (B, 1)
+        mean_pool = tag_repr_masked.sum(dim=1) / tag_count  # (B, per_tag_dim)
+
+        # Max pool (set padding to -inf)
+        tag_repr_for_max = tag_repr_masked + (1 - mask_f) * (-1e9)
+        max_pool = tag_repr_for_max.max(dim=1).values  # (B, per_tag_dim)
+
+        # Concat mean and max → repr_dim
+        return torch.cat([mean_pool, max_pool], dim=-1)  # (B, 2 * per_tag_dim = repr_dim)
+
+
+class CorrespondenceClassifier(nn.Module):
+    """Twin encoder + cross-pair features + MLP classifier.
+
+    Takes two tag bundles (pano, OSM) and predicts P(same physical object).
+    """
+
+    def __init__(self, config: CorrespondenceClassifierConfig):
+        super().__init__()
+        self.config = config
+
+        # Shared twin encoder
+        self.encoder = TagBundleEncoder(config.encoder)
+
+        repr_dim = config.encoder.repr_dim  # 128
+        # Input to MLP: [pano; osm; pano*osm; cross_features]
+        mlp_input_dim = repr_dim * 3 + config.num_cross_features
+
+        self.classifier = nn.Sequential(
+            nn.Linear(mlp_input_dim, config.mlp_hidden_dim),
+            nn.BatchNorm1d(config.mlp_hidden_dim),
+            nn.ReLU(),
+            nn.Dropout(config.dropout),
+            nn.Linear(config.mlp_hidden_dim, 1),
+        )
+
+    def forward(
+        self,
+        pano_key_indices: torch.Tensor,
+        pano_value_type: torch.Tensor,
+        pano_boolean_values: torch.Tensor,
+        pano_numeric_values: torch.Tensor,
+        pano_numeric_nan_mask: torch.Tensor,
+        pano_housenumber_values: torch.Tensor,
+        pano_housenumber_nan_mask: torch.Tensor,
+        pano_text_embeddings: torch.Tensor,
+        pano_tag_mask: torch.Tensor,
+        osm_key_indices: torch.Tensor,
+        osm_value_type: torch.Tensor,
+        osm_boolean_values: torch.Tensor,
+        osm_numeric_values: torch.Tensor,
+        osm_numeric_nan_mask: torch.Tensor,
+        osm_housenumber_values: torch.Tensor,
+        osm_housenumber_nan_mask: torch.Tensor,
+        osm_text_embeddings: torch.Tensor,
+        osm_tag_mask: torch.Tensor,
+        cross_features: torch.Tensor,
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Returns: (B, 1) logits
+        """
+        pano_repr = self.encoder(
+            pano_key_indices, pano_value_type, pano_boolean_values,
+            pano_numeric_values, pano_numeric_nan_mask,
+            pano_housenumber_values, pano_housenumber_nan_mask,
+            pano_text_embeddings, pano_tag_mask,
+        )
+        osm_repr = self.encoder(
+            osm_key_indices, osm_value_type, osm_boolean_values,
+            osm_numeric_values, osm_numeric_nan_mask,
+            osm_housenumber_values, osm_housenumber_nan_mask,
+            osm_text_embeddings, osm_tag_mask,
+        )
+
+        combined = torch.cat([
+            pano_repr,
+            osm_repr,
+            pano_repr * osm_repr,
+            cross_features,
+        ], dim=-1)
+
+        return self.classifier(combined)

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
@@ -161,7 +161,7 @@ class TestTagBundleEncoder(unittest.TestCase):
 
 
 class TestCorrespondenceClassifier(unittest.TestCase):
-    def _make_dummy_batch(self, batch_size=4, max_tags=5, text_dim=768, num_cross=17):
+    def _make_dummy_batch(self, batch_size=4, max_tags=5, text_dim=768, num_cross=13):
         def make_side():
             return dict(
                 key_indices=torch.randint(0, NUM_TAG_KEYS, (batch_size, max_tags)),

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
@@ -11,6 +11,7 @@ from experimental.overhead_matching.swag.model.landmark_correspondence_model imp
     NUM_TAG_KEYS,
     NUMERIC_KEYS,
     TAG_KEY_TO_IDX,
+    ValueType,
     CorrespondenceClassifier,
     CorrespondenceClassifierConfig,
     TagBundleEncoder,
@@ -33,12 +34,16 @@ class TestValueParsing:
         assert parse_boolean("maybe") == 0.5
 
     def test_parse_numeric(self):
-        assert parse_numeric("5") == 5.0
-        assert parse_numeric("55 mph") == 55.0
-        assert parse_numeric("20+") == 20.0
-        assert parse_numeric("high") == 20.0
-        assert parse_numeric("multi") == 5.0
-        assert math.isnan(parse_numeric("unknown"))
+        assert parse_numeric("5") == (5.0, False)
+        assert parse_numeric("55 mph") == (55.0, False)
+        # "20+" encodes as 20.0 with is_lower_bound=True
+        assert parse_numeric("20+") == (20.0, True)
+        # "high"/"multi" are key-aware: only resolve for level keys
+        assert parse_numeric("high", key="building:levels") == (20.0, False)
+        assert parse_numeric("multi", key="levels") == (5.0, False)
+        assert math.isnan(parse_numeric("high")[0])  # without key context → NaN
+        assert math.isnan(parse_numeric("multi")[0])
+        assert math.isnan(parse_numeric("unknown")[0])
 
     def test_parse_maxheight(self):
         assert abs(parse_maxheight("13'6\"") - 13.5) < 0.01
@@ -53,14 +58,20 @@ class TestValueParsing:
 
     def test_encode_numeric(self):
         enc = encode_numeric_value(100.0)
-        assert len(enc) == 3
+        assert len(enc) == 4
         assert abs(enc[0] - math.log1p(100)) < 1e-6
         assert abs(enc[1] - 0.1) < 1e-6
-        assert enc[2] == 1.0
+        assert enc[2] == 1.0  # presence flag
+        assert enc[3] == 0.0  # not a lower bound
+
+    def test_encode_numeric_lower_bound(self):
+        enc = encode_numeric_value(20.0, is_lower_bound=True)
+        assert len(enc) == 4
+        assert enc[3] == 1.0  # is_lower_bound flag
 
     def test_encode_numeric_nan(self):
         enc = encode_numeric_value(float("nan"))
-        assert enc == [0.0, 0.0, 0.0]
+        assert enc == [0.0, 0.0, 0.0, 0.0]
 
     def test_encode_housenumber(self):
         enc = encode_housenumber_value(665.0, 667.0)
@@ -70,19 +81,19 @@ class TestValueParsing:
 class TestKeyType:
     def test_boolean_keys(self):
         for k in BOOLEAN_KEYS:
-            assert key_type(k) == "boolean"
+            assert key_type(k) == ValueType.BOOLEAN
 
     def test_numeric_keys(self):
         for k in NUMERIC_KEYS:
-            assert key_type(k) == "numeric"
+            assert key_type(k) == ValueType.NUMERIC
 
     def test_housenumber(self):
-        assert key_type("addr:housenumber") == "housenumber"
+        assert key_type("addr:housenumber") == ValueType.HOUSENUMBER
 
     def test_text_keys(self):
-        assert key_type("name") == "text"
-        assert key_type("building") == "text"
-        assert key_type("amenity") == "text"
+        assert key_type("name") == ValueType.TEXT
+        assert key_type("building") == ValueType.TEXT
+        assert key_type("amenity") == ValueType.TEXT
 
     def test_all_tags_have_index(self):
         assert NUM_TAG_KEYS > 100  # Should be ~112 keys
@@ -94,7 +105,7 @@ class TestTagBundleEncoder:
             key_indices=torch.randint(0, NUM_TAG_KEYS, (batch_size, max_tags)),
             value_type=torch.randint(0, 4, (batch_size, max_tags)),
             boolean_values=torch.randint(0, 3, (batch_size, max_tags)),
-            numeric_values=torch.randn(batch_size, max_tags, 3),
+            numeric_values=torch.randn(batch_size, max_tags, 4),
             numeric_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),
             housenumber_values=torch.randn(batch_size, max_tags, 4),
             housenumber_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),
@@ -153,7 +164,7 @@ class TestCorrespondenceClassifier:
                 key_indices=torch.randint(0, NUM_TAG_KEYS, (batch_size, max_tags)),
                 value_type=torch.randint(0, 4, (batch_size, max_tags)),
                 boolean_values=torch.randint(0, 3, (batch_size, max_tags)),
-                numeric_values=torch.randn(batch_size, max_tags, 3),
+                numeric_values=torch.randn(batch_size, max_tags, 4),
                 numeric_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),
                 housenumber_values=torch.randn(batch_size, max_tags, 4),
                 housenumber_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
@@ -1,0 +1,203 @@
+"""Tests for landmark correspondence model."""
+
+import math
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+
+from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
+    BOOLEAN_KEYS,
+    HOUSENUMBER_KEY,
+    NUM_TAG_KEYS,
+    NUMERIC_KEYS,
+    TAG_KEY_TO_IDX,
+    CorrespondenceClassifier,
+    CorrespondenceClassifierConfig,
+    TagBundleEncoder,
+    TagBundleEncoderConfig,
+    encode_housenumber_value,
+    encode_numeric_value,
+    key_type,
+    parse_boolean,
+    parse_housenumber,
+    parse_maxheight,
+    parse_numeric,
+)
+
+
+class TestValueParsing:
+    def test_parse_boolean(self):
+        assert parse_boolean("yes") == 1.0
+        assert parse_boolean("no") == 0.0
+        assert parse_boolean("-1") == 0.0
+        assert parse_boolean("maybe") == 0.5
+
+    def test_parse_numeric(self):
+        assert parse_numeric("5") == 5.0
+        assert parse_numeric("55 mph") == 55.0
+        assert parse_numeric("20+") == 20.0
+        assert parse_numeric("high") == 20.0
+        assert parse_numeric("multi") == 5.0
+        assert math.isnan(parse_numeric("unknown"))
+
+    def test_parse_maxheight(self):
+        assert abs(parse_maxheight("13'6\"") - 13.5) < 0.01
+        assert parse_maxheight("2") == 2.0
+        assert math.isnan(parse_maxheight("default"))
+
+    def test_parse_housenumber(self):
+        assert parse_housenumber("665-667") == (665.0, 667.0)
+        assert parse_housenumber("1858") == (1858.0, 1858.0)
+        lo, hi = parse_housenumber("abc")
+        assert math.isnan(lo) and math.isnan(hi)
+
+    def test_encode_numeric(self):
+        enc = encode_numeric_value(100.0)
+        assert len(enc) == 3
+        assert abs(enc[0] - math.log1p(100)) < 1e-6
+        assert abs(enc[1] - 0.1) < 1e-6
+        assert enc[2] == 1.0
+
+    def test_encode_numeric_nan(self):
+        enc = encode_numeric_value(float("nan"))
+        assert enc == [0.0, 0.0, 0.0]
+
+    def test_encode_housenumber(self):
+        enc = encode_housenumber_value(665.0, 667.0)
+        assert len(enc) == 4
+
+
+class TestKeyType:
+    def test_boolean_keys(self):
+        for k in BOOLEAN_KEYS:
+            assert key_type(k) == "boolean"
+
+    def test_numeric_keys(self):
+        for k in NUMERIC_KEYS:
+            assert key_type(k) == "numeric"
+
+    def test_housenumber(self):
+        assert key_type("addr:housenumber") == "housenumber"
+
+    def test_text_keys(self):
+        assert key_type("name") == "text"
+        assert key_type("building") == "text"
+        assert key_type("amenity") == "text"
+
+    def test_all_tags_have_index(self):
+        assert NUM_TAG_KEYS > 100  # Should be ~112 keys
+
+
+class TestTagBundleEncoder:
+    def _make_dummy_input(self, batch_size=4, max_tags=5, text_dim=768):
+        return dict(
+            key_indices=torch.randint(0, NUM_TAG_KEYS, (batch_size, max_tags)),
+            value_type=torch.randint(0, 4, (batch_size, max_tags)),
+            boolean_values=torch.randint(0, 3, (batch_size, max_tags)),
+            numeric_values=torch.randn(batch_size, max_tags, 3),
+            numeric_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),
+            housenumber_values=torch.randn(batch_size, max_tags, 4),
+            housenumber_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),
+            text_embeddings=torch.randn(batch_size, max_tags, text_dim),
+            tag_mask=torch.ones(batch_size, max_tags, dtype=torch.bool),
+        )
+
+    def test_forward_shape(self):
+        config = TagBundleEncoderConfig()
+        encoder = TagBundleEncoder(config)
+        inputs = self._make_dummy_input()
+        output = encoder(**inputs)
+        assert output.shape == (4, config.repr_dim)
+
+    def test_masked_tags_dont_affect_output(self):
+        config = TagBundleEncoderConfig()
+        encoder = TagBundleEncoder(config)
+
+        # Two identical inputs, but second has extra masked-out tags
+        inputs1 = self._make_dummy_input(batch_size=1, max_tags=3)
+        inputs2 = self._make_dummy_input(batch_size=1, max_tags=5)
+
+        # Copy real tags from inputs1 to inputs2
+        for key in inputs1:
+            if key == "tag_mask":
+                inputs2["tag_mask"][:, :3] = True
+                inputs2["tag_mask"][:, 3:] = False
+            elif inputs1[key].dim() == 2:
+                inputs2[key][:, :3] = inputs1[key]
+            elif inputs1[key].dim() == 3:
+                inputs2[key][:, :3] = inputs1[key]
+
+        out1 = encoder(**inputs1)
+        out2 = encoder(**inputs2)
+        # Max pool may differ due to padding, but mean pool should be close
+        # Just verify shapes match
+        assert out1.shape == out2.shape
+
+    def test_gradient_flow(self):
+        config = TagBundleEncoderConfig()
+        encoder = TagBundleEncoder(config)
+        inputs = self._make_dummy_input()
+        output = encoder(**inputs)
+        loss = output.sum()
+        loss.backward()
+
+        for name, param in encoder.named_parameters():
+            if param.requires_grad:
+                assert param.grad is not None, f"No gradient for {name}"
+
+
+class TestCorrespondenceClassifier:
+    def _make_dummy_batch(self, batch_size=4, max_tags=5, text_dim=768, num_cross=17):
+        def make_side():
+            return dict(
+                key_indices=torch.randint(0, NUM_TAG_KEYS, (batch_size, max_tags)),
+                value_type=torch.randint(0, 4, (batch_size, max_tags)),
+                boolean_values=torch.randint(0, 3, (batch_size, max_tags)),
+                numeric_values=torch.randn(batch_size, max_tags, 3),
+                numeric_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),
+                housenumber_values=torch.randn(batch_size, max_tags, 4),
+                housenumber_nan_mask=torch.zeros(batch_size, max_tags, dtype=torch.bool),
+                text_embeddings=torch.randn(batch_size, max_tags, text_dim),
+                tag_mask=torch.ones(batch_size, max_tags, dtype=torch.bool),
+            )
+
+        pano = {f"pano_{k}": v for k, v in make_side().items()}
+        osm = {f"osm_{k}": v for k, v in make_side().items()}
+        return {
+            **pano,
+            **osm,
+            "cross_features": torch.randn(batch_size, num_cross),
+        }
+
+    def test_forward_shape(self):
+        config = CorrespondenceClassifierConfig()
+        model = CorrespondenceClassifier(config)
+        batch = self._make_dummy_batch()
+        output = model(**batch)
+        assert output.shape == (4, 1)
+
+    def test_gradient_flow(self):
+        config = CorrespondenceClassifierConfig()
+        model = CorrespondenceClassifier(config)
+        batch = self._make_dummy_batch()
+        output = model(**batch)
+        loss = output.sum()
+        loss.backward()
+
+        # Verify encoder parameters get gradients (shared weights)
+        has_encoder_grad = False
+        for name, param in model.named_parameters():
+            if "encoder" in name and param.requires_grad and param.grad is not None:
+                has_encoder_grad = True
+                break
+        assert has_encoder_grad, "Encoder should receive gradients"
+
+    def test_output_is_logit(self):
+        """Output should be unbounded logits (not probabilities)."""
+        config = CorrespondenceClassifierConfig()
+        model = CorrespondenceClassifier(config)
+        batch = self._make_dummy_batch(batch_size=100)
+        with torch.no_grad():
+            output = model(**batch).squeeze(-1)
+        # Logits can be any real number, but shouldn't all be identical
+        assert output.std() > 0, "Logits should have some variance"

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
@@ -25,6 +25,9 @@ from experimental.overhead_matching.swag.model.landmark_correspondence_model imp
     parse_maxheight,
     parse_numeric,
 )
+from experimental.overhead_matching.swag.model.semantic_landmark_utils import (
+    prune_landmark,
+)
 
 
 class TestValueParsing(unittest.TestCase):
@@ -97,7 +100,7 @@ class TestKeyType(unittest.TestCase):
         self.assertEqual(key_type("amenity"), ValueType.TEXT)
 
     def test_all_tags_have_index(self):
-        self.assertGreater(NUM_TAG_KEYS, 100)  # Should be ~112 keys
+        self.assertGreater(NUM_TAG_KEYS, 100)  # Should be ~108 keys
 
 
 class TestTagBundleEncoder(unittest.TestCase):
@@ -153,10 +156,8 @@ class TestTagBundleEncoder(unittest.TestCase):
         loss = output.sum()
         loss.backward()
 
-        # absent_embedding is only used for absent tags, which this test doesn't exercise
-        skip = {"absent_embedding"}
         for name, param in encoder.named_parameters():
-            if param.requires_grad and name not in skip:
+            if param.requires_grad:
                 self.assertIsNotNone(param.grad, f"No gradient for {name}")
 
 
@@ -215,6 +216,23 @@ class TestCorrespondenceClassifier(unittest.TestCase):
             output = model(**batch).squeeze(-1)
         # Logits can be any real number, but shouldn't all be identical
         self.assertGreater(output.std(), 0, "Logits should have some variance")
+
+
+class TestPruneLandmark(unittest.TestCase):
+    def test_keeps_relevant_tags(self):
+        props = {"building": "yes", "name": "Library"}
+        result = prune_landmark(props)
+        self.assertEqual(result, frozenset([("building", "yes"), ("name", "Library")]))
+
+    def test_drops_irrelevant_tags(self):
+        props = {"building": "yes", "opening_hours": "9-5", "name": "Library"}
+        result = prune_landmark(props)
+        self.assertIn(("building", "yes"), result)
+        self.assertIn(("name", "Library"), result)
+        self.assertNotIn(("opening_hours", "9-5"), result)
+
+    def test_empty_input(self):
+        self.assertEqual(prune_landmark({}), frozenset())
 
 
 if __name__ == "__main__":

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model_test.py
@@ -1,6 +1,7 @@
 """Tests for landmark correspondence model."""
 
 import math
+import unittest
 
 import common.torch.load_torch_deps  # noqa: F401
 import torch
@@ -26,80 +27,80 @@ from experimental.overhead_matching.swag.model.landmark_correspondence_model imp
 )
 
 
-class TestValueParsing:
+class TestValueParsing(unittest.TestCase):
     def test_parse_boolean(self):
-        assert parse_boolean("yes") == 1.0
-        assert parse_boolean("no") == 0.0
-        assert parse_boolean("-1") == 0.0
-        assert parse_boolean("maybe") == 0.5
+        self.assertEqual(parse_boolean("yes"), 1.0)
+        self.assertEqual(parse_boolean("no"), 0.0)
+        self.assertEqual(parse_boolean("-1"), 0.0)
+        self.assertEqual(parse_boolean("maybe"), 0.5)
 
     def test_parse_numeric(self):
-        assert parse_numeric("5") == (5.0, False)
-        assert parse_numeric("55 mph") == (55.0, False)
+        self.assertEqual(parse_numeric("5"), (5.0, False))
+        self.assertEqual(parse_numeric("55 mph"), (55.0, False))
         # "20+" encodes as 20.0 with is_lower_bound=True
-        assert parse_numeric("20+") == (20.0, True)
+        self.assertEqual(parse_numeric("20+"), (20.0, True))
         # "high"/"multi" are key-aware: only resolve for level keys
-        assert parse_numeric("high", key="building:levels") == (20.0, False)
-        assert parse_numeric("multi", key="levels") == (5.0, False)
-        assert math.isnan(parse_numeric("high")[0])  # without key context → NaN
-        assert math.isnan(parse_numeric("multi")[0])
-        assert math.isnan(parse_numeric("unknown")[0])
+        self.assertEqual(parse_numeric("high", key="building:levels"), (20.0, False))
+        self.assertEqual(parse_numeric("multi", key="levels"), (5.0, False))
+        self.assertTrue(math.isnan(parse_numeric("high")[0]))  # without key context → NaN
+        self.assertTrue(math.isnan(parse_numeric("multi")[0]))
+        self.assertTrue(math.isnan(parse_numeric("unknown")[0]))
 
     def test_parse_maxheight(self):
-        assert abs(parse_maxheight("13'6\"") - 13.5) < 0.01
-        assert parse_maxheight("2") == 2.0
-        assert math.isnan(parse_maxheight("default"))
+        self.assertAlmostEqual(parse_maxheight("13'6\""), 13.5, places=2)
+        self.assertEqual(parse_maxheight("2"), 2.0)
+        self.assertTrue(math.isnan(parse_maxheight("default")))
 
     def test_parse_housenumber(self):
-        assert parse_housenumber("665-667") == (665.0, 667.0)
-        assert parse_housenumber("1858") == (1858.0, 1858.0)
+        self.assertEqual(parse_housenumber("665-667"), (665.0, 667.0))
+        self.assertEqual(parse_housenumber("1858"), (1858.0, 1858.0))
         lo, hi = parse_housenumber("abc")
-        assert math.isnan(lo) and math.isnan(hi)
+        self.assertTrue(math.isnan(lo) and math.isnan(hi))
 
     def test_encode_numeric(self):
         enc = encode_numeric_value(100.0)
-        assert len(enc) == 4
-        assert abs(enc[0] - math.log1p(100)) < 1e-6
-        assert abs(enc[1] - 0.1) < 1e-6
-        assert enc[2] == 1.0  # presence flag
-        assert enc[3] == 0.0  # not a lower bound
+        self.assertEqual(len(enc), 4)
+        self.assertAlmostEqual(enc[0], math.log1p(100), places=6)
+        self.assertAlmostEqual(enc[1], 0.1, places=6)
+        self.assertEqual(enc[2], 1.0)  # presence flag
+        self.assertEqual(enc[3], 0.0)  # not a lower bound
 
     def test_encode_numeric_lower_bound(self):
         enc = encode_numeric_value(20.0, is_lower_bound=True)
-        assert len(enc) == 4
-        assert enc[3] == 1.0  # is_lower_bound flag
+        self.assertEqual(len(enc), 4)
+        self.assertEqual(enc[3], 1.0)  # is_lower_bound flag
 
     def test_encode_numeric_nan(self):
         enc = encode_numeric_value(float("nan"))
-        assert enc == [0.0, 0.0, 0.0, 0.0]
+        self.assertEqual(enc, [0.0, 0.0, 0.0, 0.0])
 
     def test_encode_housenumber(self):
         enc = encode_housenumber_value(665.0, 667.0)
-        assert len(enc) == 4
+        self.assertEqual(len(enc), 4)
 
 
-class TestKeyType:
+class TestKeyType(unittest.TestCase):
     def test_boolean_keys(self):
         for k in BOOLEAN_KEYS:
-            assert key_type(k) == ValueType.BOOLEAN
+            self.assertEqual(key_type(k), ValueType.BOOLEAN)
 
     def test_numeric_keys(self):
         for k in NUMERIC_KEYS:
-            assert key_type(k) == ValueType.NUMERIC
+            self.assertEqual(key_type(k), ValueType.NUMERIC)
 
     def test_housenumber(self):
-        assert key_type("addr:housenumber") == ValueType.HOUSENUMBER
+        self.assertEqual(key_type("addr:housenumber"), ValueType.HOUSENUMBER)
 
     def test_text_keys(self):
-        assert key_type("name") == ValueType.TEXT
-        assert key_type("building") == ValueType.TEXT
-        assert key_type("amenity") == ValueType.TEXT
+        self.assertEqual(key_type("name"), ValueType.TEXT)
+        self.assertEqual(key_type("building"), ValueType.TEXT)
+        self.assertEqual(key_type("amenity"), ValueType.TEXT)
 
     def test_all_tags_have_index(self):
-        assert NUM_TAG_KEYS > 100  # Should be ~112 keys
+        self.assertGreater(NUM_TAG_KEYS, 100)  # Should be ~112 keys
 
 
-class TestTagBundleEncoder:
+class TestTagBundleEncoder(unittest.TestCase):
     def _make_dummy_input(self, batch_size=4, max_tags=5, text_dim=768):
         return dict(
             key_indices=torch.randint(0, NUM_TAG_KEYS, (batch_size, max_tags)),
@@ -118,7 +119,7 @@ class TestTagBundleEncoder:
         encoder = TagBundleEncoder(config)
         inputs = self._make_dummy_input()
         output = encoder(**inputs)
-        assert output.shape == (4, config.repr_dim)
+        self.assertEqual(output.shape, (4, config.repr_dim))
 
     def test_masked_tags_dont_affect_output(self):
         config = TagBundleEncoderConfig()
@@ -142,7 +143,7 @@ class TestTagBundleEncoder:
         out2 = encoder(**inputs2)
         # Max pool may differ due to padding, but mean pool should be close
         # Just verify shapes match
-        assert out1.shape == out2.shape
+        self.assertEqual(out1.shape, out2.shape)
 
     def test_gradient_flow(self):
         config = TagBundleEncoderConfig()
@@ -152,12 +153,14 @@ class TestTagBundleEncoder:
         loss = output.sum()
         loss.backward()
 
+        # absent_embedding is only used for absent tags, which this test doesn't exercise
+        skip = {"absent_embedding"}
         for name, param in encoder.named_parameters():
-            if param.requires_grad:
-                assert param.grad is not None, f"No gradient for {name}"
+            if param.requires_grad and name not in skip:
+                self.assertIsNotNone(param.grad, f"No gradient for {name}")
 
 
-class TestCorrespondenceClassifier:
+class TestCorrespondenceClassifier(unittest.TestCase):
     def _make_dummy_batch(self, batch_size=4, max_tags=5, text_dim=768, num_cross=17):
         def make_side():
             return dict(
@@ -185,7 +188,7 @@ class TestCorrespondenceClassifier:
         model = CorrespondenceClassifier(config)
         batch = self._make_dummy_batch()
         output = model(**batch)
-        assert output.shape == (4, 1)
+        self.assertEqual(output.shape, (4, 1))
 
     def test_gradient_flow(self):
         config = CorrespondenceClassifierConfig()
@@ -201,7 +204,7 @@ class TestCorrespondenceClassifier:
             if "encoder" in name and param.requires_grad and param.grad is not None:
                 has_encoder_grad = True
                 break
-        assert has_encoder_grad, "Encoder should receive gradients"
+        self.assertTrue(has_encoder_grad, "Encoder should receive gradients")
 
     def test_output_is_logit(self):
         """Output should be unbounded logits (not probabilities)."""
@@ -211,4 +214,8 @@ class TestCorrespondenceClassifier:
         with torch.no_grad():
             output = model(**batch).squeeze(-1)
         # Logits can be any real number, but shouldn't all be identical
-        assert output.std() > 0, "Logits should have some variance"
+        self.assertGreater(output.std(), 0, "Logits should have some variance")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/overhead_matching/swag/model/semantic_landmark_utils.py
+++ b/experimental/overhead_matching/swag/model/semantic_landmark_utils.py
@@ -8,8 +8,6 @@ import base64
 import hashlib
 import json
 import pickle
-import hashlib
-import base64
 from pathlib import Path
 import pandas as pd
 import torch
@@ -253,8 +251,9 @@ _TAGS_TO_KEEP = [
     "waterway",
 ]
 
-# Entries ending with ':' are prefix matches (e.g. "building:" matches "building:levels").
-# All others are exact key matches.
+# Entries ending with ':' are treated as prefix matches (e.g. "building:" would match
+# "building:levels"). Currently all entries are exact matches; add a colon-terminated
+# entry to enable prefix matching.
 _TAGS_TO_KEEP_PREFIXES = [t for t in _TAGS_TO_KEEP if t.endswith(':')]
 _TAGS_TO_KEEP_SET = frozenset(t for t in _TAGS_TO_KEEP if not t.endswith(':'))
 

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -811,3 +811,32 @@ py_binary(
     "//experimental/overhead_matching/swag/model:semantic_landmark_extractor",
   ]
 )
+
+py_binary(
+  name="precompute_value_embeddings",
+  srcs=["precompute_value_embeddings.py"],
+  deps=[
+    requirement("tqdm"),
+    requirement("numpy"),
+    requirement("google-genai"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:landmark_correspondence_dataset",
+    "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
+  ]
+)
+
+py_binary(
+  name="train_landmark_correspondence",
+  srcs=["train_landmark_correspondence.py"],
+  deps=[
+    requirement("torch"),
+    requirement("tensorboard"),
+    requirement("tqdm"),
+    requirement("numpy"),
+    requirement("pyyaml"),
+    requirement("scikit-learn"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:landmark_correspondence_dataset",
+    "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
+  ]
+)

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -833,6 +833,7 @@ py_library(
   ],
   deps = [
     requirement("msgspec"),
+    requirement("pyyaml"),
     "//common/python:serialization",
   ],
 )

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -825,6 +825,18 @@ py_binary(
   ]
 )
 
+py_library(
+  name = "correspondence_configs",
+  srcs = ["correspondence_configs.py"],
+  visibility = [
+    "//experimental/overhead_matching/swag:__subpackages__",
+  ],
+  deps = [
+    requirement("msgspec"),
+    "//common/python:serialization",
+  ],
+)
+
 py_binary(
   name="train_landmark_correspondence",
   srcs=["train_landmark_correspondence.py"],
@@ -833,8 +845,8 @@ py_binary(
     requirement("tensorboard"),
     requirement("tqdm"),
     requirement("numpy"),
-    requirement("pyyaml"),
     requirement("scikit-learn"),
+    ":correspondence_configs",
     "//common/torch:load_torch_deps",
     "//experimental/overhead_matching/swag/data:landmark_correspondence_dataset",
     "//experimental/overhead_matching/swag/model:landmark_correspondence_model",

--- a/experimental/overhead_matching/swag/scripts/correspondence_configs.py
+++ b/experimental/overhead_matching/swag/scripts/correspondence_configs.py
@@ -35,6 +35,7 @@ class CorrespondenceTrainConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
     seed: int
     encoder: CorrespondenceEncoderConfig
     classifier: CorrespondenceClassifierMlpConfig
+    cosine_schedule: bool = False
 
 
 def _enc_hook(obj):

--- a/experimental/overhead_matching/swag/scripts/correspondence_configs.py
+++ b/experimental/overhead_matching/swag/scripts/correspondence_configs.py
@@ -1,0 +1,61 @@
+"""Typed configuration for landmark correspondence training."""
+
+from pathlib import Path
+
+import msgspec
+
+from common.python.serialization import MSGSPEC_STRUCT_OPTS
+
+
+class CorrespondenceEncoderConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
+    text_input_dim: int
+    text_proj_dim: int
+
+
+class CorrespondenceClassifierMlpConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
+    mlp_hidden_dim: int
+    dropout: float
+
+
+class CorrespondenceTrainConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
+    data_dir: Path
+    text_embeddings_path: Path
+    output_dir: Path
+    train_city: str
+    val_city: str
+    include_difficulties: list[str]
+    batch_size: int
+    num_epochs: int
+    lr: float
+    weight_decay: float
+    warmup_fraction: float
+    gradient_clip_norm: float
+    use_amp: bool
+    num_workers: int
+    seed: int
+    encoder: CorrespondenceEncoderConfig
+    classifier: CorrespondenceClassifierMlpConfig
+
+
+def _enc_hook(obj):
+    if isinstance(obj, Path):
+        return str(obj)
+    raise NotImplementedError(f"Cannot serialize {type(obj)}")
+
+
+def _dec_hook(type_, obj):
+    if type_ is Path:
+        return Path(obj)
+    raise NotImplementedError(f"Cannot deserialize {type_}")
+
+
+def save_config(config: CorrespondenceTrainConfig, path: Path) -> None:
+    yaml_bytes = msgspec.yaml.encode(config, enc_hook=_enc_hook)
+    path.write_bytes(yaml_bytes)
+
+
+def load_config(path: Path) -> CorrespondenceTrainConfig:
+    yaml_bytes = path.read_bytes()
+    return msgspec.yaml.decode(
+        yaml_bytes, type=CorrespondenceTrainConfig, dec_hook=_dec_hook
+    )

--- a/experimental/overhead_matching/swag/scripts/correspondence_configs.py
+++ b/experimental/overhead_matching/swag/scripts/correspondence_configs.py
@@ -35,6 +35,7 @@ class CorrespondenceTrainConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
     seed: int
     encoder: CorrespondenceEncoderConfig
     classifier: CorrespondenceClassifierMlpConfig
+    include_category_features: bool = True
 
 
 def _enc_hook(obj):

--- a/experimental/overhead_matching/swag/scripts/correspondence_configs.py
+++ b/experimental/overhead_matching/swag/scripts/correspondence_configs.py
@@ -35,7 +35,6 @@ class CorrespondenceTrainConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
     seed: int
     encoder: CorrespondenceEncoderConfig
     classifier: CorrespondenceClassifierMlpConfig
-    include_category_features: bool = True
 
 
 def _enc_hook(obj):

--- a/experimental/overhead_matching/swag/scripts/example_correspondence_config.yaml
+++ b/experimental/overhead_matching/swag/scripts/example_correspondence_config.yaml
@@ -1,0 +1,26 @@
+# Landmark correspondence classifier config (v0: easy negatives only)
+data_dir: /data/overhead_matching/datasets/landmark_correspondence/chicago_seattle_neg_v3_full
+text_embeddings_path: /data/overhead_matching/datasets/landmark_correspondence/chicago_seattle_neg_v3_full/text_embeddings.pkl
+output_dir: /data/overhead_matching/training_outputs/landmark_correspondence/v0_easy
+
+train_city: Chicago
+val_city: Seattle
+include_difficulties: [positive, easy]
+
+batch_size: 512
+num_epochs: 20
+lr: 0.001
+weight_decay: 0.01
+warmup_fraction: 0.05
+gradient_clip_norm: 1.0
+use_amp: true
+num_workers: 4
+seed: 42
+
+encoder:
+  text_input_dim: 768
+  text_proj_dim: 128
+
+classifier:
+  mlp_hidden_dim: 128
+  dropout: 0.1

--- a/experimental/overhead_matching/swag/scripts/inspect_correspondence_model.py
+++ b/experimental/overhead_matching/swag/scripts/inspect_correspondence_model.py
@@ -1,0 +1,557 @@
+import marimo
+
+__generated_with = "0.19.9"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _():
+    import common.torch.load_torch_deps  # noqa: F401
+
+    import json
+    import math
+    from pathlib import Path
+
+    import numpy as np
+    import pandas as pd
+    import plotly.express as px
+    import plotly.graph_objects as go
+    import torch
+    import torch.nn.functional as F
+    from PIL import Image
+    from torch.utils.data import DataLoader
+
+    import experimental.overhead_matching.swag.data.vigor_dataset as vd
+    from experimental.overhead_matching.swag.data.landmark_correspondence_dataset import (
+        LandmarkCorrespondenceDataset,
+        collate_correspondence,
+        compute_cross_features,
+        encode_tag_bundle,
+        load_pairs_from_directory,
+        load_text_embeddings,
+        parse_prompt_landmarks,
+    )
+    from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
+        CorrespondenceClassifier,
+        CorrespondenceClassifierConfig,
+        TagBundleEncoderConfig,
+    )
+
+    return (
+        CorrespondenceClassifier,
+        CorrespondenceClassifierConfig,
+        DataLoader,
+        F,
+        Image,
+        LandmarkCorrespondenceDataset,
+        Path,
+        TagBundleEncoderConfig,
+        collate_correspondence,
+        compute_cross_features,
+        encode_tag_bundle,
+        go,
+        json,
+        load_pairs_from_directory,
+        load_text_embeddings,
+        np,
+        parse_prompt_landmarks,
+        pd,
+        px,
+        torch,
+        vd,
+    )
+
+
+@app.cell
+def _(Path):
+    MODEL_PATH = Path(
+        "/data/overhead_matching/training_outputs/landmark_correspondence/v1_all/best_model.pt"
+    )
+    TEXT_EMB_PATH = Path(
+        "/data/overhead_matching/datasets/landmark_correspondence/"
+        "chicago_seattle_neg_v3_full/text_embeddings.pkl"
+    )
+    DATA_DIR = Path(
+        "/data/overhead_matching/datasets/landmark_correspondence/"
+        "chicago_seattle_neg_v3_full/Seattle"
+    )
+    VIGOR_PATH = Path("/data/overhead_matching/datasets/VIGOR/Seattle")
+    return DATA_DIR, MODEL_PATH, TEXT_EMB_PATH, VIGOR_PATH
+
+
+@app.cell
+def _(
+    CorrespondenceClassifier,
+    CorrespondenceClassifierConfig,
+    MODEL_PATH,
+    TEXT_EMB_PATH,
+    TagBundleEncoderConfig,
+    load_text_embeddings,
+    mo,
+    torch,
+):
+    text_embeddings = load_text_embeddings(TEXT_EMB_PATH)
+    encoder_config = TagBundleEncoderConfig(text_input_dim=768, text_proj_dim=128)
+    classifier_config = CorrespondenceClassifierConfig(encoder=encoder_config)
+    _model = CorrespondenceClassifier(classifier_config)
+    _model.load_state_dict(torch.load(MODEL_PATH, map_location="cpu", weights_only=True))
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = _model.to(device).eval()
+    mo.md(
+        f"**Model loaded** ({sum(p.numel() for p in model.parameters()):,} params) "
+        f"on `{device}` | **{len(text_embeddings):,}** text embeddings"
+    )
+    return device, model, text_embeddings
+
+
+@app.cell
+def _(VIGOR_PATH, mo, np, pd, vd):
+    vigor_config = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None,
+        panorama_tensor_cache_info=None,
+        should_load_images=False,
+        should_load_landmarks=True,
+        landmark_version="v4_202001",
+    )
+    vigor_dataset = vd.VigorDataset(dataset_path=VIGOR_PATH, config=vigor_config)
+
+    _lm = vigor_dataset._landmark_metadata
+    osm_landmarks_df = pd.DataFrame(
+        {
+            "landmark_idx": range(len(_lm)),
+            "lat": [
+                g.centroid.y if g is not None else np.nan for g in _lm.geometry
+            ],
+            "lon": [
+                g.centroid.x if g is not None else np.nan for g in _lm.geometry
+            ],
+            "tags": [dict(_lm.iloc[i]["pruned_props"]) for i in range(len(_lm))],
+            "tags_str": [
+                "; ".join(f"{k}={v}" for k, v in sorted(_lm.iloc[i]["pruned_props"]))
+                for i in range(len(_lm))
+            ],
+        }
+    )
+    osm_landmarks_df = osm_landmarks_df[osm_landmarks_df["tags_str"] != ""].reset_index(
+        drop=True
+    )
+
+    mo.md(
+        f"**VIGOR Seattle**: {len(vigor_dataset._panorama_metadata):,} panoramas, "
+        f"{len(osm_landmarks_df):,} OSM landmarks with tags"
+    )
+    return osm_landmarks_df, vigor_dataset
+
+
+@app.cell
+def _(DATA_DIR, json, load_pairs_from_directory, mo, parse_prompt_landmarks):
+    val_pairs = load_pairs_from_directory(DATA_DIR)
+
+    # Build pano_id -> pano landmarks lookup from JSONL
+    pano_id_to_pano_landmarks = {}
+    _jsonl_files = list(DATA_DIR.rglob("predictions.jsonl")) or list(
+        DATA_DIR.rglob("*.jsonl")
+    )
+    for _jf in _jsonl_files:
+        with open(_jf) as _f:
+            for _line in _f:
+                _line = _line.strip()
+                if not _line:
+                    continue
+                try:
+                    _data = json.loads(_line)
+                    _pid = _data["key"]
+                    _prompt = _data["request"]["contents"][0]["parts"][0]["text"]
+                    _set1, _set2 = parse_prompt_landmarks(_prompt)
+                    pano_id_to_pano_landmarks[_pid] = _set1
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    continue
+
+    pano_ids_in_val = sorted(pano_id_to_pano_landmarks.keys())
+
+    mo.md(
+        f"**Validation**: {len(val_pairs):,} pairs from {len(pano_ids_in_val):,} panoramas"
+    )
+    return pano_id_to_pano_landmarks, pano_ids_in_val, val_pairs
+
+
+@app.cell
+def _(F, collate_correspondence, device, model, torch):
+    def run_model_on_batch(batch, _model=model, _device=device):
+        """Run the correspondence model on a CorrespondenceBatch."""
+        batch = batch.to(_device)
+        with torch.no_grad():
+            logits = _model(
+                pano_key_indices=batch.pano_key_indices,
+                pano_value_type=batch.pano_value_type,
+                pano_boolean_values=batch.pano_boolean_values,
+                pano_numeric_values=batch.pano_numeric_values,
+                pano_numeric_nan_mask=batch.pano_numeric_nan_mask,
+                pano_housenumber_values=batch.pano_housenumber_values,
+                pano_housenumber_nan_mask=batch.pano_housenumber_nan_mask,
+                pano_text_embeddings=batch.pano_text_embeddings,
+                pano_tag_mask=batch.pano_tag_mask,
+                osm_key_indices=batch.osm_key_indices,
+                osm_value_type=batch.osm_value_type,
+                osm_boolean_values=batch.osm_boolean_values,
+                osm_numeric_values=batch.osm_numeric_values,
+                osm_numeric_nan_mask=batch.osm_numeric_nan_mask,
+                osm_housenumber_values=batch.osm_housenumber_values,
+                osm_housenumber_nan_mask=batch.osm_housenumber_nan_mask,
+                osm_text_embeddings=batch.osm_text_embeddings,
+                osm_tag_mask=batch.osm_tag_mask,
+                cross_features=batch.cross_features,
+            ).squeeze(-1)
+        return logits
+
+    def score_pairs(samples_list):
+        """Run model on a list of sample dicts. Returns (logits, probs, losses)."""
+        all_logits, all_probs, all_losses = [], [], []
+        _bs = 512
+        for _start in range(0, len(samples_list), _bs):
+            _batch = collate_correspondence(samples_list[_start : _start + _bs])
+            _logits = run_model_on_batch(_batch)
+            _labels = _batch.labels.to(_logits.device)
+            _loss = F.binary_cross_entropy_with_logits(
+                _logits, _labels, reduction="none"
+            )
+            all_logits.extend(_logits.cpu().tolist())
+            all_probs.extend(torch.sigmoid(_logits).cpu().tolist())
+            all_losses.extend(_loss.cpu().tolist())
+        return all_logits, all_probs, all_losses
+
+    return (run_model_on_batch,)
+
+
+@app.cell
+def _(
+    DataLoader,
+    F,
+    LandmarkCorrespondenceDataset,
+    collate_correspondence,
+    mo,
+    pd,
+    run_model_on_batch,
+    text_embeddings,
+    torch,
+    val_pairs,
+):
+    mo.output.replace(mo.md("Computing validation losses... (this takes ~1 min)"))
+
+    _include = ("positive", "hard", "easy")
+    _filtered = [p for p in val_pairs if p.difficulty in _include]
+
+    # Build metadata
+    _meta = []
+    for _i, _p in enumerate(_filtered):
+        _meta.append(
+            {
+                "pano_tags": "; ".join(
+                    f"{k}={v}" for k, v in sorted(_p.pano_tags.items())
+                ),
+                "osm_tags": "; ".join(
+                    f"{k}={v}" for k, v in sorted(_p.osm_tags.items())
+                ),
+                "label": _p.label,
+                "difficulty": _p.difficulty,
+                "uniqueness": _p.uniqueness_score,
+                "pano_id": _p.pano_id,
+            }
+        )
+    loss_df = pd.DataFrame(_meta)
+
+    # Run model
+    _dataset = LandmarkCorrespondenceDataset(
+        _filtered, text_embeddings, 768, _include
+    )
+    _loader = DataLoader(
+        _dataset,
+        batch_size=512,
+        shuffle=False,
+        collate_fn=collate_correspondence,
+        num_workers=4,
+        pin_memory=True,
+    )
+
+    _all_probs = []
+    _all_losses = []
+    with torch.no_grad():
+        for _batch in _loader:
+            _logits = run_model_on_batch(_batch)
+            _labels = _batch.labels.to(_logits.device)
+            _loss = F.binary_cross_entropy_with_logits(
+                _logits, _labels, reduction="none"
+            )
+            _all_probs.extend(torch.sigmoid(_logits).cpu().tolist())
+            _all_losses.extend(_loss.cpu().tolist())
+
+    loss_df["prob"] = _all_probs
+    loss_df["loss"] = _all_losses
+    loss_df = loss_df.sort_values("loss", ascending=False).reset_index(drop=True)
+
+    mo.output.replace(
+        mo.md(f"**Validation losses computed** for {len(loss_df):,} pairs")
+    )
+    return (loss_df,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Validation Loss Analysis
+    """)
+    return
+
+
+@app.cell
+def _(loss_df, mo, px):
+    _fig = px.histogram(
+        loss_df,
+        x="loss",
+        color="difficulty",
+        nbins=100,
+        title="Per-sample BCE loss distribution",
+        barmode="overlay",
+        opacity=0.6,
+    )
+    _fig.update_layout(height=350)
+
+    _worst = loss_df.head(25)[
+        ["pano_tags", "osm_tags", "label", "difficulty", "prob", "loss", "pano_id"]
+    ]
+    _best = loss_df.tail(25).iloc[::-1][
+        ["pano_tags", "osm_tags", "label", "difficulty", "prob", "loss", "pano_id"]
+    ]
+
+    mo.vstack(
+        [
+            _fig,
+            mo.md("### Worst predictions (highest loss)"),
+            mo.ui.table(_worst, label="Worst 25"),
+            mo.md("### Best predictions (lowest loss)"),
+            mo.ui.table(_best, label="Best 25"),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Interactive Panorama Explorer
+    """)
+    return
+
+
+@app.cell
+def _(mo, pano_ids_in_val):
+    pano_selector = mo.ui.dropdown(
+        options=pano_ids_in_val, label="Select panorama", full_width=False
+    )
+    pano_selector
+    return (pano_selector,)
+
+
+@app.cell
+def _(Image, mo, pano_id_to_pano_landmarks, pano_selector, vigor_dataset):
+    mo.stop(pano_selector.value is None, mo.md("*Select a panorama above*"))
+
+    _pid = pano_selector.value
+    _pano_row = vigor_dataset._panorama_metadata[
+        vigor_dataset._panorama_metadata.pano_id == _pid
+    ]
+    mo.stop(len(_pano_row) == 0, mo.md(f"Panorama `{_pid}` not found in VIGOR dataset"))
+    _pano_row = _pano_row.iloc[0]
+
+    # Load panorama image
+    _img = Image.open(_pano_row.path)
+    _img = _img.resize((1024, 512))
+
+    # Get pano landmarks
+    _pano_lms = pano_id_to_pano_landmarks.get(_pid, [])
+    _lm_strs = [
+        "; ".join(f"{k}={v}" for k, v in sorted(lm.items())) for lm in _pano_lms
+    ]
+    _lm_options = {s: i for i, s in enumerate(_lm_strs)} if _lm_strs else {"(no landmarks)": -1}
+
+    landmark_selector = mo.ui.dropdown(
+        options=_lm_options, label="Select landmark", full_width=True
+    )
+
+    selected_pano_landmarks = _pano_lms
+
+    mo.vstack(
+        [
+            mo.md(f"**Panorama**: `{_pid}` | lat={_pano_row.lat:.6f}, lon={_pano_row.lon:.6f}"),
+            mo.image(_img),
+            mo.md(f"**{len(_pano_lms)} pano landmarks** detected:"),
+            landmark_selector,
+        ]
+    )
+    return landmark_selector, selected_pano_landmarks
+
+
+@app.cell
+def _(
+    collate_correspondence,
+    compute_cross_features,
+    encode_tag_bundle,
+    landmark_selector,
+    mo,
+    np,
+    osm_landmarks_df,
+    run_model_on_batch,
+    selected_pano_landmarks,
+    text_embeddings,
+    torch,
+):
+    mo.stop(
+        landmark_selector.value is None or landmark_selector.value == -1,
+        mo.md("*Select a landmark above*"),
+    )
+
+    _lm_idx = landmark_selector.value
+    _pano_tags = selected_pano_landmarks[_lm_idx]
+    _pano_tags_str = "; ".join(f"{k}={v}" for k, v in sorted(_pano_tags.items()))
+
+    mo.output.replace(
+        mo.md(f"Scoring `{_pano_tags_str}` against {len(osm_landmarks_df):,} OSM landmarks...")
+    )
+
+    # Encode pano side once
+    _pano_encoded = encode_tag_bundle(_pano_tags, text_embeddings, 768)
+
+    # Build samples for all OSM landmarks
+    _samples = []
+    for _i, _row in osm_landmarks_df.iterrows():
+        _osm_tags = _row["tags"]
+        _osm_encoded = encode_tag_bundle(_osm_tags, text_embeddings, 768)
+        _cross = compute_cross_features(_pano_tags, _osm_tags, text_embeddings)
+        _samples.append(
+            {
+                "pano": _pano_encoded,
+                "osm": _osm_encoded,
+                "cross_features": _cross,
+                "label": 0.0,
+                "difficulty": "query",
+            }
+        )
+
+    # Batch model inference
+    _all_logits = []
+    _bs = 512
+    with torch.no_grad():
+        for _start in range(0, len(_samples), _bs):
+            _batch = collate_correspondence(_samples[_start : _start + _bs])
+            _logits = run_model_on_batch(_batch)
+            _all_logits.extend(_logits.cpu().tolist())
+
+    # Build results
+    scores_df = osm_landmarks_df.copy()
+    scores_df["logit"] = _all_logits
+    scores_df["prob"] = 1.0 / (1.0 + np.exp(-scores_df["logit"]))
+    scores_df = scores_df.sort_values("logit", ascending=False).reset_index(drop=True)
+
+    selected_pano_tags_str = _pano_tags_str
+
+    mo.output.replace(mo.md(f"Scored **{len(scores_df):,}** OSM landmarks"))
+    return scores_df, selected_pano_tags_str
+
+
+@app.cell
+def _(mo, scores_df, selected_pano_tags_str):
+    _top = scores_df[["tags_str", "prob", "logit", "lat", "lon"]].copy()
+    # _top = scores_df.head(30)[["tags_str", "prob", "logit", "lat", "lon"]].copy()
+    _top.columns = ["OSM tags", "P(match)", "logit", "lat", "lon"]
+
+    mo.vstack(
+        [
+            mo.md(f"### Top 30 matches for: `{selected_pano_tags_str}`"),
+            mo.ui.table(_top, label="Top matches"),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(go, mo, np, scores_df, selected_pano_tags_str):
+    _df = scores_df[scores_df["lat"].notna()].copy()
+
+    # Only plot top 2000 by logit to keep output size manageable
+    _df = _df.head(2000)
+    _df["logit_clamp"] = _df["logit"].clip(-5, 5)
+
+    _fig = go.Figure()
+
+    # Background: lower-scoring landmarks
+    _bg = _df[_df["prob"] < 0.5]
+    _fig.add_trace(
+        go.Scattermap(
+            lat=_bg["lat"],
+            lon=_bg["lon"],
+            mode="markers",
+            marker=dict(
+                size=4,
+                color=_bg["logit_clamp"],
+                colorscale="RdYlGn",
+                cmin=-5,
+                cmax=5,
+                opacity=0.3,
+            ),
+            text=_bg["tags_str"],
+            hovertemplate="%{text}<br>logit=%{marker.color:.2f}<extra></extra>",
+            name="P < 0.5",
+        )
+    )
+
+    # Foreground: high-probability matches
+    _fg = _df[_df["prob"] >= 0.5]
+    if len(_fg) > 0:
+        _fig.add_trace(
+            go.Scattermap(
+                lat=_fg["lat"],
+                lon=_fg["lon"],
+                mode="markers",
+                marker=dict(
+                    size=np.clip(_fg["prob"] * 15, 6, 20).tolist(),
+                    color=_fg["logit_clamp"],
+                    colorscale="RdYlGn",
+                    cmin=-5,
+                    cmax=5,
+                    opacity=0.9,
+                    colorbar=dict(title="logit"),
+                ),
+                text=_fg["tags_str"],
+                hovertemplate="%{text}<br>logit=%{marker.color:.2f}<extra></extra>",
+                name="P >= 0.5",
+            )
+        )
+
+    _center_lat = _df["lat"].mean()
+    _center_lon = _df["lon"].mean()
+
+    _fig.update_layout(
+        map=dict(
+            style="open-street-map",
+            center=dict(lat=_center_lat, lon=_center_lon),
+            zoom=10,
+        ),
+        height=700,
+        title=f"Top 2000 OSM landmarks by logit for: {selected_pano_tags_str[:80]}",
+        showlegend=True,
+        margin=dict(l=0, r=0, t=40, b=0),
+    )
+
+    mo.ui.plotly(_fig)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/experimental/overhead_matching/swag/scripts/inspect_correspondence_model.py
+++ b/experimental/overhead_matching/swag/scripts/inspect_correspondence_model.py
@@ -159,6 +159,7 @@ def _(DATA_DIR, json, load_pairs_from_directory, mo, parse_prompt_landmarks):
     _jsonl_files = list(DATA_DIR.rglob("predictions.jsonl")) or list(
         DATA_DIR.rglob("*.jsonl")
     )
+    _skipped = 0
     for _jf in _jsonl_files:
         with open(_jf) as _f:
             for _line in _f:
@@ -172,7 +173,10 @@ def _(DATA_DIR, json, load_pairs_from_directory, mo, parse_prompt_landmarks):
                     _set1, _set2 = parse_prompt_landmarks(_prompt)
                     pano_id_to_pano_landmarks[_pid] = _set1
                 except (json.JSONDecodeError, KeyError, ValueError):
+                    _skipped += 1
                     continue
+    if _skipped:
+        print(f"WARNING: Skipped {_skipped} unparseable JSONL lines")
 
     pano_ids_in_val = sorted(pano_id_to_pano_landmarks.keys())
 

--- a/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
+++ b/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Pre-compute text embeddings for all unique tag values in the JSONL data.
+
+Scans all JSONL response files, collects unique value strings for text-type keys,
+embeds them via Vertex AI text-embedding-005, and saves as pickle:
+  {value_string: numpy_array (768-dim)}
+
+Usage:
+    bazel run //experimental/overhead_matching/swag/scripts:precompute_value_embeddings -- \
+        --data_dir /data/overhead_matching/datasets/landmark_correspondence/neg_v3_full \
+        --output /data/overhead_matching/datasets/landmark_correspondence/text_embeddings.pkl
+
+Prerequisites:
+    export GOOGLE_CLOUD_PROJECT=your-project-id
+    gcloud auth application-default login
+"""
+
+import argparse
+import json
+import pickle
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401 - Must import before torch
+
+import numpy as np
+from tqdm import tqdm
+
+from experimental.overhead_matching.swag.data.landmark_correspondence_dataset import (
+    parse_prompt_landmarks,
+)
+from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
+    key_type,
+)
+
+
+def collect_unique_text_values(data_dir: Path) -> dict[str, int]:
+    """Scan JSONL files and collect all unique text-type tag values with counts.
+
+    Args:
+        data_dir: Root directory containing {Chicago,Seattle}/responses/ subdirs
+
+    Returns:
+        Counter mapping value strings to their occurrence counts
+    """
+    value_counts: Counter = Counter()
+    jsonl_files = list(data_dir.rglob("predictions.jsonl"))
+    if not jsonl_files:
+        jsonl_files = list(data_dir.rglob("*.jsonl"))
+
+    print(f"Scanning {len(jsonl_files)} JSONL file(s)...")
+
+    total_lines = 0
+    for jsonl_path in tqdm(jsonl_files, desc="Scanning JSONL"):
+        with open(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                total_lines += 1
+                try:
+                    data = json.loads(line)
+                    prompt_text = data["request"]["contents"][0]["parts"][0]["text"]
+                    set1, set2 = parse_prompt_landmarks(prompt_text)
+                    for landmarks in [set1, set2]:
+                        for tags in landmarks:
+                            for k, v in tags.items():
+                                if key_type(k) == "text":
+                                    value_counts[v] += 1
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    continue
+
+    print(f"Scanned {total_lines} lines from {len(jsonl_files)} files")
+    return value_counts
+
+
+def embed_texts_vertex(
+    texts: list[str],
+    model: str = "text-embedding-005",
+    task_type: str = "SEMANTIC_SIMILARITY",
+    batch_size: int = 250,
+    output_dimensionality: int = 768,
+) -> np.ndarray:
+    """Embed texts using Vertex AI.
+
+    Returns: numpy array of shape (len(texts), output_dimensionality)
+    """
+    from google import genai
+    from google.genai.types import EmbedContentConfig
+
+    client = genai.Client(vertexai=True)
+    config = EmbedContentConfig(
+        task_type=task_type,
+        output_dimensionality=output_dimensionality,
+    )
+
+    all_embeddings = []
+    num_batches = (len(texts) + batch_size - 1) // batch_size
+
+    for i in tqdm(range(0, len(texts), batch_size), desc="Embedding", total=num_batches):
+        batch = texts[i:i + batch_size]
+        for attempt in range(3):
+            try:
+                response = client.models.embed_content(
+                    model=model,
+                    contents=batch,
+                    config=config,
+                )
+                all_embeddings.extend([emb.values for emb in response.embeddings])
+                break
+            except Exception as e:
+                if attempt == 2:
+                    raise
+                wait = 2 ** attempt
+                print(f"\nRetry {attempt + 1}/3 after {wait}s: {e}")
+                time.sleep(wait)
+
+    return np.array(all_embeddings, dtype=np.float32)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Pre-compute text embeddings for tag values")
+    parser.add_argument(
+        "--data_dir", type=Path, required=True,
+        help="Root directory with {Chicago,Seattle}/responses/ subdirs",
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True,
+        help="Output pickle file path",
+    )
+    parser.add_argument(
+        "--model", type=str, default="text-embedding-005",
+        help="Embedding model (default: text-embedding-005)",
+    )
+    parser.add_argument(
+        "--output_dimensionality", type=int, default=768,
+        help="Embedding dimension (default: 768)",
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=250,
+        help="Batch size for API calls (default: 250, max: 250)",
+    )
+    parser.add_argument(
+        "--stats_only", action="store_true",
+        help="Only print statistics, don't embed",
+    )
+    args = parser.parse_args()
+
+    # Collect unique values
+    value_counts = collect_unique_text_values(args.data_dir)
+    print(f"\nUnique text values: {len(value_counts):,}")
+    print(f"Total occurrences: {sum(value_counts.values()):,}")
+
+    # Show top values
+    print("\nTop 20 most common values:")
+    for val, count in value_counts.most_common(20):
+        print(f"  {count:6d}  {val[:80]}")
+
+    # Show value length stats
+    lengths = [len(v) for v in value_counts]
+    print(f"\nValue length: min={min(lengths)}, max={max(lengths)}, "
+          f"mean={sum(lengths)/len(lengths):.1f}")
+
+    if args.stats_only:
+        return 0
+
+    # Embed
+    values = sorted(value_counts.keys())  # Deterministic ordering
+    print(f"\nEmbedding {len(values):,} unique values with {args.model}...")
+
+    embeddings = embed_texts_vertex(
+        values,
+        model=args.model,
+        output_dimensionality=args.output_dimensionality,
+        batch_size=args.batch_size,
+    )
+    print(f"Embedding shape: {embeddings.shape}")
+
+    # Save as {value_string: numpy_array}
+    result = {v: embeddings[i] for i, v in enumerate(values)}
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "wb") as f:
+        pickle.dump(result, f)
+
+    file_size_mb = args.output.stat().st_size / 1024 / 1024
+    print(f"\nSaved to {args.output} ({file_size_mb:.1f} MB)")
+    print(f"  {len(result):,} embeddings, {args.output_dimensionality}-dim each")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
+++ b/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
@@ -32,6 +32,7 @@ from experimental.overhead_matching.swag.data.landmark_correspondence_dataset im
     parse_prompt_landmarks,
 )
 from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
+    ValueType,
     key_type,
 )
 
@@ -67,7 +68,7 @@ def collect_unique_text_values(data_dir: Path) -> dict[str, int]:
                     for landmarks in [set1, set2]:
                         for tags in landmarks:
                             for k, v in tags.items():
-                                if key_type(k) == "text":
+                                if key_type(k) == ValueType.TEXT:
                                     value_counts[v] += 1
                 except (json.JSONDecodeError, KeyError, ValueError):
                     continue

--- a/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
+++ b/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
@@ -54,6 +54,7 @@ def collect_unique_text_values(data_dir: Path) -> dict[str, int]:
     print(f"Scanning {len(jsonl_files)} JSONL file(s)...")
 
     total_lines = 0
+    skipped = 0
     for jsonl_path in tqdm(jsonl_files, desc="Scanning JSONL"):
         with open(jsonl_path) as f:
             for line in f:
@@ -71,9 +72,12 @@ def collect_unique_text_values(data_dir: Path) -> dict[str, int]:
                                 if key_type(k) == ValueType.TEXT:
                                     value_counts[v] += 1
                 except (json.JSONDecodeError, KeyError, ValueError):
+                    skipped += 1
                     continue
 
     print(f"Scanned {total_lines} lines from {len(jsonl_files)} files")
+    if skipped:
+        print(f"WARNING: Skipped {skipped} unparseable lines")
     return value_counts
 
 

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -48,6 +48,8 @@ from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
 
 from experimental.overhead_matching.swag.data.landmark_correspondence_dataset import (
+    NUM_CROSS_FEATURES_WITH_CATEGORY,
+    NUM_CROSS_FEATURES_WITHOUT_CATEGORY,
     PARSE_REPORT_PATH,
     CorrespondenceBatch,
     LandmarkCorrespondenceDataset,
@@ -306,11 +308,14 @@ def train(config: CorrespondenceTrainConfig) -> None:
             PARSE_REPORT_PATH.unlink()
         print("  No parse failures found")
 
+    include_category = config.include_category_features
     train_dataset = LandmarkCorrespondenceDataset(
         train_pairs, text_embeddings, text_input_dim, include_difficulties,
+        include_category_features=include_category,
     )
     val_dataset = LandmarkCorrespondenceDataset(
         val_pairs, text_embeddings, text_input_dim, include_difficulties,
+        include_category_features=include_category,
     )
     print(f"After filtering: train={len(train_dataset):,}, val={len(val_dataset):,}")
 
@@ -332,10 +337,12 @@ def train(config: CorrespondenceTrainConfig) -> None:
         text_input_dim=text_input_dim,
         text_proj_dim=config.encoder.text_proj_dim,
     )
+    num_cross = NUM_CROSS_FEATURES_WITH_CATEGORY if include_category else NUM_CROSS_FEATURES_WITHOUT_CATEGORY
     classifier_config = CorrespondenceClassifierConfig(
         encoder=encoder_config,
         mlp_hidden_dim=config.classifier.mlp_hidden_dim,
         dropout=config.classifier.dropout,
+        num_cross_features=num_cross,
     )
     model = CorrespondenceClassifier(classifier_config).to(device)
     num_params = sum(p.numel() for p in model.parameters())

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -358,7 +358,7 @@ def train(config: dict) -> None:
     use_amp = config.get("use_amp", True) and device.type == "cuda"
     if use_amp:
         scaler = GradScaler()
-        print("Mixed precision training enabled (bfloat16)")
+        print("Mixed precision training enabled (float16)")
 
     # TensorBoard
     tb_dir = output_dir / "tensorboard"

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -39,7 +39,6 @@ import common.torch.load_torch_deps  # noqa: F401 - Must import before torch
 import numpy as np
 import torch
 import torch.nn.functional as F
-import yaml
 from sklearn.metrics import roc_auc_score
 from torch.amp import GradScaler, autocast
 from torch.optim import AdamW
@@ -62,6 +61,11 @@ from experimental.overhead_matching.swag.model.landmark_correspondence_model imp
     CorrespondenceClassifier,
     CorrespondenceClassifierConfig,
     TagBundleEncoderConfig,
+)
+from experimental.overhead_matching.swag.scripts.correspondence_configs import (
+    CorrespondenceTrainConfig,
+    load_config,
+    save_config,
 )
 
 
@@ -244,38 +248,35 @@ def evaluate(
     return avg_loss, metrics
 
 
-def train(config: dict) -> None:
+def train(config: CorrespondenceTrainConfig) -> None:
     """Main training function."""
-    seed = config.get("seed", 42)
-    setup_reproducibility(seed)
+    setup_reproducibility(config.seed)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Using device: {device}")
 
-    output_dir = Path(config["output_dir"])
+    output_dir = config.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Save config
-    with open(output_dir / "config.yaml", "w") as f:
-        yaml.dump(config, f)
+    save_config(config, output_dir / "config.yaml")
 
     # Load text embeddings
     text_embeddings = None
-    text_input_dim = config.get("encoder", {}).get("text_input_dim", 768)
-    if config.get("text_embeddings_path"):
-        emb_path = Path(config["text_embeddings_path"])
-        print(f"Loading text embeddings from {emb_path}...")
-        text_embeddings = load_text_embeddings(emb_path)
-        print(f"Loaded {len(text_embeddings):,} text embeddings")
-        # Infer dim from first embedding
-        first_emb = next(iter(text_embeddings.values()))
-        text_input_dim = first_emb.shape[0]
-        print(f"Text embedding dim: {text_input_dim}")
+    text_input_dim = config.encoder.text_input_dim
+    emb_path = config.text_embeddings_path
+    print(f"Loading text embeddings from {emb_path}...")
+    text_embeddings = load_text_embeddings(emb_path)
+    print(f"Loaded {len(text_embeddings):,} text embeddings")
+    # Infer dim from first embedding
+    first_emb = next(iter(text_embeddings.values()))
+    text_input_dim = first_emb.shape[0]
+    print(f"Text embedding dim: {text_input_dim}")
 
     # Load data
-    data_dir = Path(config["data_dir"])
-    train_city = config.get("train_city", "Chicago")
-    val_city = config.get("val_city", "Seattle")
-    include_difficulties = tuple(config.get("include_difficulties", ["positive", "easy"]))
+    data_dir = config.data_dir
+    train_city = config.train_city
+    val_city = config.val_city
+    include_difficulties = tuple(config.include_difficulties)
 
     print(f"\nLoading training data ({train_city})...")
     train_pairs = load_pairs_from_directory(data_dir / train_city)
@@ -313,8 +314,8 @@ def train(config: dict) -> None:
     )
     print(f"After filtering: train={len(train_dataset):,}, val={len(val_dataset):,}")
 
-    batch_size = config.get("batch_size", 512)
-    num_workers = config.get("num_workers", 4)
+    batch_size = config.batch_size
+    num_workers = config.num_workers
     train_loader = DataLoader(
         train_dataset, batch_size=batch_size, shuffle=True,
         collate_fn=collate_correspondence, num_workers=num_workers,
@@ -329,33 +330,30 @@ def train(config: dict) -> None:
     # Create model
     encoder_config = TagBundleEncoderConfig(
         text_input_dim=text_input_dim,
-        text_proj_dim=config.get("encoder", {}).get("text_proj_dim", 128),
+        text_proj_dim=config.encoder.text_proj_dim,
     )
     classifier_config = CorrespondenceClassifierConfig(
         encoder=encoder_config,
-        mlp_hidden_dim=config.get("classifier", {}).get("mlp_hidden_dim", 128),
-        dropout=config.get("classifier", {}).get("dropout", 0.1),
+        mlp_hidden_dim=config.classifier.mlp_hidden_dim,
+        dropout=config.classifier.dropout,
     )
     model = CorrespondenceClassifier(classifier_config).to(device)
     num_params = sum(p.numel() for p in model.parameters())
     print(f"\nModel: {num_params:,} parameters")
 
     # Optimizer
-    lr = config.get("lr", 1e-3)
-    weight_decay = config.get("weight_decay", 0.01)
-    optimizer = AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+    optimizer = AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
 
-    num_epochs = config.get("num_epochs", 20)
+    num_epochs = config.num_epochs
     total_steps = len(train_loader) * num_epochs
-    warmup_fraction = config.get("warmup_fraction", 0.05)
-    warmup_steps = int(total_steps * warmup_fraction)
+    warmup_steps = int(total_steps * config.warmup_fraction)
     scheduler = create_lr_scheduler(optimizer, warmup_steps, total_steps)
 
-    gradient_clip_norm = config.get("gradient_clip_norm", 1.0)
+    gradient_clip_norm = config.gradient_clip_norm
 
     # Mixed precision
     scaler = None
-    use_amp = config.get("use_amp", True) and device.type == "cuda"
+    use_amp = config.use_amp and device.type == "cuda"
     if use_amp:
         scaler = GradScaler()
         print("Mixed precision training enabled (float16)")
@@ -416,25 +414,9 @@ def train(config: dict) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Train landmark correspondence classifier")
     parser.add_argument("--config", type=Path, required=True, help="YAML config file")
-    # Allow CLI overrides
-    parser.add_argument("--output_dir", type=Path)
-    parser.add_argument("--batch_size", type=int)
-    parser.add_argument("--num_epochs", type=int)
-    parser.add_argument("--lr", type=float)
     args = parser.parse_args()
 
-    with open(args.config) as f:
-        config = yaml.safe_load(f)
-
-    if args.output_dir:
-        config["output_dir"] = str(args.output_dir)
-    if args.batch_size:
-        config["batch_size"] = args.batch_size
-    if args.num_epochs:
-        config["num_epochs"] = args.num_epochs
-    if args.lr:
-        config["lr"] = args.lr
-
+    config = load_config(args.config)
     train(config)
 
 

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -31,6 +31,7 @@ Config format (YAML):
 """
 
 import argparse
+import math
 import random
 from pathlib import Path
 
@@ -79,13 +80,15 @@ def setup_reproducibility(seed: int) -> None:
 
 def create_lr_scheduler(
     optimizer: AdamW, warmup_steps: int, total_steps: int,
+    cosine: bool = False,
 ) -> LambdaLR:
     def lr_lambda(step: int) -> float:
         if step < warmup_steps:
             return step / max(warmup_steps, 1)
-        remaining = total_steps - step
-        total_decay = total_steps - warmup_steps
-        return max(0.0, remaining / total_decay)
+        progress = (step - warmup_steps) / max(total_steps - warmup_steps, 1)
+        if cosine:
+            return 0.5 * (1.0 + math.cos(math.pi * progress))
+        return max(0.0, 1.0 - progress)
     return LambdaLR(optimizer, lr_lambda)
 
 
@@ -266,6 +269,11 @@ def train(config: CorrespondenceTrainConfig) -> None:
     emb_path = config.text_embeddings_path
     print(f"Loading text embeddings from {emb_path}...")
     text_embeddings = load_text_embeddings(emb_path)
+    if not text_embeddings:
+        raise RuntimeError(
+            f"Text embeddings file is empty: {emb_path}. "
+            f"Re-run precompute_value_embeddings.py."
+        )
     print(f"Loaded {len(text_embeddings):,} text embeddings")
     # Infer dim from first embedding
     first_emb = next(iter(text_embeddings.values()))
@@ -313,6 +321,11 @@ def train(config: CorrespondenceTrainConfig) -> None:
         val_pairs, text_embeddings, text_input_dim, include_difficulties,
     )
     print(f"After filtering: train={len(train_dataset):,}, val={len(val_dataset):,}")
+    if len(train_dataset) == 0:
+        raise RuntimeError(
+            f"No training pairs after filtering for {include_difficulties}. "
+            f"Check data_dir={data_dir} and train_city={train_city}."
+        )
 
     batch_size = config.batch_size
     num_workers = config.num_workers
@@ -347,7 +360,7 @@ def train(config: CorrespondenceTrainConfig) -> None:
     num_epochs = config.num_epochs
     total_steps = len(train_loader) * num_epochs
     warmup_steps = int(total_steps * config.warmup_fraction)
-    scheduler = create_lr_scheduler(optimizer, warmup_steps, total_steps)
+    scheduler = create_lr_scheduler(optimizer, warmup_steps, total_steps, cosine=config.cosine_schedule)
 
     gradient_clip_norm = config.gradient_clip_norm
 

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -21,7 +21,10 @@ Config format (YAML):
     weight_decay: 0.01
     warmup_fraction: 0.05
     gradient_clip_norm: 1.0
+    use_amp: true
+    num_workers: 4
     seed: 42
+    cosine_schedule: false  # optional, defaults to false
     encoder:
         text_input_dim: 768
         text_proj_dim: 128
@@ -106,7 +109,8 @@ def compute_metrics(
     try:
         metrics["auc_roc"] = roc_auc_score(labels, probs)
     except ValueError:
-        metrics["auc_roc"] = 0.0
+        print("WARNING: Cannot compute AUC-ROC (only one class present in labels)")
+        metrics["auc_roc"] = float("nan")
 
     tp = ((preds == 1) & (labels == 1)).sum()
     fp = ((preds == 1) & (labels == 0)).sum()

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Training script for landmark correspondence classifier.
+
+Trains a twin-encoder model to predict whether a pano landmark and OSM landmark
+refer to the same physical object.
+
+Usage:
+    bazel run //experimental/overhead_matching/swag/scripts:train_landmark_correspondence -- \
+        --config /path/to/config.yaml
+
+Config format (YAML):
+    data_dir: /data/overhead_matching/datasets/landmark_correspondence/neg_v3_full
+    text_embeddings_path: /data/overhead_matching/datasets/landmark_correspondence/text_embeddings.pkl
+    output_dir: /tmp/landmark_correspondence_training
+    train_city: Chicago
+    val_city: Seattle
+    include_difficulties: [positive, easy]
+    batch_size: 512
+    num_epochs: 20
+    lr: 0.001
+    weight_decay: 0.01
+    warmup_fraction: 0.05
+    gradient_clip_norm: 1.0
+    seed: 42
+    encoder:
+        text_input_dim: 768
+        text_proj_dim: 128
+    classifier:
+        mlp_hidden_dim: 128
+        dropout: 0.1
+"""
+
+import argparse
+import random
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401 - Must import before torch
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import yaml
+from sklearn.metrics import roc_auc_score
+from torch.amp import GradScaler, autocast
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import LambdaLR
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+from tqdm import tqdm
+
+from experimental.overhead_matching.swag.data.landmark_correspondence_dataset import (
+    PARSE_REPORT_PATH,
+    CorrespondenceBatch,
+    LandmarkCorrespondenceDataset,
+    collate_correspondence,
+    load_pairs_from_directory,
+    load_text_embeddings,
+    scan_parse_failures,
+    write_parse_report,
+)
+from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
+    CorrespondenceClassifier,
+    CorrespondenceClassifierConfig,
+    TagBundleEncoderConfig,
+)
+
+
+def setup_reproducibility(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def create_lr_scheduler(
+    optimizer: AdamW, warmup_steps: int, total_steps: int,
+) -> LambdaLR:
+    def lr_lambda(step: int) -> float:
+        if step < warmup_steps:
+            return step / max(warmup_steps, 1)
+        remaining = total_steps - step
+        total_decay = total_steps - warmup_steps
+        return max(0.0, remaining / total_decay)
+    return LambdaLR(optimizer, lr_lambda)
+
+
+def compute_metrics(
+    all_labels: list[float],
+    all_probs: list[float],
+    threshold: float = 0.5,
+) -> dict[str, float]:
+    """Compute classification metrics."""
+    labels = np.array(all_labels)
+    probs = np.array(all_probs)
+    preds = (probs >= threshold).astype(float)
+
+    metrics = {}
+    try:
+        metrics["auc_roc"] = roc_auc_score(labels, probs)
+    except ValueError:
+        metrics["auc_roc"] = 0.0
+
+    tp = ((preds == 1) & (labels == 1)).sum()
+    fp = ((preds == 1) & (labels == 0)).sum()
+    fn = ((preds == 0) & (labels == 1)).sum()
+
+    precision = tp / max(tp + fp, 1)
+    recall = tp / max(tp + fn, 1)
+    f1 = 2 * precision * recall / max(precision + recall, 1e-8)
+
+    metrics["precision"] = float(precision)
+    metrics["recall"] = float(recall)
+    metrics["f1"] = float(f1)
+    metrics["accuracy"] = float((preds == labels).mean())
+
+    return metrics
+
+
+def train_epoch(
+    model: torch.nn.Module,
+    dataloader: DataLoader,
+    optimizer: AdamW,
+    scheduler: LambdaLR,
+    device: torch.device,
+    scaler: GradScaler | None,
+    gradient_clip_norm: float,
+) -> tuple[float, list[float], list[float]]:
+    """Train for one epoch. Returns (avg_loss, all_labels, all_probs)."""
+    model.train()
+    total_loss = 0.0
+    num_batches = 0
+    all_labels = []
+    all_probs = []
+
+    use_amp = scaler is not None
+    pbar = tqdm(dataloader, desc="Training")
+
+    for batch in pbar:
+        batch: CorrespondenceBatch = batch.to(device)
+        optimizer.zero_grad()
+
+        with autocast(device_type="cuda", enabled=use_amp):
+            logits = model(
+                pano_key_indices=batch.pano_key_indices,
+                pano_value_type=batch.pano_value_type,
+                pano_boolean_values=batch.pano_boolean_values,
+                pano_numeric_values=batch.pano_numeric_values,
+                pano_numeric_nan_mask=batch.pano_numeric_nan_mask,
+                pano_housenumber_values=batch.pano_housenumber_values,
+                pano_housenumber_nan_mask=batch.pano_housenumber_nan_mask,
+                pano_text_embeddings=batch.pano_text_embeddings,
+                pano_tag_mask=batch.pano_tag_mask,
+                osm_key_indices=batch.osm_key_indices,
+                osm_value_type=batch.osm_value_type,
+                osm_boolean_values=batch.osm_boolean_values,
+                osm_numeric_values=batch.osm_numeric_values,
+                osm_numeric_nan_mask=batch.osm_numeric_nan_mask,
+                osm_housenumber_values=batch.osm_housenumber_values,
+                osm_housenumber_nan_mask=batch.osm_housenumber_nan_mask,
+                osm_text_embeddings=batch.osm_text_embeddings,
+                osm_tag_mask=batch.osm_tag_mask,
+                cross_features=batch.cross_features,
+            ).squeeze(-1)  # (B,)
+            loss = F.binary_cross_entropy_with_logits(logits, batch.labels)
+
+        if use_amp:
+            scaler.scale(loss).backward()
+            scaler.unscale_(optimizer)
+            if gradient_clip_norm > 0:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), gradient_clip_norm)
+            scaler.step(optimizer)
+            scaler.update()
+        else:
+            loss.backward()
+            if gradient_clip_norm > 0:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), gradient_clip_norm)
+            optimizer.step()
+
+        scheduler.step()
+
+        total_loss += loss.item()
+        num_batches += 1
+
+        with torch.no_grad():
+            probs = torch.sigmoid(logits).cpu().tolist()
+            labels = batch.labels.cpu().tolist()
+            all_labels.extend(labels)
+            all_probs.extend(probs)
+
+        pbar.set_postfix(loss=loss.item())
+
+    return total_loss / max(num_batches, 1), all_labels, all_probs
+
+
+@torch.no_grad()
+def evaluate(
+    model: torch.nn.Module,
+    dataloader: DataLoader,
+    device: torch.device,
+) -> tuple[float, dict[str, float]]:
+    """Evaluate model. Returns (avg_loss, metrics_dict)."""
+    model.eval()
+    total_loss = 0.0
+    num_batches = 0
+    all_labels = []
+    all_probs = []
+
+    for batch in tqdm(dataloader, desc="Evaluating"):
+        batch = batch.to(device)
+        logits = model(
+            pano_key_indices=batch.pano_key_indices,
+            pano_value_type=batch.pano_value_type,
+            pano_boolean_values=batch.pano_boolean_values,
+            pano_numeric_values=batch.pano_numeric_values,
+            pano_numeric_nan_mask=batch.pano_numeric_nan_mask,
+            pano_housenumber_values=batch.pano_housenumber_values,
+            pano_housenumber_nan_mask=batch.pano_housenumber_nan_mask,
+            pano_text_embeddings=batch.pano_text_embeddings,
+            pano_tag_mask=batch.pano_tag_mask,
+            osm_key_indices=batch.osm_key_indices,
+            osm_value_type=batch.osm_value_type,
+            osm_boolean_values=batch.osm_boolean_values,
+            osm_numeric_values=batch.osm_numeric_values,
+            osm_numeric_nan_mask=batch.osm_numeric_nan_mask,
+            osm_housenumber_values=batch.osm_housenumber_values,
+            osm_housenumber_nan_mask=batch.osm_housenumber_nan_mask,
+            osm_text_embeddings=batch.osm_text_embeddings,
+            osm_tag_mask=batch.osm_tag_mask,
+            cross_features=batch.cross_features,
+        ).squeeze(-1)
+        loss = F.binary_cross_entropy_with_logits(logits, batch.labels)
+
+        total_loss += loss.item()
+        num_batches += 1
+
+        probs = torch.sigmoid(logits).cpu().tolist()
+        labels = batch.labels.cpu().tolist()
+        all_labels.extend(labels)
+        all_probs.extend(probs)
+
+    avg_loss = total_loss / max(num_batches, 1)
+    metrics = compute_metrics(all_labels, all_probs)
+    return avg_loss, metrics
+
+
+def train(config: dict) -> None:
+    """Main training function."""
+    seed = config.get("seed", 42)
+    setup_reproducibility(seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    output_dir = Path(config["output_dir"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save config
+    with open(output_dir / "config.yaml", "w") as f:
+        yaml.dump(config, f)
+
+    # Load text embeddings
+    text_embeddings = None
+    text_input_dim = config.get("encoder", {}).get("text_input_dim", 768)
+    if config.get("text_embeddings_path"):
+        emb_path = Path(config["text_embeddings_path"])
+        print(f"Loading text embeddings from {emb_path}...")
+        text_embeddings = load_text_embeddings(emb_path)
+        print(f"Loaded {len(text_embeddings):,} text embeddings")
+        # Infer dim from first embedding
+        first_emb = next(iter(text_embeddings.values()))
+        text_input_dim = first_emb.shape[0]
+        print(f"Text embedding dim: {text_input_dim}")
+
+    # Load data
+    data_dir = Path(config["data_dir"])
+    train_city = config.get("train_city", "Chicago")
+    val_city = config.get("val_city", "Seattle")
+    include_difficulties = tuple(config.get("include_difficulties", ["positive", "easy"]))
+
+    print(f"\nLoading training data ({train_city})...")
+    train_pairs = load_pairs_from_directory(data_dir / train_city)
+    print(f"Loaded {len(train_pairs):,} total pairs")
+
+    print(f"Loading validation data ({val_city})...")
+    val_pairs = load_pairs_from_directory(data_dir / val_city)
+    print(f"Loaded {len(val_pairs):,} total pairs")
+
+    # Print pair statistics
+    for name, pairs in [("Train", train_pairs), ("Val", val_pairs)]:
+        pos = sum(1 for p in pairs if p.difficulty == "positive")
+        hard = sum(1 for p in pairs if p.difficulty == "hard")
+        easy = sum(1 for p in pairs if p.difficulty == "easy")
+        print(f"  {name}: {pos} positive, {hard} hard neg, {easy} easy neg")
+
+    # Scan for parse failures and write report (cleared each run)
+    all_pairs = train_pairs + val_pairs
+    print("\nScanning for parse failures...")
+    failures = scan_parse_failures(all_pairs, text_embeddings)
+    if failures:
+        write_parse_report(failures, all_pairs, PARSE_REPORT_PATH)
+        print(f"  {len(failures)} parse failures found (see {PARSE_REPORT_PATH})")
+    else:
+        # Clear any old report
+        if PARSE_REPORT_PATH.exists():
+            PARSE_REPORT_PATH.unlink()
+        print("  No parse failures found")
+
+    train_dataset = LandmarkCorrespondenceDataset(
+        train_pairs, text_embeddings, text_input_dim, include_difficulties,
+    )
+    val_dataset = LandmarkCorrespondenceDataset(
+        val_pairs, text_embeddings, text_input_dim, include_difficulties,
+    )
+    print(f"After filtering: train={len(train_dataset):,}, val={len(val_dataset):,}")
+
+    batch_size = config.get("batch_size", 512)
+    num_workers = config.get("num_workers", 4)
+    train_loader = DataLoader(
+        train_dataset, batch_size=batch_size, shuffle=True,
+        collate_fn=collate_correspondence, num_workers=num_workers,
+        pin_memory=True, drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_dataset, batch_size=batch_size, shuffle=False,
+        collate_fn=collate_correspondence, num_workers=num_workers,
+        pin_memory=True,
+    )
+
+    # Create model
+    encoder_config = TagBundleEncoderConfig(
+        text_input_dim=text_input_dim,
+        text_proj_dim=config.get("encoder", {}).get("text_proj_dim", 128),
+    )
+    classifier_config = CorrespondenceClassifierConfig(
+        encoder=encoder_config,
+        mlp_hidden_dim=config.get("classifier", {}).get("mlp_hidden_dim", 128),
+        dropout=config.get("classifier", {}).get("dropout", 0.1),
+    )
+    model = CorrespondenceClassifier(classifier_config).to(device)
+    num_params = sum(p.numel() for p in model.parameters())
+    print(f"\nModel: {num_params:,} parameters")
+
+    # Optimizer
+    lr = config.get("lr", 1e-3)
+    weight_decay = config.get("weight_decay", 0.01)
+    optimizer = AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+
+    num_epochs = config.get("num_epochs", 20)
+    total_steps = len(train_loader) * num_epochs
+    warmup_fraction = config.get("warmup_fraction", 0.05)
+    warmup_steps = int(total_steps * warmup_fraction)
+    scheduler = create_lr_scheduler(optimizer, warmup_steps, total_steps)
+
+    gradient_clip_norm = config.get("gradient_clip_norm", 1.0)
+
+    # Mixed precision
+    scaler = None
+    use_amp = config.get("use_amp", True) and device.type == "cuda"
+    if use_amp:
+        scaler = GradScaler()
+        print("Mixed precision training enabled (bfloat16)")
+
+    # TensorBoard
+    tb_dir = output_dir / "tensorboard"
+    tb_dir.mkdir(parents=True, exist_ok=True)
+    writer = SummaryWriter(tb_dir)
+
+    # Training loop
+    best_auc = 0.0
+    print(f"\nTraining for {num_epochs} epochs ({total_steps} steps, {warmup_steps} warmup)")
+
+    for epoch in range(num_epochs):
+        print(f"\nEpoch {epoch + 1}/{num_epochs}")
+
+        train_loss, train_labels, train_probs = train_epoch(
+            model, train_loader, optimizer, scheduler, device, scaler, gradient_clip_norm,
+        )
+        train_metrics = compute_metrics(train_labels, train_probs)
+
+        val_loss, val_metrics = evaluate(model, val_loader, device)
+
+        # Log
+        print(f"  Train loss: {train_loss:.4f}, AUC: {train_metrics['auc_roc']:.4f}, "
+              f"F1: {train_metrics['f1']:.4f}")
+        print(f"  Val   loss: {val_loss:.4f}, AUC: {val_metrics['auc_roc']:.4f}, "
+              f"P: {val_metrics['precision']:.4f}, R: {val_metrics['recall']:.4f}, "
+              f"F1: {val_metrics['f1']:.4f}")
+
+        writer.add_scalar("train/loss", train_loss, epoch)
+        writer.add_scalar("val/loss", val_loss, epoch)
+        for name, val in train_metrics.items():
+            writer.add_scalar(f"train/{name}", val, epoch)
+        for name, val in val_metrics.items():
+            writer.add_scalar(f"val/{name}", val, epoch)
+        writer.add_scalar("train/lr", scheduler.get_last_lr()[0], epoch)
+
+        # Save best model
+        if val_metrics["auc_roc"] > best_auc:
+            best_auc = val_metrics["auc_roc"]
+            torch.save(model.state_dict(), output_dir / "best_model.pt")
+            print(f"  New best AUC: {best_auc:.4f}")
+
+        # Save checkpoint
+        torch.save({
+            "epoch": epoch + 1,
+            "model_state_dict": model.state_dict(),
+            "optimizer_state_dict": optimizer.state_dict(),
+            "scheduler_state_dict": scheduler.state_dict(),
+            "val_metrics": val_metrics,
+        }, output_dir / f"checkpoint_epoch_{epoch + 1}.pt")
+
+    writer.close()
+    print(f"\nTraining complete. Best val AUC: {best_auc:.4f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train landmark correspondence classifier")
+    parser.add_argument("--config", type=Path, required=True, help="YAML config file")
+    # Allow CLI overrides
+    parser.add_argument("--output_dir", type=Path)
+    parser.add_argument("--batch_size", type=int)
+    parser.add_argument("--num_epochs", type=int)
+    parser.add_argument("--lr", type=float)
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    if args.output_dir:
+        config["output_dir"] = str(args.output_dir)
+    if args.batch_size:
+        config["batch_size"] = args.batch_size
+    if args.num_epochs:
+        config["num_epochs"] = args.num_epochs
+    if args.lr:
+        config["lr"] = args.lr
+
+    train(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -48,8 +48,6 @@ from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
 
 from experimental.overhead_matching.swag.data.landmark_correspondence_dataset import (
-    NUM_CROSS_FEATURES_WITH_CATEGORY,
-    NUM_CROSS_FEATURES_WITHOUT_CATEGORY,
     PARSE_REPORT_PATH,
     CorrespondenceBatch,
     LandmarkCorrespondenceDataset,
@@ -308,14 +306,11 @@ def train(config: CorrespondenceTrainConfig) -> None:
             PARSE_REPORT_PATH.unlink()
         print("  No parse failures found")
 
-    include_category = config.include_category_features
     train_dataset = LandmarkCorrespondenceDataset(
         train_pairs, text_embeddings, text_input_dim, include_difficulties,
-        include_category_features=include_category,
     )
     val_dataset = LandmarkCorrespondenceDataset(
         val_pairs, text_embeddings, text_input_dim, include_difficulties,
-        include_category_features=include_category,
     )
     print(f"After filtering: train={len(train_dataset):,}, val={len(val_dataset):,}")
 
@@ -337,12 +332,10 @@ def train(config: CorrespondenceTrainConfig) -> None:
         text_input_dim=text_input_dim,
         text_proj_dim=config.encoder.text_proj_dim,
     )
-    num_cross = NUM_CROSS_FEATURES_WITH_CATEGORY if include_category else NUM_CROSS_FEATURES_WITHOUT_CATEGORY
     classifier_config = CorrespondenceClassifierConfig(
         encoder=encoder_config,
         mlp_hidden_dim=config.classifier.mlp_hidden_dim,
         dropout=config.classifier.dropout,
-        num_cross_features=num_cross,
     )
     model = CorrespondenceClassifier(classifier_config).to(device)
     num_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
Start landmark correspondence classifier

Landmark correspondence classifier: model, dataset, training, and inspector

Twin-encoder model that predicts P(same physical object) for pano↔OSM
landmark pairs. Architecture: per-key-type value encoders (boolean,
numeric, housenumber, text embedding) → mean/max pool → cross-pair
features → MLP classifier.

- Model: TagBundleEncoder + CorrespondenceClassifier (174k params)
- Dataset: JSONL parser, tag encoding, 17 cross-pair features, collation
- Precompute script: embed ~26k unique text values via Vertex AI
- Training: BCE loss, AdamW, bfloat16 AMP, Chicago→Seattle split
- Parse failure report to /tmp on each training run
- Marimo inspector notebook: loss analysis, panorama explorer, city heatmap
- Tests for model (forward/gradient) and dataset (parsing/collation)

v0 (easy neg): AUC 0.989 after 1 epoch
v1 (all neg):  AUC 0.938 after 20 epochs