### PR TITLE
SWAG scripts: path-gen/pairing/Gemini QoL tweaks

### DIFF
--- a/experimental/overhead_matching/swag/scripts/create_embeddings_with_gemini.py
+++ b/experimental/overhead_matching/swag/scripts/create_embeddings_with_gemini.py
@@ -243,7 +243,7 @@ class VertexEmbeddingGenerator:
         # Convert to tensor
         return torch.tensor(all_embeddings, dtype=torch.float32)
 
-    def _embed_batch_with_retry(self, batch: list[str], max_retries: int = 3) -> list:
+    def _embed_batch_with_retry(self, batch: list[str], max_retries: int = 8) -> list:
         """Embed a batch with exponential backoff retry."""
         for attempt in range(max_retries):
             try:
@@ -261,7 +261,7 @@ class VertexEmbeddingGenerator:
                 if attempt == max_retries - 1:
                     print(f"\nFailed to embed batch after {max_retries} attempts: {e}")
                     raise
-                wait_time = 2 ** attempt
+                wait_time = min(2 ** attempt * 5, 300)  # 5s, 10s, 20s, 40s, ... up to 5min
                 print(f"\nEmbedding failed (attempt {attempt+1}/{max_retries}), "
                       f"retrying in {wait_time}s: {e}")
                 time.sleep(wait_time)

--- a/experimental/overhead_matching/swag/scripts/create_evaluation_paths.py
+++ b/experimental/overhead_matching/swag/scripts/create_evaluation_paths.py
@@ -253,7 +253,7 @@ def generate_goal_directed_path(
     min_goal_distance_percentile: float = 0.75,
     min_bbox_coverage_ratio: float = 0.05,
     max_regeneration_attempts: int = 100,
-    max_astar_expansions: int = 50000,
+    max_astar_expansions: int = 100000,
     goal_resample_distance_m: float = 2000.0,
     # Exploration options
     epsilon_greedy: float = 0.0,
@@ -396,7 +396,7 @@ def generate_goal_directed_path(
                 consecutive_astar_failures += 1
                 if consecutive_astar_failures >= max_consecutive_failures:
                     # Graph might be disconnected at this location, start over
-                    logger.warning(f"A* failed {consecutive_astar_failures} times from node {current_idx}, trying new start")
+                    logger.warning(f"A* failed {consecutive_astar_failures} times from node {current_idx}, trying new start (max_expansions={max_astar_expansions})")
                     break
                 goal_idx = select_goal(current_idx)
                 distance_since_goal_change_m = 0.0
@@ -404,6 +404,8 @@ def generate_goal_directed_path(
 
             # Reset failure counter on success
             consecutive_astar_failures = 0
+            if result.num_nodes_expanded > max_astar_expansions * 0.5:
+                logger.info(f"A* used {result.num_nodes_expanded}/{max_astar_expansions} expansions (node {current_idx}->{goal_idx})")
 
             # Traverse A* path, accumulating distance
             a_star_path = result.states
@@ -507,11 +509,17 @@ if __name__ == "__main__":
         edge_costs_for_path = None
         if args.visited_penalty > 0 and args.goal_directed and base_edge_costs is not None:
             penalized_edge_costs = []
+            max_penalty = 0.0
             for node_idx, node_costs in enumerate(base_edge_costs):
                 penalty = 1.0 + args.visited_penalty * visit_counts[node_idx]
+                max_penalty = max(max_penalty, penalty)
                 penalized_costs = [cost * penalty for cost in node_costs]
                 penalized_edge_costs.append(penalized_costs)
             edge_costs_for_path = penalized_edge_costs
+            if (i + 1) % 100 == 0:
+                max_visits = max(visit_counts)
+                mean_visits = sum(visit_counts) / len(visit_counts)
+                logger.info(f"max_penalty={max_penalty:.1f}x, max_visits={max_visits}, mean_visits={mean_visits:.1f}")
 
         if args.goal_directed:
             paths.append(generate_goal_directed_path(

--- a/experimental/overhead_matching/swag/scripts/landmark_pairing_cli.py
+++ b/experimental/overhead_matching/swag/scripts/landmark_pairing_cli.py
@@ -256,20 +256,20 @@ def main():
     s = _pano_prune_stats
     dropped_lm = s["total_landmarks"] - s["kept_landmarks"]
     dropped_tags = s["total_tags"] - s["kept_tags"]
-    print(f"Loaded tags for {len(pano_tags_from_pano_id)} panoramas")
+    print(f"Loaded tags for {len(pano_tags_from_pano_id)} panoramas (across all cities in {pano_v2_base})")
     print(f"  Pano landmarks: {s['kept_landmarks']}/{s['total_landmarks']} kept ({dropped_lm} dropped, all tags pruned)")
     print(f"  Pano tags: {s['kept_tags']}/{s['total_tags']} kept ({dropped_tags} dropped by keep-list filter)")
 
     # Select panorama IDs
     dataset_pano_ids = set(dataset._panorama_metadata.pano_id.values)
+    available = [pid for pid in pano_tags_from_pano_id if pid in dataset_pano_ids]
+    print(f"  {len(available)} panoramas overlap with {args.city} VIGOR dataset ({len(dataset_pano_ids)} VIGOR panos)")
     if args.pano_ids:
         pano_ids = args.pano_ids.split(',')
     elif args.all:
-        pano_ids = sorted([pid for pid in pano_tags_from_pano_id if pid in dataset_pano_ids])
+        pano_ids = sorted(available)
     elif args.random_n:
         rng = np.random.default_rng(42)
-        available = [pid for pid in pano_tags_from_pano_id
-                     if pid in dataset_pano_ids]
         pano_ids = rng.choice(
             available, size=min(args.random_n, len(available)),
             replace=False).tolist()


### PR DESCRIPTION
## Summary

Three small, unrelated drive-by fixes to SWAG scripts. Bundled to keep review overhead low.

- **`create_evaluation_paths.py`**: raise A* expansion cap 50k → 100k so longer goal-directed paths aren't cut short; add diagnostic logging (`max_penalty`, `max_visits`, expansion count when >50% of cap).
- **`landmark_pairing_cli.py`**: show how many pano_v2 panoramas overlap the selected VIGOR dataset at startup so the selection stats aren't misleading. Hoists the `available` list out of the `--random_n` branch so `--all` uses it too.
- **`create_embeddings_with_gemini.py`**: bump retry count 3 → 8 and change backoff from `2^a` to `5 * 2^a` capped at 5 min, so Vertex rate-limit spikes don't fail the whole job.

## Test plan

- [ ] `bazel build //experimental/overhead_matching/swag/scripts:create_evaluation_paths //experimental/overhead_matching/swag/scripts:create_embeddings_with_gemini //experimental/overhead_matching/swag/scripts:landmark_pairing_cli` passes.
- [ ] Regenerate a small batch of eval paths; confirm the new diagnostic logs appear and no regression in path distribution.
- [ ] Run `landmark_pairing_cli --all` on one city; confirm the startup overlap count is printed.
- [ ] Trigger at least one Gemini embedding retry (e.g. force a rate-limit) and confirm the new backoff cadence.