### PR TITLE
Tune OSM landmark extraction prompt and improve evaluation plots

### DIFF
--- a/experimental/overhead_matching/swag/analysis/compare_histogram_evaluations.py
+++ b/experimental/overhead_matching/swag/analysis/compare_histogram_evaluations.py
@@ -2,9 +2,10 @@
 
 Used to look at how quickly different aggregation strategies (e.g., image-only
 vs. landmark-fused) converge during histogram filter localization. Produces a
-2x2 plot grid: convergence probability at 25m/50m/100m radii vs. distance
-traveled, plus median localization error over time. Each curve shows the median
-with IQR shading across all paths in a run.
+plot grid: convergence probability at 25m/50m/100m radii vs. distance
+traveled, median localization error, and path survival. Each curve shows the
+median with IQR shading across only the paths that are still active at that
+distance.
 
 Usage:
     bazel run //experimental/overhead_matching/swag/analysis:compare_histogram_evaluations -- \
@@ -59,15 +60,57 @@ def collect_path_data(eval_path: Path, num_paths: int):
     return all_prob_mass, all_errors, all_distances
 
 
-def interpolate_curves(curves, distance_bins):
-    """Interpolate list of (distance, values) curves onto common distance bins."""
-    interpolated = []
-    for dist, vals in curves:
-        interp = np.interp(
-            distance_bins, dist, vals, left=vals[0], right=vals[-1]
+def interpolate_curves_masked(curves, distance_bins):
+    """Interpolate curves onto common bins, masking values beyond each path's end.
+
+    Returns:
+        masked: (n_curves, n_bins) masked array — masked where the bin exceeds
+                the path's maximum distance.
+    """
+    n = len(curves)
+    m = len(distance_bins)
+    values = np.full((n, m), np.nan)
+
+    for i, (dist, vals) in enumerate(curves):
+        max_dist = dist[-1]
+        # Only interpolate within the path's range
+        valid = distance_bins <= max_dist
+        values[i, valid] = np.interp(
+            distance_bins[valid], dist, vals, left=vals[0],
         )
-        interpolated.append(interp)
-    return np.array(interpolated)
+
+    return np.ma.masked_invalid(values)
+
+
+def compute_path_survival(distances_list, distance_bins):
+    """Compute fraction of paths still active at each distance bin.
+
+    Args:
+        distances_list: list of distance arrays (one per path)
+        distance_bins: common distance grid
+
+    Returns:
+        (n_bins,) array of fractions in [0, 1]
+    """
+    max_dists = np.array([d[-1] for d in distances_list])
+    n_paths = len(max_dists)
+    survival = np.array([
+        np.sum(max_dists >= d) / n_paths for d in distance_bins
+    ])
+    return survival
+
+
+def masked_percentile(masked_arr, q, axis=0):
+    """Compute percentile along axis, ignoring masked values.
+
+    For bins where all values are masked, returns NaN.
+    """
+    result = np.full(masked_arr.shape[1], np.nan)
+    for j in range(masked_arr.shape[1]):
+        col = masked_arr[:, j].compressed()
+        if len(col) > 0:
+            result[j] = np.percentile(col, q)
+    return result
 
 
 def main():
@@ -105,6 +148,17 @@ def main():
         type=int,
         default=5000,
         help="Maximum number of paths to load per run",
+    )
+    parser.add_argument(
+        "--title",
+        type=str,
+        default=None,
+        help="Title prefix for the plot (e.g., city name)",
+    )
+    parser.add_argument(
+        "--normalize-convergence",
+        action="store_true",
+        help="Normalize convergence costs by path length (cost / path_distance)",
     )
     args = parser.parse_args()
 
@@ -150,34 +204,52 @@ def main():
     distance_bins = np.linspace(0, xlim, 200)
     colors = [f"C{i}" for i in range(len(run_data))]
 
-    # Figure layout: 2 rows x 2 cols
-    # Top row: convergence @ 25m, convergence @ 50m
-    # Bottom row: convergence @ 100m, median error + summary table
-    fig, axes = plt.subplots(2, 2, figsize=(16, 12))
+    # Find the shortest path end across all runs (for vertical line)
+    min_path_end = min(
+        d[-1]
+        for data in run_data.values()
+        for d in data["distances"]
+    )
 
-    # Convergence plots for each radius
-    for ax, radius in zip([axes[0, 0], axes[0, 1], axes[1, 0]], [25, 50, 100]):
+    # Figure layout: top row 3 convergence plots, bottom row error + survival
+    fig, axes = plt.subplots(2, 3, figsize=(22, 12))
+
+    all_axes = list(axes.flat)
+
+    # Convergence plots for each radius (top row)
+    for ax, radius in zip([axes[0, 0], axes[0, 1], axes[0, 2]], [25, 50, 100]):
         for (label, data), color in zip(run_data.items(), colors):
             if radius not in data["prob_mass"]:
                 continue
             curves = data["prob_mass"][radius]
-            interp = interpolate_curves(curves, distance_bins)
-            median = np.median(interp, axis=0)
-            q25 = np.percentile(interp, 25, axis=0)
-            q75 = np.percentile(interp, 75, axis=0)
+            interp = interpolate_curves_masked(curves, distance_bins)
+            median = masked_percentile(interp, 50)
+            q25 = masked_percentile(interp, 25)
+            q75 = masked_percentile(interp, 75)
             ax.fill_between(distance_bins, q25, q75, alpha=0.2, color=color)
 
             # Get mean convergence cost for this radius
             s = data["summary"]
             cc_key = f"convergence_cost_{radius}m"
-            cc_val = np.mean(s[cc_key]) if s and cc_key in s else None
-            cc_str = f", CC={cc_val:.0f}" if cc_val is not None else ""
+            if s and cc_key in s:
+                costs = s[cc_key]
+                if args.normalize_convergence:
+                    path_lengths = [d[-1] for d in data["distances"]]
+                    normed = [c / l for c, l in zip(costs, path_lengths) if l > 0]
+                    cc_val = np.mean(normed) if normed else None
+                    cc_str = f", nCC={cc_val:.2f}" if cc_val is not None else ""
+                else:
+                    cc_val = np.mean(costs)
+                    cc_str = f", CC={cc_val:.0f}"
+            else:
+                cc_str = ""
 
             ax.plot(
                 distance_bins, median, linewidth=2, color=color,
                 label=f"{label}{cc_str}",
             )
 
+        ax.axvline(min_path_end, color="gray", linestyle="--", alpha=0.5, linewidth=1)
         ax.set_xlabel("Distance Traveled (m)")
         ax.set_ylabel("P(mass within radius)")
         ax.set_title(f"Convergence @ {radius}m radius")
@@ -186,24 +258,17 @@ def main():
         ax.legend(loc="lower right", fontsize=9)
         ax.grid(True, alpha=0.3)
 
-    # Bottom right: median error curves
-    ax = axes[1, 1]
+    # Bottom left: median error curves
+    ax = axes[1, 0]
     for (label, data), color in zip(run_data.items(), colors):
-        interp_errors = []
+        error_curves = []
         for error, dist in zip(data["errors"], data["distances"]):
             min_len = min(len(error), len(dist))
-            interp = np.interp(
-                distance_bins,
-                dist[:min_len],
-                error[:min_len],
-                left=error[0],
-                right=error[-1],
-            )
-            interp_errors.append(interp)
-        interp_errors = np.array(interp_errors)
-        median = np.median(interp_errors, axis=0)
-        q25 = np.percentile(interp_errors, 25, axis=0)
-        q75 = np.percentile(interp_errors, 75, axis=0)
+            error_curves.append((dist[:min_len], error[:min_len]))
+        interp = interpolate_curves_masked(error_curves, distance_bins)
+        median = masked_percentile(interp, 50)
+        q25 = masked_percentile(interp, 25)
+        q75 = masked_percentile(interp, 75)
         ax.fill_between(distance_bins, q25, q75, alpha=0.2, color=color)
         s = data["summary"]
         err_str = f" (mean final: {s['average_final_error']:.1f}m)" if s else ""
@@ -212,6 +277,7 @@ def main():
             label=f"{label}{err_str}",
         )
 
+    ax.axvline(min_path_end, color="gray", linestyle="--", alpha=0.5, linewidth=1)
     ax.set_xlabel("Distance Traveled (m)")
     ax.set_ylabel("Error (m)")
     ax.set_title("Median Localization Error")
@@ -220,9 +286,61 @@ def main():
     ax.legend(fontsize=9)
     ax.grid(True, alpha=0.3)
 
+    # Bottom middle: path survival
+    ax = axes[1, 1]
+    # All runs share the same paths, so just use the first one
+    first_data = next(iter(run_data.values()))
+    survival = compute_path_survival(first_data["distances"], distance_bins)
+    ax.plot(distance_bins, survival, linewidth=2, color="black")
+    ax.fill_between(distance_bins, 0, survival, alpha=0.1, color="black")
+    ax.axvline(min_path_end, color="gray", linestyle="--", alpha=0.5, linewidth=1)
+    ax.set_xlabel("Distance Traveled (m)")
+    ax.set_ylabel("Fraction of paths remaining")
+    ax.set_title("Path Survival")
+    ax.set_ylim(0, 1.05)
+    ax.set_xlim(0, xlim)
+    ax.grid(True, alpha=0.3)
+
+    # Bottom right: summary table
+    ax = axes[1, 2]
+    ax.axis("off")
+    table_data = []
+    cc_label = "nCC" if args.normalize_convergence else "CC"
+    col_labels = ["Method", "Error", f"{cc_label}@25", f"{cc_label}@50", f"{cc_label}@100"]
+    for label, data in run_data.items():
+        s = data["summary"]
+        if s is None:
+            table_data.append([label, "N/A", "", "", ""])
+            continue
+        err = s["average_final_error"]
+        cc_vals = []
+        for radius in [25, 50, 100]:
+            costs = s.get(f"convergence_cost_{radius}m", [float("nan")])
+            if args.normalize_convergence:
+                path_lengths = [d[-1] for d in data["distances"]]
+                normed = [c / l for c, l in zip(costs, path_lengths) if l > 0]
+                cc_vals.append(np.mean(normed) if normed else float("nan"))
+            else:
+                cc_vals.append(np.mean(costs))
+        if args.normalize_convergence:
+            table_data.append([label, f"{err:.1f}", f"{cc_vals[0]:.2f}", f"{cc_vals[1]:.2f}", f"{cc_vals[2]:.2f}"])
+        else:
+            table_data.append([label, f"{err:.1f}", f"{cc_vals[0]:.0f}", f"{cc_vals[1]:.0f}", f"{cc_vals[2]:.0f}"])
+
+    table = ax.table(
+        cellText=table_data,
+        colLabels=col_labels,
+        loc="center",
+        cellLoc="center",
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(10)
+    table.scale(1.0, 1.5)
+    ax.set_title("Summary")
+
     # Print summary table to stdout
     print("\n" + "=" * 80)
-    header = f"{'Method':<40} {'Error':>8} {'CC@25':>8} {'CC@50':>8} {'CC@100':>8}"
+    header = f"{'Method':<40} {'Error':>8} {cc_label + '@25':>8} {cc_label + '@50':>8} {cc_label + '@100':>8}"
     print(header)
     print("-" * 80)
     for label, data in run_data.items():
@@ -231,17 +349,27 @@ def main():
             print(f"{label:<40} {'N/A':>8}")
             continue
         err = s["average_final_error"]
-        cc25 = np.mean(s.get("convergence_cost_25m", [float("nan")]))
-        cc50 = np.mean(s.get("convergence_cost_50m", [float("nan")]))
-        cc100 = np.mean(s.get("convergence_cost_100m", [float("nan")]))
-        print(f"{label:<40} {err:>8.2f} {cc25:>8.1f} {cc50:>8.1f} {cc100:>8.1f}")
+        cc_vals = []
+        for radius in [25, 50, 100]:
+            costs = s.get(f"convergence_cost_{radius}m", [float("nan")])
+            if args.normalize_convergence:
+                path_lengths = [d[-1] for d in data["distances"]]
+                normed = [c / l for c, l in zip(costs, path_lengths) if l > 0]
+                cc_vals.append(np.mean(normed) if normed else float("nan"))
+            else:
+                cc_vals.append(np.mean(costs))
+        if args.normalize_convergence:
+            print(f"{label:<40} {err:>8.2f} {cc_vals[0]:>8.3f} {cc_vals[1]:>8.3f} {cc_vals[2]:>8.3f}")
+        else:
+            print(f"{label:<40} {err:>8.2f} {cc_vals[0]:>8.1f} {cc_vals[1]:>8.1f} {cc_vals[2]:>8.1f}")
     print("=" * 80)
 
     # Build subtitle with path count info
     path_counts = [len(d["errors"]) for d in run_data.values()]
     n_paths = path_counts[0] if len(set(path_counts)) == 1 else "/".join(map(str, path_counts))
+    title_prefix = f"{args.title} — " if args.title else ""
     fig.suptitle(
-        f"Histogram Filter Comparison (first {xlim:.0f}m)\n"
+        f"{title_prefix}Histogram Filter Comparison (first {xlim:.0f}m)\n"
         f"{n_paths} paths, solid line = median, shading = IQR (25th-75th percentile)",
         fontsize=13,
         fontweight="bold",

--- a/experimental/overhead_matching/swag/analysis/compare_histogram_evaluations.py
+++ b/experimental/overhead_matching/swag/analysis/compare_histogram_evaluations.py
@@ -2,17 +2,20 @@
 
 Used to look at how quickly different aggregation strategies (e.g., image-only
 vs. landmark-fused) converge during histogram filter localization. Produces a
-plot grid: convergence probability at 25m/50m/100m radii vs. distance
-traveled, median localization error, and path survival. Each curve shows the
-median with IQR shading across only the paths that are still active at that
-distance.
+2x3 plot grid: convergence probability at 25m/50m/100m radii vs. distance
+traveled, median localization error, path survival, and a summary table. Each
+curve shows the median with IQR shading across only the paths that are still
+active at that distance. Paths that have ended are excluded from statistics
+rather than held at their final value.
 
 Usage:
     bazel run //experimental/overhead_matching/swag/analysis:compare_histogram_evaluations -- \
         --eval-dirs /path/to/run1 /path/to/run2 ... \
         --labels "Baseline" "EA proper_noun" ... \
         --output /tmp/comparison.png \
-        --xlim 1000
+        --xlim 1000 \
+        --title "Norway" \
+        --normalize-convergence
 """
 
 import argparse
@@ -54,8 +57,15 @@ def collect_path_data(eval_path: Path, num_paths: int):
                     all_prob_mass[radius].append(
                         (distance[:min_len], prob_mass_np[:min_len])
                     )
-        except FileNotFoundError:
-            break
+        except FileNotFoundError as e:
+            print(f"  Warning: skipping path {i} — missing file: {e.filename}")
+            continue
+
+    if not all_errors:
+        raise ValueError(
+            f"No valid path data found in {eval_path}. "
+            f"Expected subdirectories like 0000000/ with distance_traveled_m.pt and error.pt"
+        )
 
     return all_prob_mass, all_errors, all_distances
 
@@ -72,6 +82,8 @@ def interpolate_curves_masked(curves, distance_bins):
     values = np.full((n, m), np.nan)
 
     for i, (dist, vals) in enumerate(curves):
+        if len(dist) == 0:
+            continue  # leave row as NaN (will be masked)
         max_dist = dist[-1]
         # Only interpolate within the path's range
         valid = distance_bins <= max_dist
@@ -100,8 +112,8 @@ def compute_path_survival(distances_list, distance_bins):
     return survival
 
 
-def masked_percentile(masked_arr, q, axis=0):
-    """Compute percentile along axis, ignoring masked values.
+def masked_percentile(masked_arr, q):
+    """Compute percentile along axis 0, ignoring masked values.
 
     For bins where all values are masked, returns NaN.
     """
@@ -111,6 +123,24 @@ def masked_percentile(masked_arr, q, axis=0):
         if len(col) > 0:
             result[j] = np.percentile(col, q)
     return result
+
+
+def compute_cc_values(summary, distances, normalize, radii=(25, 50, 100)):
+    """Compute convergence cost values for given radii.
+
+    Returns list of floats (one per radius). Uses path-length normalization
+    if normalize is True.
+    """
+    cc_vals = []
+    for radius in radii:
+        costs = summary.get(f"convergence_cost_{radius}m", [float("nan")])
+        if normalize:
+            path_lengths = [d[-1] for d in distances]
+            normed = [c / l for c, l in zip(costs, path_lengths) if l > 0]
+            cc_vals.append(np.mean(normed) if normed else float("nan"))
+        else:
+            cc_vals.append(np.mean(costs))
+    return cc_vals
 
 
 def main():
@@ -211,10 +241,8 @@ def main():
         for d in data["distances"]
     )
 
-    # Figure layout: top row 3 convergence plots, bottom row error + survival
+    # Figure layout: top row 3 convergence plots, bottom row error + survival + summary table
     fig, axes = plt.subplots(2, 3, figsize=(22, 12))
-
-    all_axes = list(axes.flat)
 
     # Convergence plots for each radius (top row)
     for ax, radius in zip([axes[0, 0], axes[0, 1], axes[0, 2]], [25, 50, 100]):
@@ -232,14 +260,10 @@ def main():
             s = data["summary"]
             cc_key = f"convergence_cost_{radius}m"
             if s and cc_key in s:
-                costs = s[cc_key]
+                cc_val = compute_cc_values(s, data["distances"], args.normalize_convergence, [radius])[0]
                 if args.normalize_convergence:
-                    path_lengths = [d[-1] for d in data["distances"]]
-                    normed = [c / l for c, l in zip(costs, path_lengths) if l > 0]
-                    cc_val = np.mean(normed) if normed else None
-                    cc_str = f", nCC={cc_val:.2f}" if cc_val is not None else ""
+                    cc_str = f", nCC={cc_val:.2f}" if not np.isnan(cc_val) else ""
                 else:
-                    cc_val = np.mean(costs)
                     cc_str = f", CC={cc_val:.0f}"
             else:
                 cc_str = ""
@@ -288,7 +312,7 @@ def main():
 
     # Bottom middle: path survival
     ax = axes[1, 1]
-    # All runs share the same paths, so just use the first one
+    # All runs share the same evaluation paths, so just use the first one
     first_data = next(iter(run_data.values()))
     survival = compute_path_survival(first_data["distances"], distance_bins)
     ax.plot(distance_bins, survival, linewidth=2, color="black")
@@ -313,15 +337,7 @@ def main():
             table_data.append([label, "N/A", "", "", ""])
             continue
         err = s["average_final_error"]
-        cc_vals = []
-        for radius in [25, 50, 100]:
-            costs = s.get(f"convergence_cost_{radius}m", [float("nan")])
-            if args.normalize_convergence:
-                path_lengths = [d[-1] for d in data["distances"]]
-                normed = [c / l for c, l in zip(costs, path_lengths) if l > 0]
-                cc_vals.append(np.mean(normed) if normed else float("nan"))
-            else:
-                cc_vals.append(np.mean(costs))
+        cc_vals = compute_cc_values(s, data["distances"], args.normalize_convergence)
         if args.normalize_convergence:
             table_data.append([label, f"{err:.1f}", f"{cc_vals[0]:.2f}", f"{cc_vals[1]:.2f}", f"{cc_vals[2]:.2f}"])
         else:
@@ -349,15 +365,7 @@ def main():
             print(f"{label:<40} {'N/A':>8}")
             continue
         err = s["average_final_error"]
-        cc_vals = []
-        for radius in [25, 50, 100]:
-            costs = s.get(f"convergence_cost_{radius}m", [float("nan")])
-            if args.normalize_convergence:
-                path_lengths = [d[-1] for d in data["distances"]]
-                normed = [c / l for c, l in zip(costs, path_lengths) if l > 0]
-                cc_vals.append(np.mean(normed) if normed else float("nan"))
-            else:
-                cc_vals.append(np.mean(costs))
+        cc_vals = compute_cc_values(s, data["distances"], args.normalize_convergence)
         if args.normalize_convergence:
             print(f"{label:<40} {err:>8.2f} {cc_vals[0]:>8.3f} {cc_vals[1]:>8.3f} {cc_vals[2]:>8.3f}")
         else:

--- a/experimental/overhead_matching/swag/analysis/compare_histogram_evaluations.py
+++ b/experimental/overhead_matching/swag/analysis/compare_histogram_evaluations.py
@@ -58,14 +58,10 @@ def collect_path_data(eval_path: Path, num_paths: int):
                         (distance[:min_len], prob_mass_np[:min_len])
                     )
         except FileNotFoundError as e:
-            print(f"  Warning: skipping path {i} — missing file: {e.filename}")
-            continue
-
-    if not all_errors:
-        raise ValueError(
-            f"No valid path data found in {eval_path}. "
-            f"Expected subdirectories like 0000000/ with distance_traveled_m.pt and error.pt"
-        )
+            raise FileNotFoundError(
+                f"Path {i} directory exists but is missing {e.filename}. "
+                f"This may indicate a partially completed evaluation run."
+            ) from e
 
     return all_prob_mass, all_errors, all_distances
 

--- a/experimental/overhead_matching/swag/analysis/correspondence_explorer.py
+++ b/experimental/overhead_matching/swag/analysis/correspondence_explorer.py
@@ -145,6 +145,10 @@ HTML_TEMPLATE = '''
             <button onclick="navigate(-1)">&#9664;</button>
             <select id="pano-select" onchange="loadPanorama(this.value)"></select>
             <button onclick="navigate(1)">&#9654;</button>
+            <input type="text" id="pano-search" placeholder="Search pano ID..."
+                   style="padding:6px 10px;border-radius:4px;border:1px solid #ccc;font-size:13px;width:180px;"
+                   onkeydown="if(event.key==='Enter')searchPano()">
+            <button onclick="searchPano()">Go</button>
             <span id="pano-counter" style="font-size:12px;color:#666;"></span>
         </div>
         <div class="controls">
@@ -160,10 +164,11 @@ HTML_TEMPLATE = '''
                 <option value="log_odds">Log Odds</option>
             </select>
             <label>Thresh:</label>
-            <input type="range" id="threshold-slider" min="0" max="0.9" step="0.05" value="0.3"
+            <input type="range" id="threshold-slider" min="0" max="0.9" step="0.05" value="0.8"
                    oninput="document.getElementById('threshold-val').textContent=this.value">
-            <span id="threshold-val" style="font-size:12px;width:30px;">0.3</span>
+            <span id="threshold-val" style="font-size:12px;width:30px;">0.8</span>
             <button onclick="recomputeScores()" style="background:#2e7d32;">Recompute</button>
+            <label style="margin-left:12px;"><input type="checkbox" id="show-zeros" onchange="recomputeScores()"> Show zero patches</label>
         </div>
         <div class="metrics-bar" id="metrics-bar"></div>
     </div>
@@ -243,6 +248,23 @@ HTML_TEMPLATE = '''
             loadPanorama(panoIds[currentPanoIdx]);
         }
 
+        function searchPano() {
+            const query = document.getElementById('pano-search').value.trim();
+            if (!query) return;
+            // Exact match first, then substring match
+            let idx = panoIds.indexOf(query);
+            if (idx === -1) {
+                idx = panoIds.findIndex(id => id.includes(query));
+            }
+            if (idx !== -1) {
+                document.getElementById('pano-select').value = panoIds[idx];
+                loadPanorama(panoIds[idx]);
+                document.getElementById('pano-search').style.borderColor = '#ccc';
+            } else {
+                document.getElementById('pano-search').style.borderColor = '#c00';
+            }
+        }
+
         function loadPanorama(panoId) {
             currentPanoId = panoId;
             currentPanoIdx = panoIds.indexOf(panoId);
@@ -281,6 +303,7 @@ HTML_TEMPLATE = '''
                 method: document.getElementById('method-select').value,
                 aggregation: document.getElementById('agg-select').value,
                 prob_threshold: parseFloat(document.getElementById('threshold-slider').value),
+                show_zeros: document.getElementById('show-zeros').checked ? '1' : '0',
             };
         }
 
@@ -326,12 +349,14 @@ HTML_TEMPLATE = '''
             const maxScore = Math.max(...scores.filter(s => s > 0), 0.001);
 
             // Add satellite markers
+            const showZeros = document.getElementById('show-zeros').checked;
             sats.forEach(s => {
-                if (s.score <= 0 && !s.is_positive) return;  // skip zero-score non-positives
+                if (s.score <= 0 && !s.is_positive && !showZeros) return;
+                const isZero = s.score <= 0 && !s.is_positive;
                 const t = Math.min(s.score / maxScore, 1.0);
-                const color = viridisColor(t);
-                const radius = s.is_positive ? 7 : 4 + t * 4;
-                const opacity = s.is_positive ? 0.9 : 0.3 + t * 0.6;
+                const color = isZero ? '#888' : viridisColor(t);
+                const radius = s.is_positive ? 7 : isZero ? 3 : 4 + t * 4;
+                const opacity = s.is_positive ? 0.9 : isZero ? 0.4 : 0.3 + t * 0.6;
 
                 const marker = L.circleMarker([s.lat, s.lon], {
                     radius: radius,
@@ -340,7 +365,7 @@ HTML_TEMPLATE = '''
                     fillOpacity: opacity,
                     weight: s.is_positive ? 2 : 1,
                 });
-                marker.bindTooltip(`#${s.rank+1} score=${s.score.toFixed(3)}${s.is_positive ? ' ✓' : ''} (${s.n_landmarks} lm)`,
+                marker.bindTooltip(`#${s.rank+1} score=${s.score.toFixed(3)}${s.is_positive ? ' ✓' : ''}${isZero ? ' (zero)' : ''} (${s.n_landmarks} lm)`,
                     {direction: 'top'});
                 marker.on('click', () => loadSatDetail(s.sat_idx, s.rank, s.score, s.is_positive));
                 marker.addTo(satMap);
@@ -355,8 +380,9 @@ HTML_TEMPLATE = '''
             panoMarker.bindTooltip('Panorama', {permanent: true, direction: 'top'});
 
             // Fit bounds
-            const allLats = sats.filter(s => s.score > 0 || s.is_positive).map(s => s.lat).concat([data.pano_lat]);
-            const allLons = sats.filter(s => s.score > 0 || s.is_positive).map(s => s.lon).concat([data.pano_lon]);
+            const visibleSats = sats.filter(s => s.score > 0 || s.is_positive || showZeros);
+            const allLats = visibleSats.map(s => s.lat).concat([data.pano_lat]);
+            const allLons = visibleSats.map(s => s.lon).concat([data.pano_lon]);
             if (allLats.length > 0) {
                 satMap.fitBounds([[Math.min(...allLats), Math.min(...allLons)],
                                   [Math.max(...allLats), Math.max(...allLons)]],
@@ -850,6 +876,15 @@ def get_satellite_scores(pano_id):
     top_500 = set(ranking[:500].tolist())
     include_set = top_500 | positive_set | set(np.where(nonzero_mask)[0].tolist())
 
+    # Optionally include all zero-score satellites that have landmarks
+    show_zeros = params.get('show_zeros', '0') == '1'
+    if show_zeros:
+        for sat_idx in range(num_sats):
+            if sat_idx in include_set:
+                continue
+            if SAT_TO_COL_POSITIONS[sat_idx]:
+                include_set.add(sat_idx)
+
     satellites = []
     for sat_idx in include_set:
         sat_idx = int(sat_idx)
@@ -1037,9 +1072,23 @@ def main():
     for idx, (_, row) in enumerate(VIGOR_DATASET._panorama_metadata.iterrows()):
         PANO_ID_TO_VIGOR_IDX[row['pano_id']] = idx
 
-    PANO_ID_LIST = [pid for pid in RAW_DATA.pano_id_to_lm_rows.keys()
-                    if pid in PANO_ID_TO_VIGOR_IDX]
-    print(f"  {len(PANO_ID_LIST)} panoramas with cost data")
+    # Order by trajectory using pano_id_mapping.csv if available
+    valid_pano_ids = {pid for pid in RAW_DATA.pano_id_to_lm_rows.keys()
+                      if pid in PANO_ID_TO_VIGOR_IDX}
+    mapping_csv = dataset_path / "pano_id_mapping.csv"
+    if mapping_csv.exists():
+        import csv
+        with open(mapping_csv) as f:
+            reader = csv.DictReader(f)
+            trajectory_order = [row['pano_id'] for row in reader]
+        PANO_ID_LIST = [pid for pid in trajectory_order if pid in valid_pano_ids]
+        # Add any remaining not in mapping
+        remaining = valid_pano_ids - set(PANO_ID_LIST)
+        PANO_ID_LIST.extend(sorted(remaining))
+        print(f"  {len(PANO_ID_LIST)} panoramas with cost data (trajectory order)")
+    else:
+        PANO_ID_LIST = sorted(valid_pano_ids)
+        print(f"  {len(PANO_ID_LIST)} panoramas with cost data")
 
     # 4. Pre-build sat → col positions
     osm_idx_to_col = {idx: col for col, idx in enumerate(RAW_DATA.osm_lm_indices)}

--- a/experimental/overhead_matching/swag/model/semantic_landmark_extractor.py
+++ b/experimental/overhead_matching/swag/model/semantic_landmark_extractor.py
@@ -676,7 +676,12 @@ You are an expert at identifying landmarks in street-level imagery and mapping t
 </role>
 
 <instructions>
-Given four images which show the same location from yaws 0°, 90°, 180°, and 270° respectively, identify distinctive, permanent landmarks and classify them using OSM's key=value tagging system.
+Given four images which show the same location from yaws 0° (facing north), 90° (facing west), 180° (facing south), and 270° (facing east) respectively, identify distinctive, permanent landmarks and classify them using OSM's key=value tagging system.
+
+Your workflow should be:
+ 1. Analyze the images for any visually distinctive landmarks and useful signs. Summarize what you have found.
+ 2. Identify what OSM tags are appropriate and justifiable for each identified landmark.
+ 3. Report your results using the specified JSON schema.
 
 For each landmark:
 - Assign a primary OSM tag (e.g., amenity=cafe, shop=pharmacy, building=apartments)
@@ -685,9 +690,37 @@ For each landmark:
 - Rate your confidence (high/medium/low)
 - Provide a brief description
 
+If you cannot confidently identify any visually distinct landmarks, it is acceptable to return an empty list of landmarks.
 Based on the images, classify the location type (e.g., urban_commercial, suburban, rural).
-- If street name signs are readable, include them as highway landmarks with appropriate tags (e.g., highway=tertiary, name=James Street), but ONLY if they are readable.
+Finally, review your work and confirm you have not included any information you cannot confidently make out from the images.
 </instructions>
+
+<landmark_selection>
+Focus on landmarks that are VISUALLY DISTINCTIVE and useful for identifying a specific location. Prioritize:
+- Readable street names on signs (e.g., "Adams St", "Michigan Ave") — these are extremely
+  informative for localization. Tag the street itself: highway=residential (or service,
+  tertiary, secondary, primary depending on size) with name=<street name> but ONLY if the name is clearly readable.
+- Named businesses, restaurants, shops with visible signage
+- Branded locations (gas stations, chain stores, banks)
+- Architecturally unique buildings (churches, historic buildings)
+- Named parks, monuments, public art, memorials
+- Distinctive infrastructure (clock towers, unique bridges)
+
+DO NOT include generic, ubiquitous features such as:
+- Traffic signals, street lamps, fire hydrants
+- Crosswalks, stop signs, generic road markings
+- Plain sidewalks, curbs, gutters
+- Trees, bushes, or grass unless they are a notable landmark (e.g., a named park)
+- Apartment buildings or residential complexes, even if visually distinctive — these are
+  rarely represented in the map data and are not useful for localization
+- Generic buildings described only by their appearance (e.g., "a multi-story brick building",
+  "a low-rise commercial building"). Only include a building if you can identify at least one of:
+  - A readable building number or address
+  - A visible name or sign on the building
+  - A well-known or historically significant building (e.g., Willis Tower, Chicago Stock Exchange)
+
+The goal is to identify landmarks that distinguish THIS location from others, not to catalog every object in the scene.
+</landmark_selection>
 
 <osm_tag_guidelines>
 ## Primary OSM Tag Categories
@@ -699,7 +732,7 @@ Based on the images, classify the location type (e.g., urban_commercial, suburba
 - `leisure`: recreation (parks, playgrounds, sports facilities)
 - `office`: professional services (lawyer, accountant, insurance)
 - `craft`: custom workshops (carpenter, tailor, jeweller)
-- `highway`: roads and road infrastructure (residential, tertiary, secondary, primary, trunk; also traffic_signals, crossing, bus_stop, street_lamp)
+- `highway`: roads and bus stops (residential, tertiary, secondary, primary, service, bus_stop)
 - `man_made`: non-building structures (towers, piers, bridges, chimneys, water towers)
 - `historic`: historically significant features (monuments, memorials, ruins)
 - `natural`: natural features (trees, water bodies)
@@ -718,10 +751,10 @@ For chains, include both category and brand:
 </osm_tag_guidelines>
 
 <constraints>
-- Focus on OSM-mappable features within 100 meters, don't include street lamps and fire hydrants.
+- Focus on OSM-mappable features within ~80 meters, don't include street lamps and fire hydrants.
 - Extract visible text for name/brand tags only if clearly readable
 - Be conservative: only output tags you can confidently identify
-- Exclude transient objects (cars, pedestrians, temporary items)
+- Exclude transient objects (cars, pedestrians, temporary items, construction areas)
 - Do NOT extract text from billboards, advertisement banners (e.g., on lampposts), or other commercial advertisements — these are temporary and not OSM-mappable
 - Do not mention location in image or relative to other landmarks
 </constraints>

--- a/experimental/overhead_matching/swag/scripts/panorama_viewer.py
+++ b/experimental/overhead_matching/swag/scripts/panorama_viewer.py
@@ -2494,6 +2494,7 @@ def find_common_panoramas(panorama_dir, pinhole_dir, pano_sentences, dataset_pat
     print(f"  Scanned {len(pinhole_dirs)} pinhole directories in {time.time()-t2:.1f}s")
 
     # Find intersection — require panorama image + pinhole dir, but not sentence data
+    # (so we can browse panoramas that have no extracted landmarks)
     common_ids = set(pano_files.keys()) & set(pinhole_dirs.keys())
     with_landmarks = common_ids & set(pano_sentences.keys())
     print(f"  Found {len(common_ids)} panoramas with both panorama image and pinhole dir "

--- a/experimental/overhead_matching/swag/scripts/panorama_viewer.py
+++ b/experimental/overhead_matching/swag/scripts/panorama_viewer.py
@@ -2493,9 +2493,11 @@ def find_common_panoramas(panorama_dir, pinhole_dir, pano_sentences, dataset_pat
     pinhole_dirs = {d.name.split(',')[0]: d for d in pinhole_path.iterdir() if d.is_dir()}
     print(f"  Scanned {len(pinhole_dirs)} pinhole directories in {time.time()-t2:.1f}s")
 
-    # Find intersection with sentence data
-    common_ids = set(pano_files.keys()) & set(pinhole_dirs.keys()) & set(pano_sentences.keys())
-    print(f"  Found {len(common_ids)} panoramas present in all locations")
+    # Find intersection — require panorama image + pinhole dir, but not sentence data
+    common_ids = set(pano_files.keys()) & set(pinhole_dirs.keys())
+    with_landmarks = common_ids & set(pano_sentences.keys())
+    print(f"  Found {len(common_ids)} panoramas present in all locations "
+          f"({len(with_landmarks)} with landmarks, {len(common_ids) - len(with_landmarks)} without)")
 
     # Determine ordering: use pano_id_mapping.csv if available (sequential capture order)
     ordered_ids = None

--- a/experimental/overhead_matching/swag/scripts/panorama_viewer.py
+++ b/experimental/overhead_matching/swag/scripts/panorama_viewer.py
@@ -2496,7 +2496,7 @@ def find_common_panoramas(panorama_dir, pinhole_dir, pano_sentences, dataset_pat
     # Find intersection — require panorama image + pinhole dir, but not sentence data
     common_ids = set(pano_files.keys()) & set(pinhole_dirs.keys())
     with_landmarks = common_ids & set(pano_sentences.keys())
-    print(f"  Found {len(common_ids)} panoramas present in all locations "
+    print(f"  Found {len(common_ids)} panoramas with both panorama image and pinhole dir "
           f"({len(with_landmarks)} with landmarks, {len(common_ids) - len(with_landmarks)} without)")
 
     # Determine ordering: use pano_id_mapping.csv if available (sequential capture order)

--- a/experimental/overhead_matching/swag/scripts/step_through_histogram.py
+++ b/experimental/overhead_matching/swag/scripts/step_through_histogram.py
@@ -534,6 +534,12 @@ def main():
             html.Div([
                 html.Button('Previous', id='prev-btn', n_clicks=0),
                 html.Button('Next', id='next-btn', n_clicks=0),
+                dcc.Checklist(
+                    id='skip-motion-check',
+                    options=[{'label': ' Skip motion steps', 'value': 'skip'}],
+                    value=['skip'],
+                    style={'display': 'inline-block', 'marginLeft': '20px'},
+                ),
                 html.Span(id='step-info', style={'marginLeft': '20px'}),
             ], style={'textAlign': 'center', 'margin': '10px'}),
         ], id='step-controls'),
@@ -561,6 +567,24 @@ def main():
         # Minimal client-side state (just path index and step count)
         dcc.Store(id='path-metadata-store'),
     ])
+
+    # Arrow key navigation via clientside callback
+    app.clientside_callback(
+        """
+        function(id) {
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'ArrowLeft') {
+                    document.getElementById('prev-btn').click();
+                } else if (e.key === 'ArrowRight') {
+                    document.getElementById('next-btn').click();
+                }
+            });
+            return window.dash_clientside.no_update;
+        }
+        """,
+        Output('step-slider', 'id'),  # dummy output
+        Input('step-slider', 'id'),   # triggers once on load
+    )
 
     @app.callback(
         [Output('path-metadata-store', 'data'),
@@ -625,25 +649,52 @@ def main():
 
         print(f"Loaded path {path_idx} with {num_steps} steps")
 
+        # Compute obs step indices (init + observation steps, not motion steps)
+        obs_step_indices = []
+        for i, h in enumerate(history):
+            if h['stage'] == 'init' or h['stage'].startswith('obs_'):
+                obs_step_indices.append(i)
+
         # Only send minimal metadata to browser
-        return {'path_idx': path_idx, 'num_steps': num_steps}, num_steps - 1, marks, 0
+        return {
+            'path_idx': path_idx,
+            'num_steps': num_steps,
+            'obs_step_indices': obs_step_indices,
+        }, num_steps - 1, marks, 0
 
     @app.callback(
         Output('step-slider', 'value', allow_duplicate=True),
         [Input('prev-btn', 'n_clicks'),
          Input('next-btn', 'n_clicks')],
         [State('step-slider', 'value'),
-         State('step-slider', 'max')],
+         State('step-slider', 'max'),
+         State('skip-motion-check', 'value'),
+         State('path-metadata-store', 'data')],
         prevent_initial_call=True
     )
-    def update_slider(prev_clicks, next_clicks, current_value, max_value):
+    def update_slider(prev_clicks, next_clicks, current_value, max_value,
+                      skip_motion_value, metadata):
         ctx = dash.callback_context
         if not ctx.triggered:
             return current_value
+
+        skip_motion = 'skip' in (skip_motion_value or [])
+        obs_steps = None
+        if skip_motion and metadata and 'obs_step_indices' in metadata:
+            obs_steps = metadata['obs_step_indices']
+
         button_id = ctx.triggered[0]['prop_id'].split('.')[0]
         if button_id == 'prev-btn' and current_value > 0:
+            if obs_steps:
+                # Find the largest obs step index strictly less than current_value
+                prev_obs = [s for s in obs_steps if s < current_value]
+                return prev_obs[-1] if prev_obs else current_value
             return current_value - 1
         elif button_id == 'next-btn' and current_value < max_value:
+            if obs_steps:
+                # Find the smallest obs step index strictly greater than current_value
+                next_obs = [s for s in obs_steps if s > current_value]
+                return next_obs[0] if next_obs else current_value
             return current_value + 1
         return current_value
 
@@ -699,149 +750,199 @@ def main():
         # Create heatmap data
         _t0 = _time.time()
         belief_data, lat_coords, lon_coords = create_belief_heatmap(log_belief, grid_spec, args.downsample_heatmap)
-        print(f"  Heatmap data: {belief_data.shape}, {_time.time() - _t0:.2f}s")
+        _t_belief = _time.time() - _t0
 
-        # Create subplots
-        fig = make_subplots(
-            rows=1, cols=2,
-            subplot_titles=[f'Full View - Path {path_idx}', 'Zoomed View'],
-            horizontal_spacing=0.1,
-        )
+        # Compute zoom center and extent (used for zoomed panels)
+        center_lat = (gt_positions[gt_idx, 0] + mean[0]) / 2
+        center_lon = (gt_positions[gt_idx, 1] + mean[1]) / 2
+        zoom_size = 0.015
 
-        # Heatmap for full view
-        fig.add_trace(
-            go.Heatmap(
-                z=belief_data,
-                x=lon_coords,
-                y=lat_coords,
-                colorscale='Hot',
-                showscale=False,
-                opacity=0.7,
-            ),
-            row=1, col=1
-        )
+        def crop_heatmap(z, lats, lons, clat, clon, size):
+            """Crop heatmap data to zoom window, returns (z_crop, lats_crop, lons_crop)."""
+            lats_arr = np.array(lats)
+            lons_arr = np.array(lons)
+            lat_mask = (lats_arr >= clat - size) & (lats_arr <= clat + size)
+            lon_mask = (lons_arr >= clon - size) & (lons_arr <= clon + size)
+            if not lat_mask.any() or not lon_mask.any():
+                return z, lats, lons
+            z_crop = z[np.ix_(lat_mask, lon_mask)] if isinstance(z, np.ndarray) else z
+            return z_crop, lats_arr[lat_mask].tolist(), lons_arr[lon_mask].tolist()
 
-        # Satellite patches — color by obs likelihood on obs steps (unless simple mode)
-        if not simple_mode and obs_log_ll is not None:
+        # Prepare obs likelihood heatmap data
+        _t0 = _time.time()
+        has_obs = not simple_mode and obs_log_ll is not None
+        obs_heatmap_data = None
+        obs_lat_coords = None
+        obs_lon_coords = None
+        if has_obs:
             ll_np = obs_log_ll.numpy()
-            n_pts = len(ll_np)
-            max_scatter = args.downsample_scatter
-            if max_scatter is not None and n_pts > max_scatter:
-                # Keep top-k by likelihood + uniform subsample for coverage
-                top_k = max_scatter // 2
-                top_indices = np.argpartition(ll_np, -top_k)[-top_k:]
-                remaining = np.setdiff1d(np.arange(n_pts), top_indices)
-                uniform_indices = remaining[np.linspace(0, len(remaining) - 1,
-                                                        max_scatter - top_k, dtype=int)]
-                scatter_idx = np.concatenate([top_indices, uniform_indices])
-                scatter_idx.sort()
+            # Satellites are on a regular grid — reshape directly
+            lats = sat_positions[:, 0]
+            lons = sat_positions[:, 1]
+            unique_lats = np.sort(np.unique(lats))
+            unique_lons = np.sort(np.unique(lons))
+            n_rows, n_cols = len(unique_lats), len(unique_lons)
+            if n_rows * n_cols == len(ll_np):
+                # Perfect grid — use argsort to map each point to its grid cell
+                lat_order = np.argsort(lats)
+                # Sort by lat then lon to get row-major grid
+                sorted_idx = np.lexsort((lons, lats))
+                obs_heatmap_data = ll_np[sorted_idx].reshape(n_rows, n_cols)
+                obs_lat_coords = unique_lats.tolist()
+                obs_lon_coords = unique_lons.tolist()
             else:
-                scatter_idx = np.arange(n_pts)
-            for subplot_col, marker_size in [(1, 3), (2, 5)]:
-                fig.add_trace(
-                    go.Scatter(
-                        x=sat_positions[scatter_idx, 1],
-                        y=sat_positions[scatter_idx, 0],
-                        mode='markers',
-                        marker=dict(
-                            size=marker_size,
-                            color=ll_np[scatter_idx],
-                            colorscale='Viridis',
-                            opacity=0.6,
-                            showscale=(subplot_col == 2),
-                            colorbar=dict(title='Log LL') if subplot_col == 2 else None,
-                        ),
-                        name='Obs likelihood' if subplot_col == 1 else None,
-                        showlegend=(subplot_col == 1),
-                    ),
-                    row=1, col=subplot_col
-                )
+                # Irregular grid — fall back to binning
+                grid_dim = max(n_rows, n_cols)
+                lat_bins = np.linspace(lats.min(), lats.max(), grid_dim + 1)
+                lon_bins = np.linspace(lons.min(), lons.max(), grid_dim + 1)
+                lat_bin_idx = np.clip(np.digitize(lats, lat_bins) - 1, 0, grid_dim - 1)
+                lon_bin_idx = np.clip(np.digitize(lons, lon_bins) - 1, 0, grid_dim - 1)
+                obs_grid = np.full((grid_dim, grid_dim), np.nan)
+                for i in range(len(ll_np)):
+                    r, c = lat_bin_idx[i], lon_bin_idx[i]
+                    if np.isnan(obs_grid[r, c]) or ll_np[i] > obs_grid[r, c]:
+                        obs_grid[r, c] = ll_np[i]
+                obs_heatmap_data = obs_grid
+                obs_lat_coords = ((lat_bins[:-1] + lat_bins[1:]) / 2).tolist()
+                obs_lon_coords = ((lon_bins[:-1] + lon_bins[1:]) / 2).tolist()
+
+        # Create 2x2 subplots
+        _t_obs = _time.time() - _t0
+
+        _t0 = _time.time()
+        fig = make_subplots(
+            rows=2, cols=2,
+            subplot_titles=[
+                'Obs Likelihood (full)', 'Obs Likelihood (zoomed)',
+                f'Belief - Path {path_idx} (full)', 'Belief (zoomed)',
+            ],
+            horizontal_spacing=0.08,
+            vertical_spacing=0.1,
+        )
+
+        # --- Top-left (1,1): Obs likelihood heatmap full view ---
+        if has_obs:
+            fig.add_trace(
+                go.Heatmap(
+                    z=obs_heatmap_data,
+                    x=obs_lon_coords,
+                    y=obs_lat_coords,
+                    colorscale='Viridis',
+                    showscale=True,
+                    colorbar=dict(title='Log LL', x=0.45, len=0.45, y=0.78),
+                    opacity=0.8,
+                    hovertemplate='lat=%{y:.4f}<br>lon=%{x:.4f}<br>log LL=%{z:.2f}<extra></extra>',
+                ),
+                row=1, col=1
+            )
         else:
-            step_size = max(1, len(sat_positions) // 500)
-            for subplot_col, marker_size in [(1, 3), (2, 5)]:
+            fig.add_annotation(
+                text="No observation at this step",
+                xref="x1", yref="y1",
+                x=0.5, y=0.5, xanchor="center", yanchor="middle",
+                showarrow=False, font=dict(size=14, color="gray"),
+            )
+
+        # --- Top-right (1,2): Obs likelihood heatmap zoomed ---
+        if has_obs:
+            obs_z_crop, obs_lat_crop, obs_lon_crop = crop_heatmap(
+                obs_heatmap_data, obs_lat_coords, obs_lon_coords,
+                center_lat, center_lon, zoom_size)
+            fig.add_trace(
+                go.Heatmap(
+                    z=obs_z_crop,
+                    x=obs_lon_crop,
+                    y=obs_lat_crop,
+                    colorscale='Viridis',
+                    showscale=False,
+                    opacity=0.8,
+                    hovertemplate='lat=%{y:.4f}<br>lon=%{x:.4f}<br>log LL=%{z:.2f}<extra></extra>',
+                ),
+                row=1, col=2
+            )
+
+        # Add GT path + markers to top row
+        for col in [1, 2]:
+            if has_obs or col == 1:
                 fig.add_trace(
                     go.Scatter(
-                        x=sat_positions[::step_size, 1],
-                        y=sat_positions[::step_size, 0],
-                        mode='markers',
-                        marker=dict(size=marker_size, color='lightblue', opacity=0.3 if subplot_col == 1 else 0.5),
-                        name='Sat patches' if subplot_col == 1 else None,
-                        showlegend=(subplot_col == 1),
-                    ),
-                    row=1, col=subplot_col
+                        x=gt_positions[:gt_idx+1, 1], y=gt_positions[:gt_idx+1, 0],
+                        mode='lines+markers', line=dict(color='green', width=2),
+                        marker=dict(size=5), showlegend=(col == 1), name='GT path' if col == 1 else None,
+                    ), row=1, col=col
+                )
+                fig.add_trace(
+                    go.Scatter(
+                        x=[gt_positions[gt_idx, 1]], y=[gt_positions[gt_idx, 0]],
+                        mode='markers', marker=dict(size=15, color='green', symbol='star'),
+                        showlegend=(col == 1), name='GT current' if col == 1 else None,
+                    ), row=1, col=col
+                )
+                fig.add_trace(
+                    go.Scatter(
+                        x=[mean[1]], y=[mean[0]],
+                        mode='markers', marker=dict(size=15, color='red', symbol='x'),
+                        showlegend=(col == 1), name='Estimate' if col == 1 else None,
+                    ), row=1, col=col
                 )
 
-        # GT path up to current position
-        fig.add_trace(
-            go.Scatter(
-                x=gt_positions[:gt_idx+1, 1],
-                y=gt_positions[:gt_idx+1, 0],
-                mode='lines+markers',
-                line=dict(color='green', width=2),
-                marker=dict(size=5),
-                name='GT path',
-            ),
-            row=1, col=1
-        )
-
-        # Current GT position
-        fig.add_trace(
-            go.Scatter(
-                x=[gt_positions[gt_idx, 1]],
-                y=[gt_positions[gt_idx, 0]],
-                mode='markers',
-                marker=dict(size=15, color='green', symbol='star'),
-                name='GT current',
-            ),
-            row=1, col=1
-        )
-
-        # Estimate
-        fig.add_trace(
-            go.Scatter(
-                x=[mean[1]],
-                y=[mean[0]],
-                mode='markers',
-                marker=dict(size=15, color='red', symbol='x'),
-                name='Estimate',
-            ),
-            row=1, col=1
-        )
-
-        # Zoomed view (same traces)
+        # --- Bottom-left (2,1): Belief heatmap full view ---
         fig.add_trace(
             go.Heatmap(
-                z=belief_data,
-                x=lon_coords,
-                y=lat_coords,
-                colorscale='Hot',
-                showscale=True,
+                z=belief_data, x=lon_coords, y=lat_coords,
+                colorscale='Hot', showscale=False, opacity=0.7,
+            ), row=2, col=1
+        )
+
+        # GT path on belief full view
+        fig.add_trace(
+            go.Scatter(
+                x=gt_positions[:gt_idx+1, 1], y=gt_positions[:gt_idx+1, 0],
+                mode='lines+markers', line=dict(color='green', width=2),
+                marker=dict(size=5), showlegend=False,
+            ), row=2, col=1
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=[gt_positions[gt_idx, 1]], y=[gt_positions[gt_idx, 0]],
+                mode='markers', marker=dict(size=15, color='green', symbol='star'),
+                showlegend=False,
+            ), row=2, col=1
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=[mean[1]], y=[mean[0]],
+                mode='markers', marker=dict(size=15, color='red', symbol='x'),
+                showlegend=False,
+            ), row=2, col=1
+        )
+
+        # --- Bottom-right (2,2): Belief heatmap zoomed ---
+        bel_z_crop, bel_lat_crop, bel_lon_crop = crop_heatmap(
+            belief_data, lat_coords, lon_coords,
+            center_lat, center_lon, zoom_size)
+        fig.add_trace(
+            go.Heatmap(
+                z=bel_z_crop, x=bel_lon_crop, y=bel_lat_crop,
+                colorscale='Hot', showscale=True,
+                colorbar=dict(title='Belief', x=1.0, len=0.45, y=0.22),
                 opacity=0.7,
-            ),
-            row=1, col=2
+            ), row=2, col=2
         )
 
         fig.add_trace(
             go.Scatter(
-                x=gt_positions[:gt_idx+1, 1],
-                y=gt_positions[:gt_idx+1, 0],
-                mode='lines+markers',
-                line=dict(color='green', width=2),
-                marker=dict(size=8),
-                showlegend=False,
-            ),
-            row=1, col=2
+                x=gt_positions[:gt_idx+1, 1], y=gt_positions[:gt_idx+1, 0],
+                mode='lines+markers', line=dict(color='green', width=2),
+                marker=dict(size=8), showlegend=False,
+            ), row=2, col=2
         )
-
         fig.add_trace(
             go.Scatter(
-                x=[gt_positions[gt_idx, 1]],
-                y=[gt_positions[gt_idx, 0]],
-                mode='markers',
-                marker=dict(size=20, color='green', symbol='star'),
+                x=[gt_positions[gt_idx, 1]], y=[gt_positions[gt_idx, 0]],
+                mode='markers', marker=dict(size=20, color='green', symbol='star'),
                 showlegend=False,
-            ),
-            row=1, col=2
+            ), row=2, col=2
         )
 
         fig.add_trace(
@@ -852,22 +953,22 @@ def main():
                 marker=dict(size=20, color='red', symbol='x'),
                 showlegend=False,
             ),
-            row=1, col=2
+            row=2, col=2
         )
 
-        # Set zoom for right plot
-        center_lat = (gt_positions[gt_idx, 0] + mean[0]) / 2
-        center_lon = (gt_positions[gt_idx, 1] + mean[1]) / 2
-        zoom_size = 0.015
-
+        # Set zoom for right column (top-right and bottom-right)
         fig.update_xaxes(range=[center_lon - zoom_size, center_lon + zoom_size], row=1, col=2)
         fig.update_yaxes(range=[center_lat - zoom_size, center_lat + zoom_size], row=1, col=2)
+        fig.update_xaxes(range=[center_lon - zoom_size, center_lon + zoom_size], row=2, col=2)
+        fig.update_yaxes(range=[center_lat - zoom_size, center_lat + zoom_size], row=2, col=2)
 
         fig.update_layout(
-            height=600,
+            height=900,
             showlegend=True,
             legend=dict(x=0.01, y=0.99),
         )
+
+        _t_fig = _time.time() - _t0
 
         # Compute error
         error_deg = np.sqrt((mean[0] - gt_positions[gt_idx, 0])**2 +
@@ -876,6 +977,7 @@ def main():
 
         info = f"Path {path_idx} | Stage: {stage} | GT idx: {gt_idx} | Error: {error_m:.1f}m"
 
+        _t0 = _time.time()
         # Load panorama and top satellite patches (skip in simple mode)
         if simple_mode:
             pano_src = ""
@@ -915,7 +1017,12 @@ def main():
                 patch_children = [html.Div("No observation at this step", style={'color': 'gray', 'fontStyle': 'italic'})]
                 patches_title = "Top Satellite Patches by Observation Likelihood"
 
-        print(f"  Total update_plot: {_time.time() - _t_start:.2f}s")
+        _t_images = _time.time() - _t0
+        _t_total = _time.time() - _t_start
+        import sys
+        print(f"  Timing: belief_heatmap={_t_belief:.2f}s obs_heatmap={_t_obs:.2f}s "
+              f"fig_build={_t_fig:.2f}s images={_t_images:.2f}s total={_t_total:.2f}s",
+              file=sys.stderr, flush=True)
         return fig, info, pano_src, pano_title, patch_children, patches_title
 
     print(f"Starting server at http://localhost:{args.port}")

--- a/experimental/overhead_matching/swag/scripts/step_through_histogram.py
+++ b/experimental/overhead_matching/swag/scripts/step_through_histogram.py
@@ -8,6 +8,7 @@ import json
 import argparse
 import io
 import base64
+import sys
 from PIL import Image as PILImage
 
 import dash
@@ -564,7 +565,7 @@ def main():
             ], style={'width': '68%', 'display': 'inline-block', 'verticalAlign': 'top', 'padding': '10px'}),
         ], style={'marginTop': '20px', 'display': 'none' if simple_mode else 'block'}),
 
-        # Minimal client-side state (just path index and step count)
+        # Minimal client-side state (path index, step count, and obs step indices)
         dcc.Store(id='path-metadata-store'),
     ])
 
@@ -783,9 +784,7 @@ def main():
             unique_lons = np.sort(np.unique(lons))
             n_rows, n_cols = len(unique_lats), len(unique_lons)
             if n_rows * n_cols == len(ll_np):
-                # Perfect grid — use argsort to map each point to its grid cell
-                lat_order = np.argsort(lats)
-                # Sort by lat then lon to get row-major grid
+                # Perfect grid — sort by (lat, lon) via lexsort to get row-major order
                 sorted_idx = np.lexsort((lons, lats))
                 obs_heatmap_data = ll_np[sorted_idx].reshape(n_rows, n_cols)
                 obs_lat_coords = unique_lats.tolist()
@@ -1019,7 +1018,6 @@ def main():
 
         _t_images = _time.time() - _t0
         _t_total = _time.time() - _t_start
-        import sys
         print(f"  Timing: belief_heatmap={_t_belief:.2f}s obs_heatmap={_t_obs:.2f}s "
               f"fig_build={_t_fig:.2f}s images={_t_images:.2f}s total={_t_total:.2f}s",
               file=sys.stderr, flush=True)


### PR DESCRIPTION
## Summary
- Update the `osm_tags` prompt in `semantic_landmark_extractor` to filter generic features (traffic signs, crosswalks, generic buildings), add `<landmark_selection>` guidance with prioritized landmark types, and fix highway tag examples to match actual usage (residential, tertiary, secondary, primary, service, bus_stop)
- Rework `compare_histogram_evaluations` plots: drop ended paths from statistics (masked interpolation), add path survival subplot, vertical line at shortest path end, summary table subplot, `--title` flag, and `--normalize-convergence` option

Stacked on #611.

## Test plan
- [x] Re-extracted panov2 landmarks for all 9 mapillary/boston/nightdrive cities + Chicago + Seattle with tuned prompt
- [x] Ran full evaluation pipeline (text embeddings → raw scores → similarity matrices → histogram filter) 
- [x] Generated comparison plots and tables with 90% CI