### PR TITLE
Histogram eval: honor source_px footprint + Wiener odometry scaling

### DIFF
--- a/experimental/overhead_matching/swag/evaluation/odometry_noise.py
+++ b/experimental/overhead_matching/swag/evaluation/odometry_noise.py
@@ -19,11 +19,12 @@ from common.gps.web_mercator import METERS_PER_DEG_LAT
 class OdometryNoiseConfig:
     """Per-step odometry noise applied to each motion delta independently.
 
-    sigma_noise_frac: noise std as fraction of step distance.
+    sigma_noise_frac: noise intensity in m/sqrt(m).
         For a step of d meters, north and east offsets are each
-        sampled from N(0, sigma_noise_frac * d) meters.
+        sampled from N(0, sigma_noise_frac^2 * d) — i.e. variance
+        scales linearly with distance (Wiener process scaling).
     """
-    sigma_noise_frac: float = 0.05    # fraction of step size
+    sigma_noise_frac: float = 0.05    # m/sqrt(m)
     seed: int = 7919
 
     def __post_init__(self):
@@ -97,12 +98,12 @@ def add_noise_to_motion_deltas(
     east_m = deltas_f64[:, 1] * meters_per_deg_lon
     distance = torch.sqrt(north_m ** 2 + east_m ** 2)
 
-    # Sample north/east offsets in meters, proportional to step distance
+    # Sample north/east offsets in meters: variance = sigma_noise_frac^2 * d,
+    # so std = sigma_noise_frac * sqrt(d) (Wiener process scaling)
     N = deltas_f64.shape[0]
-    noise_north_m = torch.randn(N, dtype=torch.float64, device=deltas_f64.device, generator=generator) * (
-        config.sigma_noise_frac * distance)
-    noise_east_m = torch.randn(N, dtype=torch.float64, device=deltas_f64.device, generator=generator) * (
-        config.sigma_noise_frac * distance)
+    std_m = config.sigma_noise_frac * torch.sqrt(distance)
+    noise_north_m = torch.randn(N, dtype=torch.float64, device=deltas_f64.device, generator=generator) * std_m
+    noise_east_m = torch.randn(N, dtype=torch.float64, device=deltas_f64.device, generator=generator) * std_m
 
     # Convert offsets to lat/lon degrees and add to original deltas
     noise_lat = noise_north_m / METERS_PER_DEG_LAT

--- a/experimental/overhead_matching/swag/evaluation/odometry_noise_test.py
+++ b/experimental/overhead_matching/swag/evaluation/odometry_noise_test.py
@@ -113,9 +113,9 @@ class TestNoiseScalesWithStepSize(unittest.TestCase):
         mean_small = sum(errors_small) / len(errors_small)
         mean_large = sum(errors_large) / len(errors_large)
         ratio = mean_large / mean_small
-        # Should be ~2.0 (50/25)
-        self.assertGreater(ratio, 1.5, f"Ratio {ratio:.2f} should be ~2.0")
-        self.assertLess(ratio, 2.5, f"Ratio {ratio:.2f} should be ~2.0")
+        # std ~ sigma * sqrt(d) (Wiener scaling), so ratio for d=50 vs d=25 is ~sqrt(2)=1.41
+        self.assertGreater(ratio, 1.25, f"Ratio {ratio:.2f} should be ~sqrt(2)=1.41")
+        self.assertLess(ratio, 1.6, f"Ratio {ratio:.2f} should be ~sqrt(2)=1.41")
 
 
 class TestNoiseIsIsotropic(unittest.TestCase):

--- a/experimental/overhead_matching/swag/scripts/evaluate_histogram_on_paths.py
+++ b/experimental/overhead_matching/swag/scripts/evaluate_histogram_on_paths.py
@@ -67,8 +67,18 @@ class HistogramFilterConfig:
     initial_offset_std_deg: float = 0.0117  # ~1300m offset
     zoom_level: int = 20
     patch_size_px: int = 640
+    # source_px: actual footprint of each satellite patch in zoom-level pixels.
+    # When satellite images are resolution-normalized (cropped to source_px and
+    # resized to patch_size_px), the ground footprint is source_px, not patch_size_px.
+    # Read from satellite_bbox.json; defaults to patch_size_px (no normalization).
+    source_px: int | None = None
     odometry_noise: OdometryNoiseConfig | None = None  # Optional odometry noise config
     max_chunk_gib: float = 2.0  # Peak GPU memory per chunk for cell-to-patch mapping
+
+    @property
+    def footprint_px(self) -> float:
+        """Ground footprint of each satellite patch in zoom-level pixels."""
+        return float(self.source_px if self.source_px is not None else self.patch_size_px)
 
 
 @dataclass
@@ -267,13 +277,14 @@ def evaluate_histogram_on_paths(
             convergence_costs_by_radius[radius] = []
 
     with torch.no_grad():
-        # Build GridSpec from dataset bounds with buffer of half patch size
+        # Build GridSpec from dataset bounds with buffer of half patch footprint
         min_lat, max_lat, min_lon, max_lon = get_dataset_bounds(vigor_dataset)
-        cell_size_px = config.patch_size_px / config.subdivision_factor
+        footprint_px = config.footprint_px
+        cell_size_px = footprint_px / config.subdivision_factor
 
-        # Add buffer of half patch size (in pixels at zoom level)
+        # Add buffer of half patch footprint (in pixels at zoom level)
         # Convert to degrees using web mercator at the center latitude
-        patch_half_size_px = config.patch_size_px / 2.0
+        patch_half_size_px = footprint_px / 2.0
         center_lat = (min_lat + max_lat) / 2
         ref_y, ref_x = web_mercator.latlon_to_pixel_coords(center_lat, min_lon, config.zoom_level)
         buf_lat, _ = web_mercator.pixel_coords_to_latlon(ref_y - patch_half_size_px, ref_x, config.zoom_level)
@@ -289,11 +300,11 @@ def evaluate_histogram_on_paths(
             zoom_level=config.zoom_level,
             cell_size_px=cell_size_px,
         )
-        print(f"Grid size: {grid_spec.num_rows} x {grid_spec.num_cols} = {grid_spec.num_rows * grid_spec.num_cols} cells")
+        print(f"Grid size: {grid_spec.num_rows} x {grid_spec.num_cols} = {grid_spec.num_rows * grid_spec.num_cols} cells "
+              f"(cell={cell_size_px:.0f}px, footprint={footprint_px:.0f}px)")
 
         # Get patch positions and build mapping
         patch_positions_px = get_patch_positions_px(vigor_dataset, device)
-        patch_half_size_px = config.patch_size_px / 2.0
         mapping = build_cell_to_patch_mapping(
             grid_spec=grid_spec,
             patch_positions_px=patch_positions_px,
@@ -593,11 +604,22 @@ if __name__ == "__main__":
         )
         print(f"Odometry noise enabled: sigma_frac={odometry_noise_config.sigma_noise_frac}, seed={odometry_noise_config.seed}")
 
+    # Read source_px from satellite_bbox.json if available
+    source_px = None
+    sat_bbox_path = Path(args.dataset_path) / "satellite_bbox.json"
+    if sat_bbox_path.exists():
+        with open(sat_bbox_path) as f:
+            sat_bbox = json.load(f)
+        source_px = sat_bbox.get("source_px")
+    if source_px is not None and source_px != 640:
+        print(f"Resolution-normalized dataset: source_px={source_px} (footprint {source_px}px, image 640px)")
+
     config = HistogramFilterConfig(
         noise_percent=args.noise_percent,
         subdivision_factor=args.subdivision_factor,
         initial_std_deg=degrees_from_meters(2970.0),
         initial_offset_std_deg=degrees_from_meters(1300.0),
+        source_px=source_px,
         odometry_noise=odometry_noise_config,
         max_chunk_gib=args.max_chunk_gib,
     )
@@ -609,6 +631,7 @@ if __name__ == "__main__":
         "initial_offset_std_deg": config.initial_offset_std_deg,
         "zoom_level": config.zoom_level,
         "patch_size_px": config.patch_size_px,
+        "source_px": config.source_px,
     }
     if odometry_noise_config is not None:
         histogram_config_dict["odometry_noise"] = {


### PR DESCRIPTION
## Summary

Two related fixes to the histogram-filter evaluation pipeline.

- **`source_px` / `footprint_px` in `evaluate_histogram_on_paths.py`**: resolution-normalized satellite datasets store the true ground footprint in `satellite_bbox.json[source_px]` (often not equal to the 640px image width after resize). The histogram filter previously assumed `patch_size_px` was the ground footprint, which over/under-sized the grid cells and bounds buffer on normalized data. New `HistogramFilterConfig.footprint_px` property is threaded through grid construction, buffer calculation, and diagnostic logging. When `source_px` is absent, behavior is unchanged (defaults to `patch_size_px`).
- **`odometry_noise.py` Wiener scaling fix**: per-step noise std was `sigma_noise_frac * d` (variance ~ d²); correct Wiener-process behavior is variance ~ d, so std should be `sigma_noise_frac * sqrt(d)`. Units updated to m/sqrt(m) and docstring clarified.

## Test plan

- [ ] `bazel build //experimental/overhead_matching/swag/scripts:evaluate_histogram_on_paths //experimental/overhead_matching/swag/evaluation:odometry_noise` passes.
- [ ] Run `evaluate_histogram_on_paths` on a standard (non-normalized) city; confirm grid size and metrics are unchanged.
- [ ] Run on a resolution-normalized city (`source_px != 640`); confirm the grid is scaled to `source_px` and the startup log prints `(cell=..., footprint=...)` with the expected footprint.
- [ ] Spot-check simulated odometry noise variance scales linearly (not quadratically) with step distance.