### PR TITLE
SWAG utility scripts: dataset stats, trajectory paths, trim, plot

### DIFF
--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -248,9 +248,10 @@ py_binary(
   ]
 )
 
-py_binary(
-  name = "dataset_statistics",
+py_library(
+  name = "dataset_statistics_lib",
   srcs = ["dataset_statistics.py"],
+  visibility = ["//experimental/overhead_matching/swag:__subpackages__"],
   deps = [
     requirement("geopandas"),
     requirement("pandas"),
@@ -259,7 +260,15 @@ py_binary(
     ":create_eval_paths_from_panorama_trajectory_lib",
     "//experimental/overhead_matching/swag/model:semantic_landmark_utils",
     "//common/gps:web_mercator",
-  ]
+  ],
+)
+
+py_binary(
+  name = "dataset_statistics",
+  srcs = ["dataset_statistics.py"],
+  deps = [
+    ":dataset_statistics_lib",
+  ],
 )
 
 py_library(
@@ -276,6 +285,16 @@ py_binary(
   srcs = ["create_eval_paths_from_panorama_trajectory.py"],
   deps = [
     ":create_eval_paths_from_panorama_trajectory_lib",
+  ],
+)
+
+py_test(
+  name = "create_eval_paths_from_panorama_trajectory_test",
+  srcs = ["create_eval_paths_from_panorama_trajectory_test.py"],
+  deps = [
+    ":create_eval_paths_from_panorama_trajectory_lib",
+    ":dataset_statistics_lib",
+    "//common/math:haversine",
   ],
 )
 

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -248,8 +248,8 @@ py_binary(
   ]
 )
 
-py_library(
-  name = "dataset_statistics_lib",
+py_binary(
+  name = "dataset_statistics",
   srcs = ["dataset_statistics.py"],
   visibility = ["//experimental/overhead_matching/swag:__subpackages__"],
   deps = [
@@ -257,34 +257,19 @@ py_library(
     requirement("pandas"),
     requirement("pyarrow"),
     requirement("Pillow"),
-    ":create_eval_paths_from_panorama_trajectory_lib",
+    ":create_eval_paths_from_panorama_trajectory",
     "//experimental/overhead_matching/swag/model:semantic_landmark_utils",
     "//common/gps:web_mercator",
   ],
 )
 
 py_binary(
-  name = "dataset_statistics",
-  srcs = ["dataset_statistics.py"],
-  deps = [
-    ":dataset_statistics_lib",
-  ],
-)
-
-py_library(
-  name = "create_eval_paths_from_panorama_trajectory_lib",
+  name = "create_eval_paths_from_panorama_trajectory",
   srcs = ["create_eval_paths_from_panorama_trajectory.py"],
   visibility = ["//experimental/overhead_matching/swag:__subpackages__"],
   deps = [
+    "//common/gps:web_mercator",
     "//common/math:haversine",
-  ],
-)
-
-py_binary(
-  name = "create_eval_paths_from_panorama_trajectory",
-  srcs = ["create_eval_paths_from_panorama_trajectory.py"],
-  deps = [
-    ":create_eval_paths_from_panorama_trajectory_lib",
   ],
 )
 
@@ -292,8 +277,9 @@ py_test(
   name = "create_eval_paths_from_panorama_trajectory_test",
   srcs = ["create_eval_paths_from_panorama_trajectory_test.py"],
   deps = [
-    ":create_eval_paths_from_panorama_trajectory_lib",
-    ":dataset_statistics_lib",
+    ":create_eval_paths_from_panorama_trajectory",
+    ":dataset_statistics",
+    "//common/gps:web_mercator",
     "//common/math:haversine",
   ],
 )

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -256,14 +256,27 @@ py_binary(
     requirement("pandas"),
     requirement("pyarrow"),
     requirement("Pillow"),
+    ":create_eval_paths_from_panorama_trajectory_lib",
     "//experimental/overhead_matching/swag/model:semantic_landmark_utils",
     "//common/gps:web_mercator",
   ]
 )
 
+py_library(
+  name = "create_eval_paths_from_panorama_trajectory_lib",
+  srcs = ["create_eval_paths_from_panorama_trajectory.py"],
+  visibility = ["//experimental/overhead_matching/swag:__subpackages__"],
+  deps = [
+    "//common/math:haversine",
+  ],
+)
+
 py_binary(
-  name = "create_trajectory_paths",
-  srcs = ["create_trajectory_paths.py"],
+  name = "create_eval_paths_from_panorama_trajectory",
+  srcs = ["create_eval_paths_from_panorama_trajectory.py"],
+  deps = [
+    ":create_eval_paths_from_panorama_trajectory_lib",
+  ],
 )
 
 py_binary(

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -249,6 +249,24 @@ py_binary(
 )
 
 py_binary(
+  name = "dataset_statistics",
+  srcs = ["dataset_statistics.py"],
+  deps = [
+    requirement("geopandas"),
+    requirement("pandas"),
+    requirement("pyarrow"),
+    requirement("Pillow"),
+    "//experimental/overhead_matching/swag/model:semantic_landmark_utils",
+    "//common/gps:web_mercator",
+  ]
+)
+
+py_binary(
+  name = "create_trajectory_paths",
+  srcs = ["create_trajectory_paths.py"],
+)
+
+py_binary(
   name = "extract_landmarks_for_vigor_dataset",
   srcs = ["extract_landmarks_for_vigor_dataset.py"],
   deps = [
@@ -886,6 +904,22 @@ py_binary(
     "//experimental/overhead_matching/swag/data:landmark_correspondence_dataset",
     "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
   ]
+)
+
+py_binary(
+  name="paper_convergence_plot",
+  srcs=["paper_convergence_plot.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    "//common/torch:load_torch_deps",
+  ]
+)
+
+py_binary(
+  name = "trim_dataset_start",
+  srcs = ["trim_dataset_start.py"],
 )
 
 py_binary(

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
@@ -23,16 +23,19 @@ from common.math.haversine import find_d_on_unit_circle
 def load_trajectory(dataset_path: Path) -> tuple[list[str], list[float]]:
     """Load pano IDs and cumulative distances (meters) along the trajectory.
 
-    Returns ([], []) when the CSV has fewer than two rows — no trajectory can
-    be formed, and we don't touch any column so missing columns in the
-    degenerate case don't raise.
+    Raises ValueError if the CSV has fewer than two rows — no trajectory
+    can be formed from a single point. The row-count check runs before
+    column access so a degenerate CSV with missing columns still produces
+    a clear error instead of a KeyError.
     """
     mapping = dataset_path / "pano_id_mapping.csv"
     with open(mapping) as f:
         rows = list(csv.DictReader(f))
 
     if len(rows) < 2:
-        return [], []
+        raise ValueError(
+            f"{mapping} has {len(rows)} rows; at least 2 are required to form a trajectory"
+        )
 
     pano_ids = [r["pano_id"] for r in rows]
     latlons = [(float(r["lat"]), float(r["lon"])) for r in rows]
@@ -112,10 +115,6 @@ def main():
     args = parser.parse_args()
 
     pano_ids, cum_dist = load_trajectory(args.dataset_path)
-    if len(pano_ids) < 2:
-        raise ValueError(
-            f"{args.dataset_path}/pano_id_mapping.csv needs at least 2 rows to form a trajectory"
-        )
     total_dist = cum_dist[-1]
     print(f"Trajectory: {len(pano_ids)} panos, {total_dist:.0f}m")
 

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
@@ -22,10 +22,18 @@ EARTH_RADIUS_M = 6378137.0
 
 
 def load_trajectory(dataset_path: Path) -> tuple[list[str], list[float]]:
-    """Load pano IDs and cumulative distances (meters) along the trajectory."""
+    """Load pano IDs and cumulative distances (meters) along the trajectory.
+
+    Returns ([], []) when the CSV has fewer than two rows — no trajectory can
+    be formed, and we don't touch any column so missing columns in the
+    degenerate case don't raise.
+    """
     mapping = dataset_path / "pano_id_mapping.csv"
     with open(mapping) as f:
         rows = list(csv.DictReader(f))
+
+    if len(rows) < 2:
+        return [], []
 
     pano_ids = [r["pano_id"] for r in rows]
     latlons = [(float(r["lat"]), float(r["lon"])) for r in rows]
@@ -105,6 +113,10 @@ def main():
     args = parser.parse_args()
 
     pano_ids, cum_dist = load_trajectory(args.dataset_path)
+    if len(pano_ids) < 2:
+        raise ValueError(
+            f"{args.dataset_path}/pano_id_mapping.csv needs at least 2 rows to form a trajectory"
+        )
     total_dist = cum_dist[-1]
     print(f"Trajectory: {len(pano_ids)} panos, {total_dist:.0f}m")
 

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
@@ -4,7 +4,7 @@ Creates paths of a fixed distance by sliding a window along the trajectory
 at uniform intervals. Half the paths go forward, half go backward.
 
 Usage:
-    bazel run //experimental/overhead_matching/swag/scripts:create_trajectory_paths -- \
+    bazel run //experimental/overhead_matching/swag/scripts:create_eval_paths_from_panorama_trajectory -- \
         --dataset_path /data/overhead_matching/datasets/VIGOR/mapillary/Framingham \
         --target_distance_m 3000 \
         --num_paths 1000 \
@@ -14,31 +14,26 @@ Usage:
 import argparse
 import csv
 import json
-import math
 from pathlib import Path
 
+from common.math.haversine import find_d_on_unit_circle
 
-def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    lat1, lon1, lat2, lon2 = map(math.radians, (lat1, lon1, lat2, lon2))
-    dlat = lat2 - lat1
-    dlon = lon2 - lon1
-    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
-    return 2 * 6378137 * math.asin(math.sqrt(a))
+EARTH_RADIUS_M = 6378137.0
 
 
 def load_trajectory(dataset_path: Path) -> tuple[list[str], list[float]]:
-    """Load pano IDs and cumulative distances along the trajectory."""
+    """Load pano IDs and cumulative distances (meters) along the trajectory."""
     mapping = dataset_path / "pano_id_mapping.csv"
     with open(mapping) as f:
         rows = list(csv.DictReader(f))
 
     pano_ids = [r["pano_id"] for r in rows]
-    lats = [float(r["lat"]) for r in rows]
-    lons = [float(r["lon"]) for r in rows]
+    latlons = [(float(r["lat"]), float(r["lon"])) for r in rows]
 
     cum_dist = [0.0]
     for i in range(1, len(pano_ids)):
-        cum_dist.append(cum_dist[-1] + haversine_m(lats[i - 1], lons[i - 1], lats[i], lons[i]))
+        step_m = EARTH_RADIUS_M * find_d_on_unit_circle(latlons[i - 1], latlons[i])
+        cum_dist.append(cum_dist[-1] + step_m)
 
     return pano_ids, cum_dist
 

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory.py
@@ -16,9 +16,8 @@ import csv
 import json
 from pathlib import Path
 
+from common.gps.web_mercator import EARTH_RADIUS_M
 from common.math.haversine import find_d_on_unit_circle
-
-EARTH_RADIUS_M = 6378137.0
 
 
 def load_trajectory(dataset_path: Path) -> tuple[list[str], list[float]]:

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
@@ -1,0 +1,103 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from common.math.haversine import find_d_on_unit_circle
+from experimental.overhead_matching.swag.scripts.create_eval_paths_from_panorama_trajectory import (
+    EARTH_RADIUS_M,
+    load_trajectory,
+)
+from experimental.overhead_matching.swag.scripts.dataset_statistics import (
+    compute_trajectory_km,
+)
+
+
+def _write_mapping(dir_path: Path, rows: list[dict]) -> None:
+    mapping = dir_path / "pano_id_mapping.csv"
+    with open(mapping, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["pano_id", "lat", "lon"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class CreateEvalPathsTrajectoryTest(unittest.TestCase):
+
+    def test_load_trajectory_matches_haversine(self):
+        rows = [
+            {"pano_id": "a", "lat": "42.3601", "lon": "-71.0589"},  # Boston
+            {"pano_id": "b", "lat": "42.3611", "lon": "-71.0592"},
+            {"pano_id": "c", "lat": "42.3615", "lon": "-71.0600"},
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = Path(tmp)
+            _write_mapping(dataset, rows)
+
+            pano_ids, cum_dist = load_trajectory(dataset)
+
+            self.assertEqual(pano_ids, ["a", "b", "c"])
+            self.assertEqual(cum_dist[0], 0.0)
+
+            # Cumulative distance must be monotone non-decreasing.
+            for prev, curr in zip(cum_dist, cum_dist[1:]):
+                self.assertGreaterEqual(curr, prev)
+
+            # Final distance matches a direct haversine computation (pins
+            # the (lat, lon) argument order and the EARTH_RADIUS_M scaling).
+            expected = 0.0
+            for i in range(1, len(rows)):
+                p1 = (float(rows[i - 1]["lat"]), float(rows[i - 1]["lon"]))
+                p2 = (float(rows[i]["lat"]), float(rows[i]["lon"]))
+                expected += EARTH_RADIUS_M * find_d_on_unit_circle(p1, p2)
+            self.assertAlmostEqual(cum_dist[-1], expected, places=6)
+
+    def test_load_trajectory_short_csv_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = Path(tmp)
+            # Zero data rows (header only): must not touch any columns.
+            _write_mapping(dataset, [])
+            self.assertEqual(load_trajectory(dataset), ([], []))
+
+            # Single data row: still can't form a trajectory segment.
+            _write_mapping(dataset, [{"pano_id": "a", "lat": "1.0", "lon": "2.0"}])
+            self.assertEqual(load_trajectory(dataset), ([], []))
+
+    def test_load_trajectory_short_csv_tolerates_missing_columns(self):
+        # < 2 rows must bail before dereferencing columns, so a CSV that
+        # has a valid header structure but is missing the pano_id column
+        # should not raise.
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = Path(tmp)
+            mapping = dataset / "pano_id_mapping.csv"
+            with open(mapping, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=["lat", "lon"])
+                writer.writeheader()
+                writer.writerow({"lat": "1.0", "lon": "2.0"})
+            self.assertEqual(load_trajectory(dataset), ([], []))
+
+    def test_compute_trajectory_km_matches_cum_dist(self):
+        rows = [
+            {"pano_id": "a", "lat": "42.3601", "lon": "-71.0589"},
+            {"pano_id": "b", "lat": "42.3650", "lon": "-71.0700"},
+            {"pano_id": "c", "lat": "42.3700", "lon": "-71.0800"},
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = Path(tmp)
+            _write_mapping(dataset, rows)
+            _, cum_dist = load_trajectory(dataset)
+            self.assertAlmostEqual(
+                compute_trajectory_km(dataset), cum_dist[-1] / 1000.0, places=6
+            )
+
+    def test_compute_trajectory_km_returns_none_on_missing_or_short(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = Path(tmp)
+            # Missing file.
+            self.assertIsNone(compute_trajectory_km(dataset))
+            # < 2 rows.
+            _write_mapping(dataset, [{"pano_id": "a", "lat": "1", "lon": "2"}])
+            self.assertIsNone(compute_trajectory_km(dataset))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
@@ -3,9 +3,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from common.gps.web_mercator import EARTH_RADIUS_M
 from common.math.haversine import find_d_on_unit_circle
 from experimental.overhead_matching.swag.scripts.create_eval_paths_from_panorama_trajectory import (
-    EARTH_RADIUS_M,
     load_trajectory,
 )
 from experimental.overhead_matching.swag.scripts.dataset_statistics import (

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from common.gps.web_mercator import EARTH_RADIUS_M
 from common.math.haversine import find_d_on_unit_circle
 from experimental.overhead_matching.swag.scripts.create_eval_paths_from_panorama_trajectory import (
+    generate_paths,
     load_trajectory,
 )
 from experimental.overhead_matching.swag.scripts.dataset_statistics import (
@@ -21,9 +22,31 @@ def _write_mapping(dir_path: Path, rows: list[dict]) -> None:
         writer.writerows(rows)
 
 
-class CreateEvalPathsTrajectoryTest(unittest.TestCase):
+def _write_uniform_linear_trajectory(
+    dir_path: Path, n_points: int, step_m: float, base_lat: float = 0.0
+) -> None:
+    """Write a mapping CSV of n_points points spaced step_m apart along
+    a constant-latitude line (so each segment is approximately step_m meters
+    at the equator — uniform spacing is what the generate_paths tests rely on)."""
+    # At the equator a small longitude step Δlon (radians) traces an arc of
+    # length EARTH_RADIUS_M * Δlon on the unit sphere, so Δlon = step_m / R.
+    import math
 
-    def test_load_trajectory_matches_haversine(self):
+    lon_step_deg = math.degrees(step_m / EARTH_RADIUS_M)
+    rows = [
+        {
+            "pano_id": f"p{i:06d}",
+            "lat": f"{base_lat}",
+            "lon": f"{i * lon_step_deg}",
+        }
+        for i in range(n_points)
+    ]
+    _write_mapping(dir_path, rows)
+
+
+class LoadTrajectoryTest(unittest.TestCase):
+
+    def test_matches_haversine(self):
         rows = [
             {"pano_id": "a", "lat": "42.3601", "lon": "-71.0589"},  # Boston
             {"pano_id": "b", "lat": "42.3611", "lon": "-71.0592"},
@@ -37,13 +60,11 @@ class CreateEvalPathsTrajectoryTest(unittest.TestCase):
 
             self.assertEqual(pano_ids, ["a", "b", "c"])
             self.assertEqual(cum_dist[0], 0.0)
-
-            # Cumulative distance must be monotone non-decreasing.
             for prev, curr in zip(cum_dist, cum_dist[1:]):
                 self.assertGreaterEqual(curr, prev)
 
-            # Final distance matches a direct haversine computation (pins
-            # the (lat, lon) argument order and the EARTH_RADIUS_M scaling).
+            # Pin the (lat, lon) argument order and EARTH_RADIUS_M scaling
+            # by recomputing with the shared haversine utility.
             expected = 0.0
             for i in range(1, len(rows)):
                 p1 = (float(rows[i - 1]["lat"]), float(rows[i - 1]["lon"]))
@@ -51,21 +72,22 @@ class CreateEvalPathsTrajectoryTest(unittest.TestCase):
                 expected += EARTH_RADIUS_M * find_d_on_unit_circle(p1, p2)
             self.assertAlmostEqual(cum_dist[-1], expected, places=6)
 
-    def test_load_trajectory_short_csv_returns_empty(self):
+    def test_raises_on_short_csv(self):
         with tempfile.TemporaryDirectory() as tmp:
             dataset = Path(tmp)
-            # Zero data rows (header only): must not touch any columns.
-            _write_mapping(dataset, [])
-            self.assertEqual(load_trajectory(dataset), ([], []))
 
-            # Single data row: still can't form a trajectory segment.
+            _write_mapping(dataset, [])  # header only
+            with self.assertRaises(ValueError):
+                load_trajectory(dataset)
+
             _write_mapping(dataset, [{"pano_id": "a", "lat": "1.0", "lon": "2.0"}])
-            self.assertEqual(load_trajectory(dataset), ([], []))
+            with self.assertRaises(ValueError):
+                load_trajectory(dataset)
 
-    def test_load_trajectory_short_csv_tolerates_missing_columns(self):
-        # < 2 rows must bail before dereferencing columns, so a CSV that
-        # has a valid header structure but is missing the pano_id column
-        # should not raise.
+    def test_raises_on_short_csv_before_touching_columns(self):
+        # If the CSV is short, we must raise before dereferencing any column,
+        # so missing columns produce a ValueError from our check rather than
+        # a less-informative KeyError from the row parsing.
         with tempfile.TemporaryDirectory() as tmp:
             dataset = Path(tmp)
             mapping = dataset / "pano_id_mapping.csv"
@@ -73,9 +95,13 @@ class CreateEvalPathsTrajectoryTest(unittest.TestCase):
                 writer = csv.DictWriter(f, fieldnames=["lat", "lon"])
                 writer.writeheader()
                 writer.writerow({"lat": "1.0", "lon": "2.0"})
-            self.assertEqual(load_trajectory(dataset), ([], []))
+            with self.assertRaises(ValueError):
+                load_trajectory(dataset)
 
-    def test_compute_trajectory_km_matches_cum_dist(self):
+
+class ComputeTrajectoryKmTest(unittest.TestCase):
+
+    def test_matches_cum_dist(self):
         rows = [
             {"pano_id": "a", "lat": "42.3601", "lon": "-71.0589"},
             {"pano_id": "b", "lat": "42.3650", "lon": "-71.0700"},
@@ -89,14 +115,105 @@ class CreateEvalPathsTrajectoryTest(unittest.TestCase):
                 compute_trajectory_km(dataset), cum_dist[-1] / 1000.0, places=6
             )
 
-    def test_compute_trajectory_km_returns_none_on_missing_or_short(self):
+    def test_returns_none_when_csv_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(compute_trajectory_km(Path(tmp)))
+
+    def test_propagates_short_csv_error(self):
         with tempfile.TemporaryDirectory() as tmp:
             dataset = Path(tmp)
-            # Missing file.
-            self.assertIsNone(compute_trajectory_km(dataset))
-            # < 2 rows.
             _write_mapping(dataset, [{"pano_id": "a", "lat": "1", "lon": "2"}])
-            self.assertIsNone(compute_trajectory_km(dataset))
+            with self.assertRaises(ValueError):
+                compute_trajectory_km(dataset)
+
+
+class GeneratePathsTest(unittest.TestCase):
+
+    # Uniform synthetic trajectory: 10001 points spaced ~1m apart ⇒ ~10 km.
+    N_POINTS = 10001
+    STEP_M = 1.0
+    TARGET_M = 1000.0
+
+    def _load_uniform(self, tmp: Path) -> tuple[list[str], list[float]]:
+        _write_uniform_linear_trajectory(tmp, self.N_POINTS, self.STEP_M)
+        pano_ids, cum_dist = load_trajectory(tmp)
+        # Sanity: ~10 km total.
+        self.assertAlmostEqual(cum_dist[-1], (self.N_POINTS - 1) * self.STEP_M, delta=0.5)
+        return pano_ids, cum_dist
+
+    def test_half_forward_half_backward_with_correct_ordering(self):
+        num_paths = 10
+        with tempfile.TemporaryDirectory() as tmp:
+            pano_ids, cum_dist = self._load_uniform(Path(tmp))
+            paths = generate_paths(pano_ids, cum_dist, self.TARGET_M, num_paths)
+
+        self.assertEqual(len(paths), num_paths)
+        num_fwd = num_paths // 2
+        num_bwd = num_paths - num_fwd
+        fwd, bwd = paths[:num_fwd], paths[num_fwd:]
+        self.assertEqual(len(fwd), num_bwd)  # equal halves (num_paths is even)
+
+        pano_idx = {pid: i for i, pid in enumerate(pano_ids)}
+        for path in fwd:
+            idx = [pano_idx[p] for p in path]
+            self.assertEqual(idx, sorted(idx), "forward path not in ascending order")
+        for path in bwd:
+            idx = [pano_idx[p] for p in path]
+            self.assertEqual(idx, sorted(idx, reverse=True),
+                             "backward path not in descending order")
+
+    def test_all_paths_cover_target_distance(self):
+        num_paths = 10
+        with tempfile.TemporaryDirectory() as tmp:
+            pano_ids, cum_dist = self._load_uniform(Path(tmp))
+            paths = generate_paths(pano_ids, cum_dist, self.TARGET_M, num_paths)
+
+        pano_idx = {pid: i for i, pid in enumerate(pano_ids)}
+        num_fwd = num_paths // 2
+
+        for path in paths[:num_fwd]:
+            span = cum_dist[pano_idx[path[-1]]] - cum_dist[pano_idx[path[0]]]
+            self.assertGreaterEqual(span, self.TARGET_M - 1e-6)
+        for path in paths[num_fwd:]:
+            # Backward paths are stored reversed, so path[0] is the later pano.
+            span = cum_dist[pano_idx[path[0]]] - cum_dist[pano_idx[path[-1]]]
+            self.assertGreaterEqual(span, self.TARGET_M - 1e-6)
+
+        # With uniform ~1m spacing, every path should be about target_m + 1
+        # panos long (one pano per meter, inclusive endpoints). Accumulated
+        # floating-point drift in cum_dist can push the end index one step
+        # further, so allow a single extra pano.
+        base_len = int(self.TARGET_M / self.STEP_M) + 1
+        for path in paths:
+            self.assertIn(len(path), (base_len, base_len + 1))
+
+    def test_path_starts_uniformly_spaced(self):
+        num_paths = 10
+        with tempfile.TemporaryDirectory() as tmp:
+            pano_ids, cum_dist = self._load_uniform(Path(tmp))
+            paths = generate_paths(pano_ids, cum_dist, self.TARGET_M, num_paths)
+
+        pano_idx = {pid: i for i, pid in enumerate(pano_ids)}
+        total_dist = cum_dist[-1]
+        num_fwd = num_paths // 2
+        num_bwd = num_paths - num_fwd
+
+        # Forward starts: uniformly spaced over [0, total - target].
+        fwd_starts = [cum_dist[pano_idx[p[0]]] for p in paths[:num_fwd]]
+        max_fwd_start = total_dist - self.TARGET_M
+        expected_fwd = [max_fwd_start * i / (num_fwd - 1) for i in range(num_fwd)]
+        for actual, want in zip(fwd_starts, expected_fwd):
+            self.assertAlmostEqual(actual, want, delta=self.STEP_M)
+
+        # Backward starts: uniformly spaced over [target, total].
+        # path[0] for backward paths is the later pano (lists are reversed).
+        bwd_starts = [cum_dist[pano_idx[p[0]]] for p in paths[num_fwd:]]
+        expected_bwd = [
+            self.TARGET_M + (total_dist - self.TARGET_M) * i / (num_bwd - 1)
+            for i in range(num_bwd)
+        ]
+        for actual, want in zip(bwd_starts, expected_bwd):
+            self.assertAlmostEqual(actual, want, delta=self.STEP_M)
 
 
 if __name__ == "__main__":

--- a/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
+++ b/experimental/overhead_matching/swag/scripts/create_eval_paths_from_panorama_trajectory_test.py
@@ -170,14 +170,19 @@ class GeneratePathsTest(unittest.TestCase):
 
         pano_idx = {pid: i for i, pid in enumerate(pano_ids)}
         num_fwd = num_paths // 2
+        # find_index_at_distance stops at the first index whose cum_dist ≥ target,
+        # so each path overshoots the target by at most one trajectory step.
+        max_span = self.TARGET_M + self.STEP_M + 1e-6
 
         for path in paths[:num_fwd]:
             span = cum_dist[pano_idx[path[-1]]] - cum_dist[pano_idx[path[0]]]
             self.assertGreaterEqual(span, self.TARGET_M - 1e-6)
+            self.assertLessEqual(span, max_span)
         for path in paths[num_fwd:]:
             # Backward paths are stored reversed, so path[0] is the later pano.
             span = cum_dist[pano_idx[path[0]]] - cum_dist[pano_idx[path[-1]]]
             self.assertGreaterEqual(span, self.TARGET_M - 1e-6)
+            self.assertLessEqual(span, max_span)
 
         # With uniform ~1m spacing, every path should be about target_m + 1
         # panos long (one pano per meter, inclusive endpoints). Accumulated

--- a/experimental/overhead_matching/swag/scripts/create_trajectory_paths.py
+++ b/experimental/overhead_matching/swag/scripts/create_trajectory_paths.py
@@ -1,0 +1,144 @@
+"""Generate evaluation paths from sequential trajectory datasets.
+
+Creates paths of a fixed distance by sliding a window along the trajectory
+at uniform intervals. Half the paths go forward, half go backward.
+
+Usage:
+    bazel run //experimental/overhead_matching/swag/scripts:create_trajectory_paths -- \
+        --dataset_path /data/overhead_matching/datasets/VIGOR/mapillary/Framingham \
+        --target_distance_m 3000 \
+        --num_paths 1000 \
+        --out /data/overhead_matching/evaluation/paths/mappilary_v2/Framingham.json
+"""
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+
+
+def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    lat1, lon1, lat2, lon2 = map(math.radians, (lat1, lon1, lat2, lon2))
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    return 2 * 6378137 * math.asin(math.sqrt(a))
+
+
+def load_trajectory(dataset_path: Path) -> tuple[list[str], list[float]]:
+    """Load pano IDs and cumulative distances along the trajectory."""
+    mapping = dataset_path / "pano_id_mapping.csv"
+    with open(mapping) as f:
+        rows = list(csv.DictReader(f))
+
+    pano_ids = [r["pano_id"] for r in rows]
+    lats = [float(r["lat"]) for r in rows]
+    lons = [float(r["lon"]) for r in rows]
+
+    cum_dist = [0.0]
+    for i in range(1, len(pano_ids)):
+        cum_dist.append(cum_dist[-1] + haversine_m(lats[i - 1], lons[i - 1], lats[i], lons[i]))
+
+    return pano_ids, cum_dist
+
+
+def find_index_at_distance(cum_dist: list[float], start_idx: int, target_m: float, forward: bool) -> int:
+    """Find the trajectory index that is ~target_m away from start_idx."""
+    if forward:
+        target = cum_dist[start_idx] + target_m
+        idx = start_idx
+        while idx < len(cum_dist) - 1 and cum_dist[idx] < target:
+            idx += 1
+        return idx
+    else:
+        target = cum_dist[start_idx] - target_m
+        idx = start_idx
+        while idx > 0 and cum_dist[idx] > target:
+            idx -= 1
+        return idx
+
+
+def generate_paths(
+    pano_ids: list[str],
+    cum_dist: list[float],
+    target_distance_m: float,
+    num_paths: int,
+) -> list[list[str]]:
+    """Generate paths by uniformly spacing start points along the trajectory.
+
+    Half go forward, half go backward. Start points are uniformly spaced
+    within the valid range for each direction.
+    """
+    n = len(pano_ids)
+    total_dist = cum_dist[-1]
+    num_forward = num_paths // 2
+    num_backward = num_paths - num_forward
+
+    if target_distance_m > total_dist:
+        raise ValueError(
+            f"Target distance {target_distance_m:.0f}m exceeds trajectory length {total_dist:.0f}m"
+        )
+
+    paths = []
+
+    # Forward paths: start points spaced uniformly from 0 to (total - target)
+    max_forward_start = total_dist - target_distance_m
+    for i in range(num_forward):
+        start_dist = max_forward_start * i / max(num_forward - 1, 1)
+        # Find the trajectory index closest to this distance
+        start_idx = min(range(n), key=lambda j: abs(cum_dist[j] - start_dist))
+        end_idx = find_index_at_distance(cum_dist, start_idx, target_distance_m, forward=True)
+        paths.append(pano_ids[start_idx : end_idx + 1])
+
+    # Backward paths: start points spaced uniformly from target to total
+    for i in range(num_backward):
+        start_dist = target_distance_m + (total_dist - target_distance_m) * i / max(num_backward - 1, 1)
+        start_idx = min(range(n), key=lambda j: abs(cum_dist[j] - start_dist))
+        end_idx = find_index_at_distance(cum_dist, start_idx, target_distance_m, forward=False)
+        paths.append(list(reversed(pano_ids[end_idx : start_idx + 1])))
+
+    return paths
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate fixed-length evaluation paths from trajectory datasets")
+    parser.add_argument("--dataset_path", type=Path, required=True)
+    parser.add_argument("--target_distance_m", type=float, required=True, help="Path length in meters")
+    parser.add_argument("--num_paths", type=int, required=True, help="Total paths (half forward, half backward)")
+    parser.add_argument("--out", type=Path, required=True, help="Output JSON path")
+    args = parser.parse_args()
+
+    pano_ids, cum_dist = load_trajectory(args.dataset_path)
+    total_dist = cum_dist[-1]
+    print(f"Trajectory: {len(pano_ids)} panos, {total_dist:.0f}m")
+
+    paths = generate_paths(pano_ids, cum_dist, args.target_distance_m, args.num_paths)
+
+    # Stats
+    lengths = [len(p) for p in paths]
+    num_fwd = args.num_paths // 2
+    fwd_lengths = lengths[:num_fwd]
+    bwd_lengths = lengths[num_fwd:]
+    print(f"Forward:  {num_fwd} paths, {min(fwd_lengths)}-{max(fwd_lengths)} panos")
+    print(f"Backward: {len(bwd_lengths)} paths, {min(bwd_lengths)}-{max(bwd_lengths)} panos")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    out_data = {
+        "paths": paths,
+        "dataset_path": str(args.dataset_path),
+        "dataset_hash": "new",
+        "args": {
+            "target_distance_m": args.target_distance_m,
+            "num_paths": args.num_paths,
+            "num_forward": num_fwd,
+            "num_backward": args.num_paths - num_fwd,
+        },
+    }
+    with open(args.out, "w") as f:
+        json.dump(out_data, f, indent=2)
+    print(f"Saved to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/dataset_statistics.py
+++ b/experimental/overhead_matching/swag/scripts/dataset_statistics.py
@@ -161,8 +161,6 @@ def compute_trajectory_km(dataset_path: Path) -> float | None:
     if not (dataset_path / "pano_id_mapping.csv").exists():
         return None
     _, cum_dist = load_trajectory(dataset_path)
-    if not cum_dist:
-        return None
     return cum_dist[-1] / 1000.0
 
 

--- a/experimental/overhead_matching/swag/scripts/dataset_statistics.py
+++ b/experimental/overhead_matching/swag/scripts/dataset_statistics.py
@@ -11,6 +11,9 @@ import pandas as pd
 from PIL import Image
 
 from common.gps import web_mercator
+from experimental.overhead_matching.swag.scripts.create_eval_paths_from_panorama_trajectory import (
+    load_trajectory,
+)
 from experimental.overhead_matching.swag.model.semantic_landmark_utils import (
     _TAGS_TO_KEEP_PREFIXES,
     _TAGS_TO_KEEP_SET,
@@ -154,27 +157,13 @@ def parse_satellite_coords(sat_dir: Path) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=["lat", "lon"])
 
 
-def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    lat1, lon1, lat2, lon2 = map(math.radians, (lat1, lon1, lat2, lon2))
-    dlat = lat2 - lat1
-    dlon = lon2 - lon1
-    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
-    return 2 * 6378.137 * math.asin(math.sqrt(a))
-
-
-def compute_trajectory_km(mapping_path: Path) -> float | None:
-    import csv
-    with open(mapping_path) as f:
-        rows = list(csv.DictReader(f))
-    if len(rows) < 2:
+def compute_trajectory_km(dataset_path: Path) -> float | None:
+    if not (dataset_path / "pano_id_mapping.csv").exists():
         return None
-    total = 0.0
-    for i in range(1, len(rows)):
-        total += haversine_km(
-            float(rows[i - 1]["lat"]), float(rows[i - 1]["lon"]),
-            float(rows[i]["lat"]), float(rows[i]["lon"]),
-        )
-    return total
+    pano_ids, cum_dist = load_trajectory(dataset_path)
+    if len(pano_ids) < 2:
+        return None
+    return cum_dist[-1] / 1000.0
 
 
 def compute_bbox_area_km2(north: float, south: float, east: float, west: float) -> float:
@@ -288,9 +277,7 @@ def compute_stats(config: DatasetConfig, pano_embed_base: Path | None) -> Datase
 
     # Fall back to computing trajectory from pano_id_mapping.csv
     if trajectory_km is None:
-        mapping_path = config.path / "pano_id_mapping.csv"
-        if mapping_path.exists():
-            trajectory_km = compute_trajectory_km(mapping_path)
+        trajectory_km = compute_trajectory_km(config.path)
 
     # Satellite source
     sat_source = None

--- a/experimental/overhead_matching/swag/scripts/dataset_statistics.py
+++ b/experimental/overhead_matching/swag/scripts/dataset_statistics.py
@@ -1,0 +1,470 @@
+import argparse
+import json
+import math
+import pickle
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+from PIL import Image
+
+from common.gps import web_mercator
+from experimental.overhead_matching.swag.model.semantic_landmark_utils import (
+    _TAGS_TO_KEEP_PREFIXES,
+    _TAGS_TO_KEEP_SET,
+)
+
+ZOOM_LEVEL = 20
+METERS_PER_DEG_LAT = 111319.49
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png"}
+
+# Map dataset names -> pano landmark embedding directory names
+PANO_LANDMARK_DIR_MAP = {
+    "Chicago": "Chicago",
+    "Seattle": "Seattle",
+    "Boston": "boston_snowy",
+    "nightdrive": "nightdrive",
+    "mapillary/Framingham": "Framingham",
+    "mapillary/Gap": "Gap",
+    "mapillary/MiamiBeach": "MiamiBeach",
+    "mapillary/Middletown": "Middletown",
+    "mapillary/Norway": "Norway",
+    "mapillary/SanFrancisco_mapillary": "SanFrancisco_mapillary",
+    "mapillary/post_hurricane_ian": "post_hurricane_ian",
+}
+
+
+@dataclass
+class DatasetConfig:
+    name: str
+    path: Path
+    landmark_file: str  # relative to path, e.g. "landmarks/v4_202001.feather"
+
+
+@dataclass
+class PanoLandmarkStats:
+    num_panoramas: int
+    num_with_landmarks: int
+    total_landmarks: int
+    avg_landmarks_per_pano: float
+
+
+@dataclass
+class DatasetStats:
+    name: str
+    num_panoramas: int
+    num_satellites: int
+    panorama_resolution: tuple[int, int]
+    satellite_resolution: tuple[int, int]
+    satellite_ground_coverage_m: tuple[float, float]
+    ground_normalized: bool
+    bbox: dict
+    geographic_extent_km2: float
+    num_landmarks_raw: int
+    num_landmarks_pruned: int
+    landmark_version: str
+    osm_date: str | None  # extracted from landmark filename
+    trajectory_km: float | None
+    capture_date: str | None
+    satellite_source: str | None
+    meters_per_pixel: float
+    pano_landmarks: PanoLandmarkStats | None
+
+
+def parse_osm_date(landmark_version: str) -> str | None:
+    """Extract OSM snapshot date from landmark filename.
+
+    Examples: v4_202001 -> 2020-01, boston -> None,
+    Framingham_v1_260101 -> 2026-01-01, Norway_v1_251201 -> 2025-12-01
+    """
+    # Match YYMMDD or YYYYMM at end of version string
+    m = re.search(r'(\d{6})$', landmark_version)
+    if not m:
+        return None
+    digits = m.group(1)
+    # Distinguish YYYYMM (e.g. 202001) from YYMMDD (e.g. 260101)
+    # YYYYMM: first 4 digits are a plausible year (2000-2099), last 2 are month (01-12)
+    year4 = int(digits[:4])
+    month2 = int(digits[4:6])
+    if 2000 <= year4 <= 2099 and 1 <= month2 <= 12:
+        return f"{digits[:4]}-{digits[4:6]}"
+    else:
+        # YYMMDD format (e.g. 260101 -> 2026-01-01)
+        return f"20{digits[:2]}-{digits[2:4]}-{digits[4:6]}"
+
+
+def discover_datasets(base: Path) -> list[DatasetConfig]:
+    configs = []
+
+    for city in ["Chicago", "NewYork", "SanFrancisco", "Seattle"]:
+        p = base / city
+        if p.is_dir() and (p / "panorama").is_dir():
+            configs.append(DatasetConfig(city, p, "landmarks/v4_202001.feather"))
+
+    if (base / "Boston" / "panorama").is_dir():
+        configs.append(DatasetConfig("Boston", base / "Boston", "landmarks/boston.feather"))
+
+    if (base / "nightdrive" / "panorama").is_dir():
+        configs.append(DatasetConfig("nightdrive", base / "nightdrive", "landmarks/boston.feather"))
+
+    mapillary_dir = base / "mapillary"
+    if mapillary_dir.is_dir():
+        for loc_dir in sorted(mapillary_dir.iterdir()):
+            if not loc_dir.is_dir() or not (loc_dir / "panorama").is_dir():
+                continue
+            landmarks_dir = loc_dir / "landmarks"
+            if not landmarks_dir.is_dir():
+                continue
+            feather_files = list(landmarks_dir.glob("*.feather"))
+            if not feather_files:
+                continue
+            landmark_file = f"landmarks/{feather_files[0].name}"
+            configs.append(DatasetConfig(f"mapillary/{loc_dir.name}", loc_dir, landmark_file))
+
+    return configs
+
+
+def get_most_common_resolution(directory: Path, sample_size: int = 100) -> tuple[int, int]:
+    from collections import Counter
+    resolutions = Counter()
+    count = 0
+    for f in sorted(directory.iterdir()):
+        if f.suffix.lower() in IMAGE_SUFFIXES:
+            with Image.open(f) as img:
+                resolutions[img.size] += 1
+            count += 1
+            if count >= sample_size:
+                break
+    if not resolutions:
+        raise FileNotFoundError(f"No images found in {directory}")
+    return resolutions.most_common(1)[0][0]
+
+
+def parse_satellite_coords(sat_dir: Path) -> pd.DataFrame:
+    rows = []
+    for f in sat_dir.iterdir():
+        if f.suffix.lower() not in IMAGE_SUFFIXES:
+            continue
+        parts = f.stem.split("_")
+        if len(parts) == 3 and parts[0] == "satellite":
+            lat, lon = float(parts[1]), float(parts[2])
+            rows.append((lat, lon))
+    return pd.DataFrame(rows, columns=["lat", "lon"])
+
+
+def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    lat1, lon1, lat2, lon2 = map(math.radians, (lat1, lon1, lat2, lon2))
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    return 2 * 6378.137 * math.asin(math.sqrt(a))
+
+
+def compute_trajectory_km(mapping_path: Path) -> float | None:
+    import csv
+    with open(mapping_path) as f:
+        rows = list(csv.DictReader(f))
+    if len(rows) < 2:
+        return None
+    total = 0.0
+    for i in range(1, len(rows)):
+        total += haversine_km(
+            float(rows[i - 1]["lat"]), float(rows[i - 1]["lon"]),
+            float(rows[i]["lat"]), float(rows[i]["lon"]),
+        )
+    return total
+
+
+def compute_bbox_area_km2(north: float, south: float, east: float, west: float) -> float:
+    height_km = (north - south) * METERS_PER_DEG_LAT / 1000.0
+    mid_lat = (north + south) / 2.0
+    width_km = (east - west) * METERS_PER_DEG_LAT * math.cos(math.radians(mid_lat)) / 1000.0
+    return width_km * height_km
+
+
+def load_pano_landmark_stats(pano_embed_base: Path, dataset_name: str) -> PanoLandmarkStats | None:
+    dir_name = PANO_LANDMARK_DIR_MAP.get(dataset_name)
+    if dir_name is None:
+        return None
+    pkl_path = pano_embed_base / dir_name / "embeddings" / "embeddings.pkl"
+    if not pkl_path.exists():
+        return None
+    with open(pkl_path, "rb") as f:
+        data = pickle.load(f)
+    panos = data.get("panoramas", {})
+    if not panos:
+        return None
+    total_landmarks = sum(len(p.get("landmarks", [])) for p in panos.values())
+    num_with = sum(1 for p in panos.values() if p.get("landmarks"))
+    return PanoLandmarkStats(
+        num_panoramas=len(panos),
+        num_with_landmarks=num_with,
+        total_landmarks=total_landmarks,
+        avg_landmarks_per_pano=total_landmarks / len(panos),
+    )
+
+
+def compute_stats(config: DatasetConfig, pano_embed_base: Path | None) -> DatasetStats:
+    pano_dir = config.path / "panorama"
+    sat_dir = config.path / "satellite"
+
+    num_panos = len([f for f in pano_dir.iterdir() if f.suffix.lower() in IMAGE_SUFFIXES])
+    num_sats = len([f for f in sat_dir.iterdir() if f.suffix.lower() in IMAGE_SUFFIXES])
+
+    pano_res = get_most_common_resolution(pano_dir)
+    sat_res = get_most_common_resolution(sat_dir)
+
+    sat_coords = parse_satellite_coords(sat_dir)
+    north = sat_coords["lat"].max()
+    south = sat_coords["lat"].min()
+    east = sat_coords["lon"].max()
+    west = sat_coords["lon"].min()
+    bbox = {"north": north, "south": south, "east": east, "west": west}
+
+    mid_lat = (north + south) / 2.0
+    mpp = web_mercator.get_meters_per_pixel(mid_lat, ZOOM_LEVEL)
+
+    ground_normalized = False
+    tile_meta_path = config.path / "satellite_tile_metadata.csv"
+    sb_path = config.path / "satellite_bbox.json"
+    sb_data = {}
+    if sb_path.exists():
+        with open(sb_path) as f:
+            sb_data = json.load(f)
+
+    if tile_meta_path.exists():
+        tile_meta = pd.read_csv(tile_meta_path)
+        sat_ground_w = tile_meta["width_meters"].median()
+        sat_ground_h = tile_meta["height_meters"].median()
+    elif sb_data.get("target_ground_m") is not None:
+        target_ground_m = sb_data["target_ground_m"]
+        ground_normalized = True
+        sat_ground_w = target_ground_m
+        sat_ground_h = target_ground_m
+    else:
+        sat_ground_w = sat_res[0] * mpp
+        sat_ground_h = sat_res[1] * mpp
+
+    half_tile_lat = (sat_ground_h / 2.0) / METERS_PER_DEG_LAT
+    half_tile_lon = (sat_ground_w / 2.0) / (METERS_PER_DEG_LAT * math.cos(math.radians(mid_lat)))
+    extent_km2 = compute_bbox_area_km2(
+        north + half_tile_lat, south - half_tile_lat,
+        east + half_tile_lon, west - half_tile_lon,
+    )
+
+    # OSM landmarks
+    landmark_path = config.path / config.landmark_file
+    landmark_version = Path(config.landmark_file).stem
+    osm_date = parse_osm_date(landmark_version)
+
+    df = gpd.read_feather(landmark_path) if landmark_path.suffix == ".feather" else gpd.read_file(landmark_path)
+    num_raw = len(df)
+
+    meta_cols = {"id", "geometry", "landmark_type", "geometry_px"}
+    kept_cols = [
+        c for c in df.columns
+        if c not in meta_cols
+        and (c in _TAGS_TO_KEEP_SET or any(c.startswith(p) for p in _TAGS_TO_KEEP_PREFIXES))
+    ]
+
+    if kept_cols:
+        kept_df = df[kept_cols]
+        non_ts_cols = [c for c in kept_cols if not pd.api.types.is_datetime64_any_dtype(kept_df[c])]
+        num_pruned = int(kept_df[non_ts_cols].notna().any(axis=1).sum())
+    else:
+        num_pruned = 0
+
+    # Capture date and trajectory length from pipeline_metadata.json
+    capture_date = None
+    trajectory_km = None
+    pm_path = config.path / "pipeline_metadata.json"
+    if pm_path.exists():
+        with open(pm_path) as f:
+            pm = json.load(f)
+        capture_date = pm.get("capture_date")
+        trajectory_km = pm.get("trajectory_km")
+
+    # Fall back to computing trajectory from pano_id_mapping.csv
+    if trajectory_km is None:
+        mapping_path = config.path / "pano_id_mapping.csv"
+        if mapping_path.exists():
+            trajectory_km = compute_trajectory_km(mapping_path)
+
+    # Satellite source
+    sat_source = None
+    if sb_data:
+        source = sb_data.get("source", "unknown")
+        esri_date = sb_data.get("esri_release_date")
+        sat_source = f"{source}" + (f" ({esri_date})" if esri_date else "")
+
+    # Panorama landmarks
+    pano_landmarks = None
+    if pano_embed_base:
+        pano_landmarks = load_pano_landmark_stats(pano_embed_base, config.name)
+
+    return DatasetStats(
+        name=config.name,
+        num_panoramas=num_panos,
+        num_satellites=num_sats,
+        panorama_resolution=pano_res,
+        satellite_resolution=sat_res,
+        satellite_ground_coverage_m=(sat_ground_w, sat_ground_h),
+        ground_normalized=ground_normalized,
+        bbox=bbox,
+        geographic_extent_km2=extent_km2,
+        trajectory_km=trajectory_km,
+        num_landmarks_raw=num_raw,
+        num_landmarks_pruned=num_pruned,
+        landmark_version=landmark_version,
+        osm_date=osm_date,
+        capture_date=capture_date,
+        satellite_source=sat_source,
+        meters_per_pixel=mpp,
+        pano_landmarks=pano_landmarks,
+    )
+
+
+CORE_VIGOR_CITIES = {"Chicago", "NewYork", "SanFrancisco", "Seattle"}
+
+
+def format_value(val) -> str:
+    if val is None:
+        return "—"
+    if isinstance(val, float):
+        if val > 100:
+            return f"{val:,.1f}"
+        return f"{val:.1f}"
+    if isinstance(val, int):
+        return f"{val:,}"
+    return str(val)
+
+
+def print_transposed_table(title: str, stats_list: list[DatasetStats]):
+    """Print a transposed table: rows are metrics, columns are datasets."""
+    if not stats_list:
+        return
+
+    # Build rows: (label, [values...])
+    rows = []
+    for s in stats_list:
+        sat_cover = f"{s.satellite_ground_coverage_m[0]:.1f}x{s.satellite_ground_coverage_m[1]:.1f}"
+        if s.ground_normalized:
+            sat_cover += "*"
+        pano_res = f"{s.panorama_resolution[0]}x{s.panorama_resolution[1]}"
+        vals = {
+            "Panoramas": format_value(s.num_panoramas),
+            "Satellite patches": format_value(s.num_satellites),
+            "Pano resolution": pano_res,
+            "Sat ground cover (m)": sat_cover,
+            "Area (km²)": format_value(s.geographic_extent_km2),
+            "Trajectory (km)": format_value(s.trajectory_km),
+            "OSM landmarks": format_value(s.num_landmarks_raw),
+            "OSM date": s.osm_date or "—",
+            "Pano landmarks": format_value(s.pano_landmarks.total_landmarks) if s.pano_landmarks else "—",
+            "Avg pano lmks/pano": format_value(s.pano_landmarks.avg_landmarks_per_pano) if s.pano_landmarks else "—",
+            "Capture date": s.capture_date or "—",
+            "Satellite source": s.satellite_source or "—",
+        }
+        rows.append(vals)
+
+    # Use short display names for columns
+    short_names = []
+    for s in stats_list:
+        name = s.name.replace("mapillary/", "")
+        short_names.append(name)
+
+    metric_keys = list(rows[0].keys())
+
+    # Compute column widths
+    label_w = max(len(k) for k in metric_keys)
+    col_widths = [max(len(short_names[i]), max(len(rows[i][k]) for k in metric_keys)) for i in range(len(stats_list))]
+
+    # Print
+    print(f"\n{title}")
+    print("-" * 40)
+
+    # Header row
+    header = f"{'':>{label_w}}"
+    for i, name in enumerate(short_names):
+        header += f"  {name:>{col_widths[i]}}"
+    print(header)
+
+    # Data rows
+    for key in metric_keys:
+        row = f"{key:>{label_w}}"
+        for i in range(len(stats_list)):
+            row += f"  {rows[i][key]:>{col_widths[i]}}"
+        print(row)
+
+
+def print_stats(all_stats: list[DatasetStats]):
+    print("VIGOR DATASET STATISTICS")
+    print("-" * 40)
+
+    for s in all_stats:
+        print(f"\n  {s.name}")
+        print(f"  ----")
+        print(f"  Panoramas:               {s.num_panoramas:,}")
+        print(f"  Satellite patches:       {s.num_satellites:,}")
+        print(f"  Panorama resolution:     {s.panorama_resolution[0]} x {s.panorama_resolution[1]}")
+        print(f"  Satellite resolution:    {s.satellite_resolution[0]} x {s.satellite_resolution[1]}")
+        print(f"  Meters/pixel (zoom 20):  {s.meters_per_pixel:.4f}")
+        coverage_note = " (normalized)" if s.ground_normalized else " (native z20)"
+        print(f"  Sat ground coverage:     {s.satellite_ground_coverage_m[0]:.1f} m x {s.satellite_ground_coverage_m[1]:.1f} m{coverage_note}")
+        print(f"  Bounding box:            N={s.bbox['north']:.4f}  S={s.bbox['south']:.4f}  E={s.bbox['east']:.4f}  W={s.bbox['west']:.4f}")
+        print(f"  Geographic extent:       {s.geographic_extent_km2:.2f} km²")
+        if s.trajectory_km is not None:
+            print(f"  Trajectory length:       {s.trajectory_km:.1f} km")
+        print(f"  OSM landmarks (raw):     {s.num_landmarks_raw:,}")
+        print(f"  OSM landmarks (pruned):  {s.num_landmarks_pruned:,}")
+        print(f"  Landmark version:        {s.landmark_version}")
+        if s.osm_date:
+            print(f"  OSM snapshot date:       {s.osm_date}")
+        if s.capture_date:
+            print(f"  Capture date:            {s.capture_date}")
+        if s.satellite_source:
+            print(f"  Satellite source:        {s.satellite_source}")
+        if s.pano_landmarks:
+            pl = s.pano_landmarks
+            print(f"  Pano landmarks:          {pl.total_landmarks:,} total across {pl.num_panoramas:,} panos "
+                  f"({pl.num_with_landmarks:,} with, {pl.num_panoramas - pl.num_with_landmarks:,} without, "
+                  f"avg {pl.avg_landmarks_per_pano:.1f}/pano)")
+
+    # Split into core VIGOR and extended
+    core = [s for s in all_stats if s.name in CORE_VIGOR_CITIES]
+    extended = [s for s in all_stats if s.name not in CORE_VIGOR_CITIES]
+
+    print_transposed_table("CORE VIGOR CITIES", core)
+    print_transposed_table("EXTENDED DATASETS (* = ground-normalized satellite patches)", extended)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gather statistics for VIGOR datasets")
+    parser.add_argument("--dataset_base", type=str, required=True,
+                        help="Base path to VIGOR datasets")
+    parser.add_argument("--pano_embed_base", type=str, default=None,
+                        help="Base path to panorama landmark embeddings")
+    args = parser.parse_args()
+
+    base = Path(args.dataset_base)
+    pano_embed_base = Path(args.pano_embed_base) if args.pano_embed_base else None
+    configs = discover_datasets(base)
+
+    print(f"Discovered {len(configs)} datasets:")
+    for c in configs:
+        print(f"  {c.name}: {c.path}")
+    print()
+
+    all_stats = []
+    for config in configs:
+        print(f"Processing {config.name}...", flush=True)
+        stats = compute_stats(config, pano_embed_base)
+        all_stats.append(stats)
+
+    print_stats(all_stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/dataset_statistics.py
+++ b/experimental/overhead_matching/swag/scripts/dataset_statistics.py
@@ -160,8 +160,8 @@ def parse_satellite_coords(sat_dir: Path) -> pd.DataFrame:
 def compute_trajectory_km(dataset_path: Path) -> float | None:
     if not (dataset_path / "pano_id_mapping.csv").exists():
         return None
-    pano_ids, cum_dist = load_trajectory(dataset_path)
-    if len(pano_ids) < 2:
+    _, cum_dist = load_trajectory(dataset_path)
+    if not cum_dist:
         return None
     return cum_dist[-1] / 1000.0
 

--- a/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
+++ b/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import numpy as np
 import json
+import re
 import argparse
 from pathlib import Path
 
@@ -34,6 +35,30 @@ DISPLAY_NAMES = {
 
 RADII = [25, 50, 100]
 
+_PATH_DIR_RE = re.compile(r"^\d{7}$")
+
+
+def _enumerate_path_dirs(eval_dir: Path) -> list[Path]:
+    """Return the list of path directories, asserting they are densely 0-indexed.
+
+    Raises if any ``{idx:07d}`` directory is missing between 0 and the highest
+    index present — i.e. refuses to silently truncate when a gap would drop
+    later paths from the sample.
+    """
+    present = sorted(
+        p for p in eval_dir.iterdir() if p.is_dir() and _PATH_DIR_RE.match(p.name)
+    )
+    if not present:
+        raise FileNotFoundError(f"No path directories (NNNNNNN) under {eval_dir}")
+    expected = [eval_dir / f"{i:07d}" for i in range(len(present))]
+    if [p.name for p in present] != [p.name for p in expected]:
+        missing = [e.name for e in expected if not e.exists()]
+        raise FileNotFoundError(
+            f"Path directories under {eval_dir} are not densely numbered 0..N; "
+            f"missing {missing}"
+        )
+    return present
+
 
 def load_per_path_convergence_costs(summary_path: Path) -> dict:
     """Load per-path convergence costs from summary_statistics.json."""
@@ -49,91 +74,66 @@ def load_per_path_convergence_costs(summary_path: Path) -> dict:
 def load_per_path_final_errors(eval_dir: Path) -> np.ndarray:
     """Load final localization error for each path from error.pt files."""
     errors = []
-    path_idx = 0
-    while True:
-        err_file = eval_dir / f"{path_idx:07d}" / "error.pt"
-        if not err_file.exists():
-            break
-        err = torch.load(err_file, map_location="cpu")
+    for path_dir in _enumerate_path_dirs(eval_dir):
+        err = torch.load(path_dir / "error.pt", map_location="cpu")
         errors.append(err[-1].item())
-        path_idx += 1
     return np.array(errors)
 
 
 def load_per_path_convergence_curves(
     eval_dir: Path, radius: int
-) -> tuple[list[np.ndarray], list[np.ndarray]]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Load per-path convergence curves (prob mass vs distance traveled).
 
     Returns:
-        distances: list of 1-D arrays (distance traveled at each step)
-        prob_masses: list of 1-D arrays (prob mass within radius at each step)
+        distances:   (n_paths, path_len + 1) — cumulative distance at each step,
+                     with a prepended 0 for the initial state.
+        prob_masses: (n_paths, path_len + 1) — prob mass within ``radius`` at
+                     each step (initial + post each update).
+
+    Raises if path directories are not densely 0-indexed, if any path lacks
+    the requested radius in ``prob_mass_by_radius.pt``, or if paths have
+    different lengths.
     """
+    path_dirs = _enumerate_path_dirs(eval_dir)
+
     distances = []
     prob_masses = []
-    path_idx = 0
-    while True:
-        path_dir = eval_dir / f"{path_idx:07d}"
-        if not path_dir.exists():
-            break
+    for path_dir in path_dirs:
         dist = torch.load(path_dir / "distance_traveled_m.pt", map_location="cpu")
         pmr = torch.load(path_dir / "prob_mass_by_radius.pt", map_location="cpu")
-        if radius in pmr:
-            # prob_mass has shape (path_len + 1): initial + after each step
-            # distance has shape (path_len): cumulative distance at each step
-            # Align: use prob_mass[1:] (after first observation) with distance
-            pm = pmr[radius].numpy()
-            d = dist.numpy()
-            # Prepend 0 distance for the initial state
-            d_with_init = np.concatenate([[0.0], d])
-            distances.append(d_with_init)
-            prob_masses.append(pm)
-        path_idx += 1
-    return distances, prob_masses
+        if radius not in pmr:
+            raise KeyError(
+                f"{path_dir}/prob_mass_by_radius.pt is missing radius {radius}m; "
+                f"available: {sorted(pmr.keys())}"
+            )
+        pm = pmr[radius].numpy()
+        d = dist.numpy()
+        # prob_mass has length path_len + 1 (initial + after each step),
+        # distance has length path_len; prepend 0 for the initial state.
+        d_with_init = np.concatenate([[0.0], d])
+        if len(pm) != len(d_with_init):
+            raise ValueError(
+                f"{path_dir}: prob_mass length {len(pm)} does not match "
+                f"distance length {len(d_with_init)} (= path_len + 1)"
+            )
+        distances.append(d_with_init)
+        prob_masses.append(pm)
 
-
-def interpolate_curves_to_common_grid(
-    distances: list[np.ndarray],
-    values: list[np.ndarray],
-    grid_spacing_m: float = 50.0,
-    min_paths_fraction: float = 0.1,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Interpolate variable-length curves onto a common distance grid.
-
-    Returns:
-        grid: common distance grid
-        mean: mean value at each grid point
-        sem: SEM at each grid point
-        n_active: number of active paths at each grid point
-    """
-    max_dist = max(d[-1] for d in distances)
-    grid = np.arange(0, max_dist + grid_spacing_m, grid_spacing_m)
-
-    # Interpolate each path onto the grid
-    interpolated = np.full((len(distances), len(grid)), np.nan)
-    for i, (d, v) in enumerate(zip(distances, values)):
-        # Only interpolate within the path's distance range
-        mask = grid <= d[-1]
-        interpolated[i, mask] = np.interp(grid[mask], d, v)
-
-    # Compute statistics, masking where too few paths are active
-    n_active = np.sum(~np.isnan(interpolated), axis=0)
-    min_paths = max(1, int(len(distances) * min_paths_fraction))
-    valid = n_active >= min_paths
-
-    mean = np.nanmean(interpolated, axis=0)
-    std = np.nanstd(interpolated, axis=0, ddof=1)
-    ci95 = 1.96 * std / np.sqrt(n_active)
-
-    # Mask invalid points
-    mean[~valid] = np.nan
-    ci95[~valid] = np.nan
-
-    return grid, mean, ci95, n_active
+    expected_len = len(distances[0])
+    for i, (d, pm) in enumerate(zip(distances, prob_masses)):
+        if len(d) != expected_len:
+            raise ValueError(
+                f"{path_dirs[i]}: path length {len(d)} differs from path 0 "
+                f"length {expected_len}; this script requires fixed-length paths"
+            )
+    return np.asarray(distances), np.asarray(prob_masses)
 
 
 def compute_stats(values: np.ndarray) -> tuple[float, float]:
-    """Compute mean and 95% CI half-width (1.96 * SEM)."""
+    """Mean and half-width of the 95% normal-approximation CI for the mean
+    (i.e. 1.96 · SEM). Bounds the uncertainty in the mean estimate, not the
+    spread of the data."""
     mean = np.mean(values)
     ci95 = 1.96 * np.std(values, ddof=1) / np.sqrt(len(values))
     return mean, ci95
@@ -169,81 +169,6 @@ def load_method_data(method_dirs: dict[str, dict[str, Path]]):
     return convergence_costs, final_errors
 
 
-# -- Figure A: Grouped Bar Chart --
-
-
-def plot_grouped_bar_chart(
-    convergence_costs: dict,
-    final_errors: dict,
-    method_names: list[str],
-    output_path: Path,
-    method_colors: dict[str, str] | None = None,
-    method_labels: dict[str, str] | None = None,
-):
-    """Plot grouped bar chart of convergence cost across environments."""
-    if method_colors is None:
-        method_colors = {
-            method_names[0]: "#888888",
-            method_names[1]: "#2196F3",
-        }
-    if method_labels is None:
-        method_labels = {m: m for m in method_names}
-
-    fig, axes = plt.subplots(1, 3, figsize=(16, 5.5), sharey=False)
-    fig.subplots_adjust(wspace=0.3)
-
-    n_envs = len(ENVIRONMENTS)
-    n_methods = len(method_names)
-    bar_width = 0.8 / n_methods
-    x = np.arange(n_envs)
-
-    for ax, radius in zip(axes, RADII):
-        for j, method in enumerate(method_names):
-            means = []
-            sems = []
-            for env in ENVIRONMENTS:
-                costs = convergence_costs[method].get(env, {}).get(radius)
-                if costs is not None and len(costs) > 0:
-                    m, s = compute_stats(costs)
-                    means.append(m)
-                    sems.append(s)
-                else:
-                    means.append(0)
-                    sems.append(0)
-
-            offset = (j - (n_methods - 1) / 2) * bar_width
-            ax.bar(
-                x + offset,
-                means,
-                bar_width,
-                yerr=sems,
-                label=method_labels[method],
-                color=method_colors[method],
-                edgecolor="white",
-                linewidth=0.5,
-                capsize=2,
-                error_kw={"linewidth": 0.8},
-            )
-
-        ax.set_title(f"r = {radius}m", fontsize=14)
-        ax.set_xticks(x)
-        ax.set_xticklabels(
-            [DISPLAY_NAMES[e] for e in ENVIRONMENTS], rotation=45, ha="right", fontsize=11
-        )
-        ax.set_ylabel("Convergence cost (m)" if radius == RADII[0] else "", fontsize=12)
-        ax.spines["top"].set_visible(False)
-        ax.spines["right"].set_visible(False)
-        ax.tick_params(labelsize=10)
-        ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
-
-    axes[0].legend(frameon=False, fontsize=12)
-    fig.tight_layout()
-    fig.savefig(output_path / "fig_a_grouped_bar.pdf", bbox_inches="tight", dpi=150)
-    fig.savefig(output_path / "fig_a_grouped_bar.png", bbox_inches="tight", dpi=150)
-    print(f"Saved grouped bar chart to {output_path / 'fig_a_grouped_bar.pdf'}")
-    plt.close(fig)
-
-
 # -- Figure B: Convergence Curves Over Distance --
 
 
@@ -256,7 +181,10 @@ def plot_convergence_curves(
     method_colors: dict[str, str] | None = None,
     method_labels: dict[str, str] | None = None,
 ):
-    """Plot convergence curves (prob mass vs distance) per environment."""
+    """Plot convergence curves (prob mass vs distance) per environment.
+
+    All paths under each (env, method) must have the same length; the
+    shaded band is a 95% CI for the mean (1.96 · SEM across paths)."""
     if method_colors is None:
         method_colors = {
             method_names[0]: "#888888",
@@ -288,26 +216,25 @@ def plot_convergence_curves(
                 distances, prob_masses = load_per_path_convergence_curves(
                     eval_dir, radius
                 )
-                if not distances:
-                    continue
+                n_paths = len(prob_masses)
+                mean_distance = distances.mean(axis=0)
+                mean_pm = prob_masses.mean(axis=0)
+                pm_std = prob_masses.std(axis=0, ddof=1)
+                ci95 = 1.96 * pm_std / np.sqrt(n_paths)
 
-                grid, mean, sem, n_active = interpolate_curves_to_common_grid(
-                    distances, prob_masses
-                )
-                valid = ~np.isnan(mean)
                 label = f"{method_labels[method]} (r={radius}m)"
                 ax.plot(
-                    grid[valid],
-                    mean[valid],
+                    mean_distance,
+                    mean_pm,
                     label=label,
                     color=method_colors[method],
                     linestyle=ls,
                     linewidth=1.5,
                 )
                 ax.fill_between(
-                    grid[valid],
-                    (mean - sem)[valid],
-                    (mean + sem)[valid],
+                    mean_distance,
+                    mean_pm - ci95,
+                    mean_pm + ci95,
                     alpha=0.15,
                     color=method_colors[method],
                 )
@@ -347,90 +274,6 @@ def plot_convergence_curves(
     print(
         f"Saved convergence curves to {output_path / f'fig_b_convergence_curves_r{suffix}.pdf'}"
     )
-    plt.close(fig)
-
-
-# -- Figure C: Dumbbell / Paired Dot Plot --
-
-
-def plot_dumbbell(
-    convergence_costs: dict,
-    method_names: list[str],
-    output_path: Path,
-    radius: int = 100,
-    method_colors: dict[str, str] | None = None,
-    method_labels: dict[str, str] | None = None,
-):
-    """Plot dumbbell chart comparing two methods across environments."""
-    if method_colors is None:
-        method_colors = {
-            method_names[0]: "#888888",
-            method_names[1]: "#2196F3",
-        }
-    if method_labels is None:
-        method_labels = {m: m for m in method_names}
-
-    fig, ax = plt.subplots(figsize=(8, 5))
-
-    y_positions = np.arange(len(ENVIRONMENTS))
-
-    for j, method in enumerate(method_names):
-        means = []
-        sems = []
-        for env in ENVIRONMENTS:
-            costs = convergence_costs[method].get(env, {}).get(radius)
-            if costs is not None and len(costs) > 0:
-                m, s = compute_stats(costs)
-                means.append(m)
-                sems.append(s)
-            else:
-                means.append(np.nan)
-                sems.append(0)
-
-        ax.errorbar(
-            means,
-            y_positions,
-            xerr=sems,
-            fmt="o",
-            color=method_colors[method],
-            label=method_labels[method],
-            markersize=7,
-            capsize=3,
-            linewidth=0,
-            elinewidth=1.2,
-            zorder=3,
-        )
-
-    # Draw connecting segments
-    for i, env in enumerate(ENVIRONMENTS):
-        vals = []
-        for method in method_names:
-            costs = convergence_costs[method].get(env, {}).get(radius)
-            if costs is not None and len(costs) > 0:
-                vals.append(np.mean(costs))
-            else:
-                vals.append(np.nan)
-        if len(vals) >= 2 and not any(np.isnan(vals)):
-            ax.plot(vals, [i, i], color="#cccccc", linewidth=1.5, zorder=1)
-
-    ax.set_yticks(y_positions)
-    ax.set_yticklabels([DISPLAY_NAMES[e] for e in ENVIRONMENTS], fontsize=12)
-    ax.set_xlabel(f"Convergence cost at r = {radius}m (m)", fontsize=13)
-    ax.invert_yaxis()
-    ax.spines["top"].set_visible(False)
-    ax.spines["right"].set_visible(False)
-    ax.legend(frameon=False, fontsize=12, loc="lower right")
-    ax.tick_params(labelsize=11)
-    ax.xaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
-
-    fig.tight_layout()
-    fig.savefig(
-        output_path / f"fig_c_dumbbell_r{radius}.pdf", bbox_inches="tight", dpi=150
-    )
-    fig.savefig(
-        output_path / f"fig_c_dumbbell_r{radius}.png", bbox_inches="tight", dpi=150
-    )
-    print(f"Saved dumbbell plot to {output_path / f'fig_c_dumbbell_r{radius}.pdf'}")
     plt.close(fig)
 
 
@@ -553,6 +396,13 @@ def main():
         help="Base directory for our method results",
     )
     parser.add_argument(
+        "--seattle_results_dir",
+        type=str,
+        default=None,
+        help="If set, override baseline_dir/ours_dir for the Seattle environment "
+             "(useful when Seattle lives in a different evaluation run)",
+    )
+    parser.add_argument(
         "--baseline_method",
         type=str,
         default="image_only",
@@ -582,20 +432,22 @@ def main():
     output_path = Path(args.output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 
-    # Build method directories
     baseline_base = Path(args.baseline_dir)
     ours_base = Path(args.ours_dir)
+    seattle_base = Path(args.seattle_results_dir) if args.seattle_results_dir else None
 
-    # Seattle uses 260325 results (older run) since it's not in 260330
-    seattle_base = Path("/data/overhead_matching/evaluation/results/260325_correspondence_fusion")
+    def base_for(env: str, default_base: Path) -> Path:
+        if env == "Seattle" and seattle_base is not None:
+            return seattle_base
+        return default_base
 
     method_dirs = {
         "safa": {
-            env: (seattle_base if env == "Seattle" else baseline_base) / env / args.baseline_method
+            env: base_for(env, baseline_base) / env / args.baseline_method
             for env in ENVIRONMENTS
         },
         "ours": {
-            env: (seattle_base if env == "Seattle" else ours_base) / env / args.ours_method
+            env: base_for(env, ours_base) / env / args.ours_method
             for env in ENVIRONMENTS
         },
     }
@@ -607,17 +459,6 @@ def main():
     print("Loading convergence costs and final errors...")
     convergence_costs, final_errors = load_method_data(method_dirs)
 
-    # Figure A: Grouped bar chart
-    print("\nGenerating Figure A: Grouped bar chart...")
-    plot_grouped_bar_chart(
-        convergence_costs,
-        final_errors,
-        ["safa", "ours"],
-        output_path,
-        method_colors=method_colors,
-        method_labels=method_labels,
-    )
-
     # Figure B: Convergence curves
     print("\nGenerating Figure B: Convergence curves over distance...")
     xlim = args.xlim_m if args.xlim_m > 0 else None
@@ -627,17 +468,6 @@ def main():
         output_path,
         radii=args.curve_radii,
         xlim_m=xlim,
-        method_colors=method_colors,
-        method_labels=method_labels,
-    )
-
-    # Figure C: Dumbbell plot
-    print("\nGenerating Figure C: Dumbbell plot...")
-    plot_dumbbell(
-        convergence_costs,
-        ["safa", "ours"],
-        output_path,
-        radius=args.curve_radii[-1],
         method_colors=method_colors,
         method_labels=method_labels,
     )

--- a/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
+++ b/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
@@ -1,0 +1,656 @@
+"""Paper plots: convergence cost and localization error comparison."""
+
+import common.torch.load_torch_deps
+import torch
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import numpy as np
+import json
+import argparse
+from pathlib import Path
+
+
+ENVIRONMENTS = [
+    "Seattle",
+    "Boston",
+    "Framingham",
+    "Middletown",
+    "Norway",
+    "post_hurricane_ian",
+    "SanFrancisco_mapillary",
+    "nightdrive",
+]
+
+DISPLAY_NAMES = {
+    "Boston": "Boston Snowy",
+    "Framingham": "Framingham",
+    "Middletown": "Middletown",
+    "Norway": "Norway",
+    "post_hurricane_ian": "Fort Myers",
+    "SanFrancisco_mapillary": "San Francisco",
+    "Seattle": "Seattle",
+    "nightdrive": "Boston Night",
+}
+
+RADII = [25, 50, 100]
+
+
+def load_per_path_convergence_costs(summary_path: Path) -> dict:
+    """Load per-path convergence costs from summary_statistics.json."""
+    with open(summary_path) as f:
+        stats = json.load(f)
+    return {
+        r: np.array(stats[f"convergence_cost_{r}m"])
+        for r in RADII
+        if f"convergence_cost_{r}m" in stats
+    }
+
+
+def load_per_path_final_errors(eval_dir: Path) -> np.ndarray:
+    """Load final localization error for each path from error.pt files."""
+    errors = []
+    path_idx = 0
+    while True:
+        err_file = eval_dir / f"{path_idx:07d}" / "error.pt"
+        if not err_file.exists():
+            break
+        err = torch.load(err_file, map_location="cpu")
+        errors.append(err[-1].item())
+        path_idx += 1
+    return np.array(errors)
+
+
+def load_per_path_convergence_curves(
+    eval_dir: Path, radius: int
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Load per-path convergence curves (prob mass vs distance traveled).
+
+    Returns:
+        distances: list of 1-D arrays (distance traveled at each step)
+        prob_masses: list of 1-D arrays (prob mass within radius at each step)
+    """
+    distances = []
+    prob_masses = []
+    path_idx = 0
+    while True:
+        path_dir = eval_dir / f"{path_idx:07d}"
+        if not path_dir.exists():
+            break
+        dist = torch.load(path_dir / "distance_traveled_m.pt", map_location="cpu")
+        pmr = torch.load(path_dir / "prob_mass_by_radius.pt", map_location="cpu")
+        if radius in pmr:
+            # prob_mass has shape (path_len + 1): initial + after each step
+            # distance has shape (path_len): cumulative distance at each step
+            # Align: use prob_mass[1:] (after first observation) with distance
+            pm = pmr[radius].numpy()
+            d = dist.numpy()
+            # Prepend 0 distance for the initial state
+            d_with_init = np.concatenate([[0.0], d])
+            distances.append(d_with_init)
+            prob_masses.append(pm)
+        path_idx += 1
+    return distances, prob_masses
+
+
+def interpolate_curves_to_common_grid(
+    distances: list[np.ndarray],
+    values: list[np.ndarray],
+    grid_spacing_m: float = 50.0,
+    min_paths_fraction: float = 0.1,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Interpolate variable-length curves onto a common distance grid.
+
+    Returns:
+        grid: common distance grid
+        mean: mean value at each grid point
+        sem: SEM at each grid point
+        n_active: number of active paths at each grid point
+    """
+    max_dist = max(d[-1] for d in distances)
+    grid = np.arange(0, max_dist + grid_spacing_m, grid_spacing_m)
+
+    # Interpolate each path onto the grid
+    interpolated = np.full((len(distances), len(grid)), np.nan)
+    for i, (d, v) in enumerate(zip(distances, values)):
+        # Only interpolate within the path's distance range
+        mask = grid <= d[-1]
+        interpolated[i, mask] = np.interp(grid[mask], d, v)
+
+    # Compute statistics, masking where too few paths are active
+    n_active = np.sum(~np.isnan(interpolated), axis=0)
+    min_paths = max(1, int(len(distances) * min_paths_fraction))
+    valid = n_active >= min_paths
+
+    mean = np.nanmean(interpolated, axis=0)
+    std = np.nanstd(interpolated, axis=0, ddof=1)
+    ci95 = 1.96 * std / np.sqrt(n_active)
+
+    # Mask invalid points
+    mean[~valid] = np.nan
+    ci95[~valid] = np.nan
+
+    return grid, mean, ci95, n_active
+
+
+def compute_stats(values: np.ndarray) -> tuple[float, float]:
+    """Compute mean and 95% CI half-width (1.96 * SEM)."""
+    mean = np.mean(values)
+    ci95 = 1.96 * np.std(values, ddof=1) / np.sqrt(len(values))
+    return mean, ci95
+
+
+# -- Data Loading --
+
+
+def load_method_data(method_dirs: dict[str, dict[str, Path]]):
+    """Load all data for all methods across all environments.
+
+    Args:
+        method_dirs: {method_name: {env_name: Path}}
+
+    Returns:
+        convergence_costs: {method: {env: {radius: array}}}
+        final_errors: {method: {env: array}}
+    """
+    convergence_costs = {}
+    final_errors = {}
+
+    for method, env_paths in method_dirs.items():
+        convergence_costs[method] = {}
+        final_errors[method] = {}
+        for env, path in env_paths.items():
+            summary = path / "summary_statistics.json"
+            if summary.exists():
+                convergence_costs[method][env] = load_per_path_convergence_costs(
+                    summary
+                )
+            final_errors[method][env] = load_per_path_final_errors(path)
+
+    return convergence_costs, final_errors
+
+
+# -- Figure A: Grouped Bar Chart --
+
+
+def plot_grouped_bar_chart(
+    convergence_costs: dict,
+    final_errors: dict,
+    method_names: list[str],
+    output_path: Path,
+    method_colors: dict[str, str] | None = None,
+    method_labels: dict[str, str] | None = None,
+):
+    """Plot grouped bar chart of convergence cost across environments."""
+    if method_colors is None:
+        method_colors = {
+            method_names[0]: "#888888",
+            method_names[1]: "#2196F3",
+        }
+    if method_labels is None:
+        method_labels = {m: m for m in method_names}
+
+    fig, axes = plt.subplots(1, 3, figsize=(16, 5.5), sharey=False)
+    fig.subplots_adjust(wspace=0.3)
+
+    n_envs = len(ENVIRONMENTS)
+    n_methods = len(method_names)
+    bar_width = 0.8 / n_methods
+    x = np.arange(n_envs)
+
+    for ax, radius in zip(axes, RADII):
+        for j, method in enumerate(method_names):
+            means = []
+            sems = []
+            for env in ENVIRONMENTS:
+                costs = convergence_costs[method].get(env, {}).get(radius)
+                if costs is not None and len(costs) > 0:
+                    m, s = compute_stats(costs)
+                    means.append(m)
+                    sems.append(s)
+                else:
+                    means.append(0)
+                    sems.append(0)
+
+            offset = (j - (n_methods - 1) / 2) * bar_width
+            ax.bar(
+                x + offset,
+                means,
+                bar_width,
+                yerr=sems,
+                label=method_labels[method],
+                color=method_colors[method],
+                edgecolor="white",
+                linewidth=0.5,
+                capsize=2,
+                error_kw={"linewidth": 0.8},
+            )
+
+        ax.set_title(f"r = {radius}m", fontsize=14)
+        ax.set_xticks(x)
+        ax.set_xticklabels(
+            [DISPLAY_NAMES[e] for e in ENVIRONMENTS], rotation=45, ha="right", fontsize=11
+        )
+        ax.set_ylabel("Convergence cost (m)" if radius == RADII[0] else "", fontsize=12)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.tick_params(labelsize=10)
+        ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+
+    axes[0].legend(frameon=False, fontsize=12)
+    fig.tight_layout()
+    fig.savefig(output_path / "fig_a_grouped_bar.pdf", bbox_inches="tight", dpi=150)
+    fig.savefig(output_path / "fig_a_grouped_bar.png", bbox_inches="tight", dpi=150)
+    print(f"Saved grouped bar chart to {output_path / 'fig_a_grouped_bar.pdf'}")
+    plt.close(fig)
+
+
+# -- Figure B: Convergence Curves Over Distance --
+
+
+def plot_convergence_curves(
+    method_dirs: dict[str, dict[str, Path]],
+    method_names: list[str],
+    output_path: Path,
+    radii: list[int] = [50, 100],
+    xlim_m: float | None = 3000,
+    method_colors: dict[str, str] | None = None,
+    method_labels: dict[str, str] | None = None,
+):
+    """Plot convergence curves (prob mass vs distance) per environment."""
+    if method_colors is None:
+        method_colors = {
+            method_names[0]: "#888888",
+            method_names[1]: "#2196F3",
+        }
+    if method_labels is None:
+        method_labels = {m: m for m in method_names}
+
+    # Line styles cycle for radii
+    all_linestyles = ["-", "--", ":", "-."]
+    radius_linestyles = {r: all_linestyles[i % len(all_linestyles)] for i, r in enumerate(radii)}
+
+    n_envs = len(ENVIRONMENTS)
+    n_cols = 4
+    n_rows = (n_envs + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(16, 4 * n_rows), squeeze=False)
+
+    for idx, env in enumerate(ENVIRONMENTS):
+        row, col = divmod(idx, n_cols)
+        ax = axes[row][col]
+
+        for radius in radii:
+            ls = radius_linestyles[radius]
+            for method in method_names:
+                eval_dir = method_dirs[method].get(env)
+                if eval_dir is None or not eval_dir.exists():
+                    continue
+
+                distances, prob_masses = load_per_path_convergence_curves(
+                    eval_dir, radius
+                )
+                if not distances:
+                    continue
+
+                grid, mean, sem, n_active = interpolate_curves_to_common_grid(
+                    distances, prob_masses
+                )
+                valid = ~np.isnan(mean)
+                label = f"{method_labels[method]} (r={radius}m)"
+                ax.plot(
+                    grid[valid],
+                    mean[valid],
+                    label=label,
+                    color=method_colors[method],
+                    linestyle=ls,
+                    linewidth=1.5,
+                )
+                ax.fill_between(
+                    grid[valid],
+                    (mean - sem)[valid],
+                    (mean + sem)[valid],
+                    alpha=0.15,
+                    color=method_colors[method],
+                )
+
+        ax.set_title(DISPLAY_NAMES[env], fontsize=14)
+        ax.set_ylim(-0.05, 1.05)
+        if xlim_m is not None:
+            ax.set_xlim(0, xlim_m)
+        ax.set_xlabel("Distance traveled (m)", fontsize=12)
+        ax.set_ylabel("P(mass within r)" if col == 0 else "", fontsize=12)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.xaxis.set_major_locator(ticker.MultipleLocator(1000))
+        ax.tick_params(labelsize=10)
+
+    # Hide unused axes
+    for idx in range(n_envs, n_rows * n_cols):
+        row, col = divmod(idx, n_cols)
+        axes[row][col].set_visible(False)
+
+    # Single legend from first subplot
+    handles, labels = axes[0][0].get_legend_handles_labels()
+    fig.legend(handles, labels, loc="lower center", ncol=len(radii) * len(method_names),
+               frameon=False, fontsize=12, bbox_to_anchor=(0.5, -0.02))
+    fig.tight_layout()
+    suffix = "_".join(str(r) for r in radii)
+    fig.savefig(
+        output_path / f"fig_b_convergence_curves_r{suffix}.pdf",
+        bbox_inches="tight",
+        dpi=150,
+    )
+    fig.savefig(
+        output_path / f"fig_b_convergence_curves_r{suffix}.png",
+        bbox_inches="tight",
+        dpi=150,
+    )
+    print(
+        f"Saved convergence curves to {output_path / f'fig_b_convergence_curves_r{suffix}.pdf'}"
+    )
+    plt.close(fig)
+
+
+# -- Figure C: Dumbbell / Paired Dot Plot --
+
+
+def plot_dumbbell(
+    convergence_costs: dict,
+    method_names: list[str],
+    output_path: Path,
+    radius: int = 100,
+    method_colors: dict[str, str] | None = None,
+    method_labels: dict[str, str] | None = None,
+):
+    """Plot dumbbell chart comparing two methods across environments."""
+    if method_colors is None:
+        method_colors = {
+            method_names[0]: "#888888",
+            method_names[1]: "#2196F3",
+        }
+    if method_labels is None:
+        method_labels = {m: m for m in method_names}
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+
+    y_positions = np.arange(len(ENVIRONMENTS))
+
+    for j, method in enumerate(method_names):
+        means = []
+        sems = []
+        for env in ENVIRONMENTS:
+            costs = convergence_costs[method].get(env, {}).get(radius)
+            if costs is not None and len(costs) > 0:
+                m, s = compute_stats(costs)
+                means.append(m)
+                sems.append(s)
+            else:
+                means.append(np.nan)
+                sems.append(0)
+
+        ax.errorbar(
+            means,
+            y_positions,
+            xerr=sems,
+            fmt="o",
+            color=method_colors[method],
+            label=method_labels[method],
+            markersize=7,
+            capsize=3,
+            linewidth=0,
+            elinewidth=1.2,
+            zorder=3,
+        )
+
+    # Draw connecting segments
+    for i, env in enumerate(ENVIRONMENTS):
+        vals = []
+        for method in method_names:
+            costs = convergence_costs[method].get(env, {}).get(radius)
+            if costs is not None and len(costs) > 0:
+                vals.append(np.mean(costs))
+            else:
+                vals.append(np.nan)
+        if len(vals) >= 2 and not any(np.isnan(vals)):
+            ax.plot(vals, [i, i], color="#cccccc", linewidth=1.5, zorder=1)
+
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels([DISPLAY_NAMES[e] for e in ENVIRONMENTS], fontsize=12)
+    ax.set_xlabel(f"Convergence cost at r = {radius}m (m)", fontsize=13)
+    ax.invert_yaxis()
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.legend(frameon=False, fontsize=12, loc="lower right")
+    ax.tick_params(labelsize=11)
+    ax.xaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+
+    fig.tight_layout()
+    fig.savefig(
+        output_path / f"fig_c_dumbbell_r{radius}.pdf", bbox_inches="tight", dpi=150
+    )
+    fig.savefig(
+        output_path / f"fig_c_dumbbell_r{radius}.png", bbox_inches="tight", dpi=150
+    )
+    print(f"Saved dumbbell plot to {output_path / f'fig_c_dumbbell_r{radius}.pdf'}")
+    plt.close(fig)
+
+
+# -- Table --
+
+
+def _get_mean_ci(values: np.ndarray | None) -> tuple[float, float] | None:
+    if values is None or len(values) == 0:
+        return None
+    return compute_stats(values)
+
+
+def _fmt_val(mean: float, ci: float, bold: bool) -> str:
+    """Format a value as mean±ci for LaTeX, optionally bold."""
+    s = f"{mean:.0f}$\\pm${ci:.0f}"
+    return f"\\textbf{{{s}}}" if bold else s
+
+
+def print_summary_table(
+    convergence_costs: dict,
+    final_errors: dict,
+    method_names: list[str],
+    method_labels: dict[str, str] | None = None,
+):
+    """Print a paired-comparison LaTeX table. Lower is better; best is bolded."""
+    if method_labels is None:
+        method_labels = {m: m for m in method_names}
+
+    assert len(method_names) == 2, "Paired table expects exactly 2 methods"
+    m_a, m_b = method_names
+
+    # Metrics: (label, radius or None for final error)
+    metrics = [(f"CC$_{{100}}$", 100), ("Error", None)]
+
+    n_metrics = len(metrics)
+    col_spec = "l" + "rr" * n_metrics
+    # Header row 1: metric names spanning 2 columns each
+    header1_parts = []
+    for label, _ in metrics:
+        header1_parts.append(f"\\multicolumn{{2}}{{c}}{{{label}}}")
+    header1 = " & ".join([""] + header1_parts) + " \\\\"
+
+    # Header row 2: method names under each metric
+    header2_parts = []
+    for _ in metrics:
+        header2_parts.append(method_labels[m_a])
+        header2_parts.append(method_labels[m_b])
+    header2 = " & ".join([""] + header2_parts) + " \\\\"
+
+    # cmidrules for grouping
+    cmidrules = ""
+    for i in range(n_metrics):
+        col_start = 2 + i * 2
+        col_end = col_start + 1
+        cmidrules += f"\\cmidrule(lr){{{col_start}-{col_end}}} "
+
+    lines = []
+    lines.append("\\begin{table}[t]")
+    lines.append("\\centering")
+    lines.append("\\caption{Convergence cost (m) and final localization error (m) across environments. "
+                  "Values shown as mean $\\pm$ 95\\% CI. \\textbf{Bold} indicates the better method.}")
+    lines.append(f"\\begin{{tabular}}{{{col_spec}}}")
+    lines.append("\\toprule")
+    lines.append(header1)
+    lines.append(cmidrules)
+    lines.append(header2)
+    lines.append("\\midrule")
+
+    for env in ENVIRONMENTS:
+        row_parts = [DISPLAY_NAMES[env]]
+        for _, radius in metrics:
+            if radius is not None:
+                val_a = _get_mean_ci(convergence_costs[m_a].get(env, {}).get(radius))
+                val_b = _get_mean_ci(convergence_costs[m_b].get(env, {}).get(radius))
+            else:
+                val_a = _get_mean_ci(final_errors[m_a].get(env))
+                val_b = _get_mean_ci(final_errors[m_b].get(env))
+
+            if val_a is None:
+                row_parts.append("--")
+            elif val_b is None:
+                row_parts.append(_fmt_val(*val_a, bold=False))
+            else:
+                row_parts.append(_fmt_val(*val_a, bold=val_a[0] <= val_b[0]))
+
+            if val_b is None:
+                row_parts.append("--")
+            elif val_a is None:
+                row_parts.append(_fmt_val(*val_b, bold=False))
+            else:
+                row_parts.append(_fmt_val(*val_b, bold=val_b[0] <= val_a[0]))
+
+        lines.append(" & ".join(row_parts) + " \\\\")
+
+    lines.append("\\bottomrule")
+    lines.append("\\end{tabular}")
+    lines.append("\\end{table}")
+
+    print("\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Paper convergence plots")
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="/tmp/paper_plots",
+        help="Directory to save figures",
+    )
+    parser.add_argument(
+        "--baseline_dir",
+        type=str,
+        default="/data/overhead_matching/evaluation/results/260310_all_non_vigor_datasets",
+        help="Base directory for SAFA baseline results",
+    )
+    parser.add_argument(
+        "--ours_dir",
+        type=str,
+        default="/data/overhead_matching/evaluation/results/260330_panov2_tuned_prompt",
+        help="Base directory for our method results",
+    )
+    parser.add_argument(
+        "--baseline_method",
+        type=str,
+        default="image_only",
+        help="Subdirectory name for baseline method within each city",
+    )
+    parser.add_argument(
+        "--ours_method",
+        type=str,
+        default="ea_safa_corr",
+        help="Subdirectory name for our method within each city",
+    )
+    parser.add_argument(
+        "--curve_radii",
+        type=int,
+        nargs="+",
+        default=[50, 100],
+        help="Radii for convergence curve plots (Fig B)",
+    )
+    parser.add_argument(
+        "--xlim_m",
+        type=float,
+        default=3000,
+        help="X-axis limit in meters for convergence curves (Fig B). 0 for no limit.",
+    )
+    args = parser.parse_args()
+
+    output_path = Path(args.output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Build method directories
+    baseline_base = Path(args.baseline_dir)
+    ours_base = Path(args.ours_dir)
+
+    # Seattle uses 260325 results (older run) since it's not in 260330
+    seattle_base = Path("/data/overhead_matching/evaluation/results/260325_correspondence_fusion")
+
+    method_dirs = {
+        "safa": {
+            env: (seattle_base if env == "Seattle" else baseline_base) / env / args.baseline_method
+            for env in ENVIRONMENTS
+        },
+        "ours": {
+            env: (seattle_base if env == "Seattle" else ours_base) / env / args.ours_method
+            for env in ENVIRONMENTS
+        },
+    }
+
+    method_colors = {"safa": "#888888", "ours": "#2196F3"}
+    method_labels = {"safa": "SAFA", "ours": "Ours"}
+
+    # Load data
+    print("Loading convergence costs and final errors...")
+    convergence_costs, final_errors = load_method_data(method_dirs)
+
+    # Figure A: Grouped bar chart
+    print("\nGenerating Figure A: Grouped bar chart...")
+    plot_grouped_bar_chart(
+        convergence_costs,
+        final_errors,
+        ["safa", "ours"],
+        output_path,
+        method_colors=method_colors,
+        method_labels=method_labels,
+    )
+
+    # Figure B: Convergence curves
+    print("\nGenerating Figure B: Convergence curves over distance...")
+    xlim = args.xlim_m if args.xlim_m > 0 else None
+    plot_convergence_curves(
+        method_dirs,
+        ["safa", "ours"],
+        output_path,
+        radii=args.curve_radii,
+        xlim_m=xlim,
+        method_colors=method_colors,
+        method_labels=method_labels,
+    )
+
+    # Figure C: Dumbbell plot
+    print("\nGenerating Figure C: Dumbbell plot...")
+    plot_dumbbell(
+        convergence_costs,
+        ["safa", "ours"],
+        output_path,
+        radius=args.curve_radii[-1],
+        method_colors=method_colors,
+        method_labels=method_labels,
+    )
+
+    # Table
+    print("\n\n=== SUMMARY TABLE ===\n")
+    print_summary_table(
+        convergence_costs,
+        final_errors,
+        ["safa", "ours"],
+        method_labels=method_labels,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/trim_dataset_start.py
+++ b/experimental/overhead_matching/swag/scripts/trim_dataset_start.py
@@ -1,0 +1,207 @@
+"""Trim the first N panoramas from a VIGOR dataset.
+
+Moves trimmed panorama images to pretrim/panorama/, backs up and rewrites
+CSV files, and updates evaluation path JSON files.
+
+Usage:
+    python trim_dataset_start.py \
+        --dataset_path /data/overhead_matching/datasets/VIGOR/Boston \
+        --num_frames 35 \
+        --eval_paths /data/overhead_matching/evaluation/paths/mappilary/Boston.json
+"""
+
+import argparse
+import csv
+import json
+import shutil
+from pathlib import Path
+
+
+def read_pano_ids_from_csv(csv_path: Path) -> list[str]:
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        return [row["pano_id"] for row in reader]
+
+
+def backup_and_trim_csv(csv_path: Path, pretrim_dir: Path, num_frames: int):
+    pretrim_dir.mkdir(parents=True, exist_ok=True)
+    backup = pretrim_dir / csv_path.name
+    if backup.exists():
+        raise FileExistsError(f"Backup already exists: {backup}")
+
+    with open(csv_path) as f:
+        lines = f.readlines()
+
+    # lines[0] is header, lines[1:] are data rows
+    header = lines[0]
+    data = lines[1:]
+    print(f"  {csv_path.name}: {len(data)} rows → {len(data) - num_frames} rows")
+
+    shutil.copy2(csv_path, backup)
+    with open(csv_path, "w") as f:
+        f.write(header)
+        f.writelines(data[num_frames:])
+
+
+def backup_and_trim_extraction_log(log_path: Path, pretrim_dir: Path, trim_ids: set[str]):
+    """Trim extraction_log.csv by filtering out rows with trimmed pano_ids (uuid column)."""
+    if not log_path.exists():
+        return
+    if log_path.is_symlink():
+        print(f"  {log_path.name}: symlink, skipping (handled by pano_id_mapping.csv)")
+        return
+
+    pretrim_dir.mkdir(parents=True, exist_ok=True)
+    backup = pretrim_dir / log_path.name
+    if backup.exists():
+        raise FileExistsError(f"Backup already exists: {backup}")
+
+    with open(log_path) as f:
+        lines = f.readlines()
+
+    header = lines[0]
+    # Determine the ID column name (uuid or pano_id)
+    col_names = header.strip().split(",")
+    id_col_idx = None
+    for i, name in enumerate(col_names):
+        if name in ("uuid", "pano_id"):
+            id_col_idx = i
+            break
+    if id_col_idx is None:
+        print(f"  {log_path.name}: no uuid/pano_id column found, skipping")
+        return
+
+    kept = []
+    removed = 0
+    for line in lines[1:]:
+        row_id = line.split(",")[id_col_idx]
+        if row_id in trim_ids:
+            removed += 1
+        else:
+            kept.append(line)
+
+    print(f"  {log_path.name}: removed {removed} rows, {len(kept)} remaining")
+    shutil.copy2(log_path, backup)
+    with open(log_path, "w") as f:
+        f.write(header)
+        f.writelines(kept)
+
+
+def move_panorama_images(pano_dir: Path, pretrim_dir: Path, trim_ids: set[str]):
+    pretrim_pano = pretrim_dir / "panorama"
+    pretrim_pano.mkdir(parents=True, exist_ok=True)
+
+    # Resolve symlinks for the panorama directory
+    real_pano_dir = pano_dir.resolve()
+
+    moved = 0
+    for f in sorted(real_pano_dir.iterdir()):
+        pano_id = f.name.split(",")[0]
+        if pano_id in trim_ids:
+            dest = pretrim_pano / f.name
+            if dest.exists():
+                raise FileExistsError(f"Already exists: {dest}")
+            shutil.move(str(f), str(dest))
+            moved += 1
+
+    print(f"  Moved {moved} panorama images to {pretrim_pano}")
+
+
+def trim_eval_paths(eval_path: Path, pretrim_dir: Path, trim_ids: set[str]):
+    if not eval_path.exists():
+        print(f"  {eval_path}: not found, skipping")
+        return
+
+    pretrim_dir.mkdir(parents=True, exist_ok=True)
+    backup = pretrim_dir / eval_path.name
+    if backup.exists():
+        raise FileExistsError(f"Backup already exists: {backup}")
+
+    with open(eval_path) as f:
+        data = json.load(f)
+
+    original_total = sum(len(p) for p in data["paths"])
+
+    new_paths = []
+    for path_list in data["paths"]:
+        trimmed = [pid for pid in path_list if pid not in trim_ids]
+        if trimmed:
+            new_paths.append(trimmed)
+
+    new_total = sum(len(p) for p in new_paths)
+    print(f"  {eval_path.name}: {len(data['paths'])} paths ({original_total} pano_ids) → {len(new_paths)} paths ({new_total} pano_ids)")
+
+    shutil.copy2(eval_path, backup)
+    data["paths"] = new_paths
+    data["dataset_hash"] = "stale"
+    with open(eval_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def rename_eval_path(eval_path: Path):
+    if not eval_path.exists():
+        print(f"  {eval_path}: not found, skipping")
+        return
+    new_name = eval_path.parent / f"old_{eval_path.name}"
+    if new_name.exists():
+        raise FileExistsError(f"Already exists: {new_name}")
+    eval_path.rename(new_name)
+    print(f"  Renamed {eval_path.name} → {new_name.name}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Trim first N panoramas from a VIGOR dataset")
+    parser.add_argument("--dataset_path", type=str, required=True)
+    parser.add_argument("--num_frames", type=int, required=True)
+    parser.add_argument("--eval_paths", type=str, nargs="*", default=[],
+                        help="Evaluation path JSON files to trim")
+    parser.add_argument("--rename_eval_paths", type=str, nargs="*", default=[],
+                        help="Evaluation path JSON files to rename with old_ prefix")
+    parser.add_argument("--dry_run", action="store_true")
+    args = parser.parse_args()
+
+    dataset = Path(args.dataset_path)
+    pretrim = dataset / "pretrim"
+    num = args.num_frames
+
+    # Step 1: Read pano_ids to trim
+    csv_path = dataset / "pano_id_mapping.csv"
+    all_ids = read_pano_ids_from_csv(csv_path)
+    trim_ids = set(all_ids[:num])
+    print(f"Trimming first {num} panoramas from {dataset.name}")
+    print(f"  Trim set: {list(trim_ids)[:3]}... ({len(trim_ids)} total)")
+    print(f"  New start: {all_ids[num]}")
+    print()
+
+    if args.dry_run:
+        print("DRY RUN — no changes made")
+        return
+
+    # Step 2: Trim CSV files
+    print("Trimming CSV files:")
+    backup_and_trim_csv(csv_path, pretrim, num)
+    extraction_log = dataset / "extraction_log.csv"
+    backup_and_trim_extraction_log(extraction_log, pretrim, trim_ids)
+    print()
+
+    # Step 3: Move panorama images
+    print("Moving panorama images:")
+    pano_dir = dataset / "panorama"
+    move_panorama_images(pano_dir, pretrim, trim_ids)
+    print()
+
+    # Step 4: Trim evaluation paths
+    if args.eval_paths or args.rename_eval_paths:
+        print("Updating evaluation paths:")
+        eval_pretrim = Path("/data/overhead_matching/evaluation/paths/pretrim")
+        for ep in args.eval_paths:
+            trim_eval_paths(Path(ep), eval_pretrim, trim_ids)
+        for ep in args.rename_eval_paths:
+            rename_eval_path(Path(ep))
+        print()
+
+    print("Done. To undo, restore files from pretrim/ directories.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Four standalone analysis/tooling scripts for the SWAG pipeline. Bundled for review convenience — no interdependencies.

- **`dataset_statistics.py`**: panorama/landmark/tag counts across cities, tag frequency, cross-modal coverage.
- **`create_trajectory_paths.py`**: sliding-window eval-path generator for sequential trajectory datasets (forward + backward at fixed step).
- **`trim_dataset_start.py`**: remove the first N panoramas from a VIGOR dataset; moves trimmed images to `pretrim/`, backs up and rewrites CSVs, and updates evaluation path JSONs.
- **`paper_convergence_plot.py`**: load convergence costs from summary JSON and final errors from `.pt` files; plot cross-environment comparisons for paper figures.

Each has a `py_binary` target in `scripts/BUILD`.

## Test plan

- [ ] `bazel build //experimental/overhead_matching/swag/scripts:dataset_statistics //experimental/overhead_matching/swag/scripts:create_trajectory_paths //experimental/overhead_matching/swag/scripts:trim_dataset_start //experimental/overhead_matching/swag/scripts:paper_convergence_plot` passes.
- [ ] Run each `bazel run` target once against a small real dataset/inputs and confirm it produces the expected output (counts, path JSONs, trimmed directory, plot file).