### PR TITLE
Ablation flags + sweep for landmark correspondence model

### DIFF
--- a/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
+++ b/experimental/overhead_matching/swag/data/landmark_correspondence_dataset.py
@@ -306,6 +306,7 @@ def encode_tag_bundle(
     tags: dict[str, str],
     text_embeddings: dict[str, torch.Tensor] | None,
     text_input_dim: int = 768,
+    all_text: bool = False,
 ) -> dict:
     """Encode a tag bundle into tensors for TagBundleEncoder.
 
@@ -335,7 +336,7 @@ def encode_tag_bundle(
             continue
 
         key_indices.append(TAG_KEY_TO_IDX[k])
-        kt = key_type(k)
+        kt = key_type(k) if not all_text else ValueType.TEXT
 
         if kt == ValueType.BOOLEAN:
             value_types.append(ValueType.BOOLEAN)
@@ -396,12 +397,16 @@ def encode_tag_bundle(
                     f"text_embeddings is required but not provided "
                     f"(key={k!r}, value={v!r})"
                 )
-            if v not in text_embeddings:
+            if v in text_embeddings:
+                text_embs.append(text_embeddings[v])
+            elif all_text:
+                text_embs.append(zero_text)
+            else:
                 raise KeyError(
                     f"Text value {v!r} for key {k!r} not found in "
                     f"text_embeddings ({len(text_embeddings)} entries)"
                 )
-            text_embs.append(text_embeddings[v])
+
 
     return {
         "key_indices": key_indices,
@@ -428,6 +433,7 @@ class LandmarkCorrespondenceDataset(Dataset):
         text_embeddings: dict[str, torch.Tensor] | None = None,
         text_input_dim: int = 768,
         include_difficulties: tuple[str, ...] = ("positive", "easy"),
+        all_text: bool = False,
     ):
         """Initialize dataset.
 
@@ -436,10 +442,12 @@ class LandmarkCorrespondenceDataset(Dataset):
             text_embeddings: Pre-computed {value_string: tensor} for text keys
             text_input_dim: Dimension of pre-computed text embeddings
             include_difficulties: Which pair types to include
+            all_text: If True, encode all tag values as text (no numeric/boolean/housenumber branches)
         """
         self.pairs = [p for p in pairs if p.difficulty in include_difficulties]
         self.text_embeddings = text_embeddings
         self.text_input_dim = text_input_dim
+        self.all_text = all_text
 
     def __len__(self) -> int:
         return len(self.pairs)
@@ -447,10 +455,12 @@ class LandmarkCorrespondenceDataset(Dataset):
     def __getitem__(self, idx: int) -> dict:
         pair = self.pairs[idx]
         pano_encoded = encode_tag_bundle(
-            pair.pano_tags, self.text_embeddings, self.text_input_dim
+            pair.pano_tags, self.text_embeddings, self.text_input_dim,
+            all_text=self.all_text,
         )
         osm_encoded = encode_tag_bundle(
-            pair.osm_tags, self.text_embeddings, self.text_input_dim
+            pair.osm_tags, self.text_embeddings, self.text_input_dim,
+            all_text=self.all_text,
         )
         cross_feats = compute_cross_features(
             pair.pano_tags, pair.osm_tags, self.text_embeddings,

--- a/experimental/overhead_matching/swag/evaluation/correspondence_matching.py
+++ b/experimental/overhead_matching/swag/evaluation/correspondence_matching.py
@@ -437,12 +437,13 @@ def batch_encode_landmarks(
     model,  # CorrespondenceClassifier
     device: torch.device,
     batch_size: int = 4096,
+    all_text: bool = False,
 ) -> torch.Tensor:
     """Encode a list of tag bundles through TagBundleEncoder in batches.
 
     Returns: (N, repr_dim) tensor of encoder representations on CPU.
     """
-    all_encoded = [encode_tag_bundle(t, text_embeddings, text_input_dim)
+    all_encoded = [encode_tag_bundle(t, text_embeddings, text_input_dim, all_text=all_text)
                    for t in tags_list]
 
     all_reprs = []
@@ -530,6 +531,7 @@ def compute_cost_matrix(
     text_input_dim: int,
     device: torch.device,
     max_pairs_per_batch: int = 50000,
+    all_text: bool = False,
 ) -> np.ndarray:
     """Compute P(match) for all (pano_lm, osm_lm) pairs.
 
@@ -556,10 +558,10 @@ def compute_cost_matrix(
         for pt in pano_tags_list:
             for ot in osm_chunk:
                 pano_encoded_list.append(
-                    encode_tag_bundle(pt, text_embeddings, text_input_dim)
+                    encode_tag_bundle(pt, text_embeddings, text_input_dim, all_text=all_text)
                 )
                 osm_encoded_list.append(
-                    encode_tag_bundle(ot, text_embeddings, text_input_dim)
+                    encode_tag_bundle(ot, text_embeddings, text_input_dim, all_text=all_text)
                 )
                 cross_features_list.append(
                     compute_cross_features(pt, ot, text_embeddings)
@@ -709,6 +711,7 @@ def precompute_raw_cost_data(
     device: torch.device,
     max_pairs_per_batch: int = 50000,
     checkpoint_dir: str | None = None,
+    all_text: bool = False,
 ) -> RawCorrespondenceData:
     """Precompute a flat (total_pano_lm × total_osm_lm) P(match) matrix.
 
@@ -747,6 +750,7 @@ def precompute_raw_cost_data(
     _log("  Encoding OSM landmarks through TagBundleEncoder...")
     osm_reprs = batch_encode_landmarks(
         osm_tags_list, text_embeddings, text_input_dim, model, device,
+        all_text=all_text,
     )
     _log(f"  OSM representations: {osm_reprs.shape}")
     _log_memory("after encoding OSM landmarks")
@@ -849,6 +853,7 @@ def precompute_raw_cost_data(
         # Encode all pano landmarks in one batch
         pano_reprs = batch_encode_landmarks(
             all_pano_tags, text_embeddings, text_input_dim, model, device,
+            all_text=all_text,
         )
 
         # Pano cross data is small (~200 landmarks)

--- a/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
+++ b/experimental/overhead_matching/swag/model/landmark_correspondence_model.py
@@ -218,6 +218,10 @@ class CorrespondenceClassifierConfig:
     mlp_hidden_dim: int = 128
     dropout: float = 0.1
     num_cross_features: int = 13  # Jaccard(1) + shared_keys(1) + exact_matches(1) + text_sim(3) + numeric(6) + housenumber(1)
+    # Ablation flags — each zeros out a feature group during forward pass.
+    # Valid flags: no_cross, no_text, no_numeric, no_boolean, no_housenumber,
+    #              no_keys, no_encoder
+    ablation: frozenset[str] = field(default_factory=frozenset)
 
 
 # ---------------------------------------------------------------------------
@@ -345,9 +349,19 @@ class CorrespondenceClassifier(nn.Module):
     Takes two tag bundles (pano, OSM) and predicts P(same physical object).
     """
 
+    VALID_ABLATION_FLAGS = frozenset([
+        "no_cross", "no_text", "no_numeric", "no_boolean",
+        "no_housenumber", "no_keys", "no_encoder", "only_text_cross",
+        "only_text_hn_cross",
+    ])
+
     def __init__(self, config: CorrespondenceClassifierConfig):
         super().__init__()
         self.config = config
+        self.ablation = config.ablation
+        bad_flags = self.ablation - self.VALID_ABLATION_FLAGS
+        if bad_flags:
+            raise ValueError(f"Unknown ablation flags: {bad_flags}")
 
         # Shared twin encoder
         self.encoder = TagBundleEncoder(config.encoder)
@@ -390,6 +404,29 @@ class CorrespondenceClassifier(nn.Module):
 
         Returns: (B, 1) logits
         """
+        abl = self.ablation
+
+        # Apply input-level ablations before encoding
+        if "no_text" in abl:
+            pano_text_embeddings = torch.zeros_like(pano_text_embeddings)
+            osm_text_embeddings = torch.zeros_like(osm_text_embeddings)
+        if "no_numeric" in abl:
+            pano_numeric_values = torch.zeros_like(pano_numeric_values)
+            pano_numeric_nan_mask = torch.ones_like(pano_numeric_nan_mask)
+            osm_numeric_values = torch.zeros_like(osm_numeric_values)
+            osm_numeric_nan_mask = torch.ones_like(osm_numeric_nan_mask)
+        if "no_boolean" in abl:
+            pano_boolean_values = torch.full_like(pano_boolean_values, BooleanValue.UNKNOWN)
+            osm_boolean_values = torch.full_like(osm_boolean_values, BooleanValue.UNKNOWN)
+        if "no_housenumber" in abl:
+            pano_housenumber_values = torch.zeros_like(pano_housenumber_values)
+            pano_housenumber_nan_mask = torch.ones_like(pano_housenumber_nan_mask)
+            osm_housenumber_values = torch.zeros_like(osm_housenumber_values)
+            osm_housenumber_nan_mask = torch.ones_like(osm_housenumber_nan_mask)
+        if "no_keys" in abl:
+            pano_key_indices = torch.zeros_like(pano_key_indices)
+            osm_key_indices = torch.zeros_like(osm_key_indices)
+
         pano_repr = self.encoder(
             pano_key_indices, pano_value_type, pano_boolean_values,
             pano_numeric_values, pano_numeric_nan_mask,
@@ -402,6 +439,22 @@ class CorrespondenceClassifier(nn.Module):
             osm_housenumber_values, osm_housenumber_nan_mask,
             osm_text_embeddings, osm_tag_mask,
         )
+
+        # Representation-level ablations
+        if "no_encoder" in abl:
+            pano_repr = torch.zeros_like(pano_repr)
+            osm_repr = torch.zeros_like(osm_repr)
+        if "no_cross" in abl:
+            cross_features = torch.zeros_like(cross_features)
+        elif "only_text_cross" in abl:
+            mask = torch.zeros_like(cross_features)
+            mask[:, 3:6] = 1.0  # keep text cosine sim (max, mean, name)
+            cross_features = cross_features * mask
+        elif "only_text_hn_cross" in abl:
+            mask = torch.zeros_like(cross_features)
+            mask[:, 3:6] = 1.0  # text cosine sim (max, mean, name)
+            mask[:, 12] = 1.0   # housenumber range overlap
+            cross_features = cross_features * mask
 
         # Elementwise product captures multiplicative interaction between pano
         # and osm representations. Motivated by ESIM (Chen et al. 2016,

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -888,6 +888,47 @@ py_binary(
   ]
 )
 
+py_library(
+  name="train_landmark_correspondence_lib",
+  srcs=["train_landmark_correspondence.py"],
+  visibility=["//experimental/overhead_matching/swag:__subpackages__"],
+  deps=[
+    requirement("torch"),
+    requirement("tensorboard"),
+    requirement("tqdm"),
+    requirement("numpy"),
+    requirement("scikit-learn"),
+    ":correspondence_configs",
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:landmark_correspondence_dataset",
+    "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
+  ]
+)
+
+py_binary(
+  name="evaluate_ablation_sweep",
+  srcs=["evaluate_ablation_sweep.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("scikit-learn"),
+    ":correspondence_configs",
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:landmark_correspondence_dataset",
+    "//experimental/overhead_matching/swag/model:landmark_correspondence_model",
+  ]
+)
+
+py_binary(
+  name="run_correspondence_ablation",
+  srcs=["run_correspondence_ablation.py"],
+  deps=[
+    ":train_landmark_correspondence_lib",
+    ":correspondence_configs",
+    "//common/torch:load_torch_deps",
+  ]
+)
+
 py_binary(
   name="export_correspondence_similarity",
   srcs=["export_correspondence_similarity.py"],

--- a/experimental/overhead_matching/swag/scripts/correspondence_configs.py
+++ b/experimental/overhead_matching/swag/scripts/correspondence_configs.py
@@ -36,6 +36,8 @@ class CorrespondenceTrainConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
     encoder: CorrespondenceEncoderConfig
     classifier: CorrespondenceClassifierMlpConfig
     cosine_schedule: bool = False
+    ablation: list[str] = []
+    all_text: bool = False
 
 
 def _enc_hook(obj):

--- a/experimental/overhead_matching/swag/scripts/evaluate_ablation_sweep.py
+++ b/experimental/overhead_matching/swag/scripts/evaluate_ablation_sweep.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Evaluate ablation sweep models on held-out cities.
+
+Usage:
+    bazel run //experimental/overhead_matching/swag/scripts:evaluate_ablation_sweep -- \
+        --sweep_dir /data/.../ablation_sweep_v5 \
+        --text_embeddings_path /data/.../eval_text_embeddings_all_cities.pkl \
+        --data_dirs /data/.../mapillary/*/responses /data/.../boston_snowy/responses ...
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401
+
+import numpy as np
+import torch
+from sklearn.metrics import roc_auc_score
+from torch.utils.data import DataLoader
+
+from experimental.overhead_matching.swag.data.landmark_correspondence_dataset import (
+    LandmarkCorrespondenceDataset,
+    collate_correspondence,
+    load_pairs_from_directory,
+    load_text_embeddings,
+)
+from experimental.overhead_matching.swag.model.landmark_correspondence_model import (
+    CorrespondenceClassifier,
+    CorrespondenceClassifierConfig,
+    TagBundleEncoderConfig,
+)
+from experimental.overhead_matching.swag.scripts.correspondence_configs import (
+    load_config,
+)
+
+
+def eval_model_on_pairs(model, pairs, text_embeddings, text_input_dim, device):
+    ds = LandmarkCorrespondenceDataset(
+        pairs, text_embeddings, text_input_dim,
+        include_difficulties=("positive", "easy", "hard"),
+    )
+    if len(ds) == 0:
+        return None
+    loader = DataLoader(ds, batch_size=512, shuffle=False,
+                        collate_fn=collate_correspondence, num_workers=0)
+    all_labels, all_probs = [], []
+    with torch.no_grad():
+        for batch in loader:
+            batch = batch.to(device)
+            logits = model(
+                pano_key_indices=batch.pano_key_indices,
+                pano_value_type=batch.pano_value_type,
+                pano_boolean_values=batch.pano_boolean_values,
+                pano_numeric_values=batch.pano_numeric_values,
+                pano_numeric_nan_mask=batch.pano_numeric_nan_mask,
+                pano_housenumber_values=batch.pano_housenumber_values,
+                pano_housenumber_nan_mask=batch.pano_housenumber_nan_mask,
+                pano_text_embeddings=batch.pano_text_embeddings,
+                pano_tag_mask=batch.pano_tag_mask,
+                osm_key_indices=batch.osm_key_indices,
+                osm_value_type=batch.osm_value_type,
+                osm_boolean_values=batch.osm_boolean_values,
+                osm_numeric_values=batch.osm_numeric_values,
+                osm_numeric_nan_mask=batch.osm_numeric_nan_mask,
+                osm_housenumber_values=batch.osm_housenumber_values,
+                osm_housenumber_nan_mask=batch.osm_housenumber_nan_mask,
+                osm_text_embeddings=batch.osm_text_embeddings,
+                osm_tag_mask=batch.osm_tag_mask,
+                cross_features=batch.cross_features,
+            ).squeeze(-1)
+            all_probs.extend(torch.sigmoid(logits).cpu().tolist())
+            all_labels.extend(batch.labels.cpu().tolist())
+
+    la = np.array(all_labels)
+    pa = np.array(all_probs)
+    try:
+        auc = roc_auc_score(la, pa)
+    except ValueError:
+        auc = float("nan")
+    return auc
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sweep_dir", type=Path, required=True)
+    parser.add_argument("--text_embeddings_path", type=Path, required=True)
+    parser.add_argument("--data_dirs", type=Path, nargs="+", required=True)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    text_embeddings = load_text_embeddings(args.text_embeddings_path)
+    text_input_dim = next(iter(text_embeddings.values())).shape[0]
+
+    # Load all city pairs once
+    city_pairs = {}
+    for data_dir in args.data_dirs:
+        city_name = data_dir.parent.name if data_dir.name == "responses" else data_dir.name
+        pairs = load_pairs_from_directory(data_dir)
+        if pairs:
+            city_pairs[city_name] = pairs
+            n_pos = sum(1 for p in pairs if p.difficulty == "positive")
+            print(f"  {city_name}: {len(pairs)} pairs ({n_pos} positive)")
+
+    # Find variant directories
+    variant_dirs = sorted([
+        d for d in args.sweep_dir.iterdir()
+        if d.is_dir() and (d / "best_model.pt").exists()
+    ])
+
+    # Evaluate each variant
+    results = {}  # variant -> {city -> auc}
+    for variant_dir in variant_dirs:
+        variant_name = variant_dir.name
+        config = load_config(variant_dir / "config.yaml")
+        ablation = frozenset(config.ablation)
+
+        encoder_config = TagBundleEncoderConfig(
+            text_input_dim=text_input_dim, text_proj_dim=128)
+        classifier_config = CorrespondenceClassifierConfig(
+            encoder=encoder_config, ablation=ablation)
+        model = CorrespondenceClassifier(classifier_config).to(device)
+        model.load_state_dict(torch.load(
+            variant_dir / "best_model.pt", map_location=device, weights_only=True))
+        model.eval()
+
+        results[variant_name] = {}
+        for city_name, pairs in city_pairs.items():
+            auc = eval_model_on_pairs(model, pairs, text_embeddings, text_input_dim, device)
+            results[variant_name][city_name] = auc
+
+    # Print table
+    cities = list(city_pairs.keys())
+    header = f"{'Variant':25s}" + "".join(f" {c:>12s}" for c in cities) + f" {'MEAN':>8s}"
+    print(f"\n{header}")
+    print("-" * len(header))
+    for variant_name in [d.name for d in variant_dirs]:
+        row = f"{variant_name:25s}"
+        aucs = []
+        for city in cities:
+            auc = results[variant_name].get(city)
+            if auc is not None and not np.isnan(auc):
+                row += f" {auc:12.4f}"
+                aucs.append(auc)
+            else:
+                row += f" {'N/A':>12s}"
+        mean_auc = np.mean(aucs) if aucs else float("nan")
+        row += f" {mean_auc:8.4f}"
+        print(row)
+
+    # Save JSON
+    out_path = args.sweep_dir / "held_out_eval.json"
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
+++ b/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
@@ -97,6 +97,10 @@ def main():
     parser.add_argument("--uniqueness_weighted", action="store_true",
                         help="Weight matched pairs by pano landmark uniqueness "
                              "(1/log2(1 + n_matches))")
+    parser.add_argument("--ablation", nargs="*", default=[],
+                        help="Ablation flags for the model (e.g. no_numeric no_boolean)")
+    parser.add_argument("--all_text", action="store_true",
+                        help="Encode all tag values as text (no numeric/boolean/housenumber branches)")
     args = parser.parse_args()
 
     dataset_path = args.dataset_path.expanduser().resolve()
@@ -163,8 +167,11 @@ def main():
 
     # 2. Load model
     print(f"Loading model from {args.model_path}")
+    ablation = frozenset(args.ablation)
+    if ablation:
+        print(f"  Ablation: {sorted(ablation)}")
     encoder_config = TagBundleEncoderConfig(text_input_dim=text_input_dim, text_proj_dim=128)
-    classifier_config = CorrespondenceClassifierConfig(encoder=encoder_config)
+    classifier_config = CorrespondenceClassifierConfig(encoder=encoder_config, ablation=ablation)
     model = CorrespondenceClassifier(classifier_config).to(device)
     model.load_state_dict(torch.load(args.model_path, map_location=device, weights_only=True))
     model.eval()
@@ -208,6 +215,7 @@ def main():
             pano_tags_from_pano_id=pano_tags_from_pano_id,
             device=device,
             checkpoint_dir=_ckpt_dir,
+            all_text=args.all_text,
         )
 
         # Save raw data — cost matrix as .npy (handles large arrays without pickle OOM),

--- a/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
+++ b/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
@@ -57,11 +57,12 @@ from experimental.overhead_matching.swag.scripts.landmark_pairing_cli import (
 )
 
 
-def collect_unique_text_values(data_dir: Path) -> dict[str, int]:
-    """Scan JSONL files and collect all unique text-type tag values with counts.
+def collect_unique_text_values(data_dir: Path, all_value_types: bool = False) -> dict[str, int]:
+    """Scan JSONL files and collect unique tag values with counts.
 
     Args:
         data_dir: Root directory containing {Chicago,Seattle}/responses/ subdirs
+        all_value_types: If True, collect ALL tag values (not just text-type keys)
 
     Returns:
         Counter mapping value strings to their occurrence counts
@@ -89,7 +90,7 @@ def collect_unique_text_values(data_dir: Path) -> dict[str, int]:
                     for landmarks in [set1, set2]:
                         for tags in landmarks:
                             for k, v in tags.items():
-                                if key_type(k) == ValueType.TEXT:
+                                if all_value_types or key_type(k) == ValueType.TEXT:
                                     value_counts[v] += 1
                 except (json.JSONDecodeError, KeyError, ValueError):
                     skipped += 1
@@ -235,6 +236,10 @@ def main():
         "--stats_only", action="store_true",
         help="Only print statistics, don't embed",
     )
+    parser.add_argument(
+        "--all_value_types", action="store_true",
+        help="Embed ALL tag values, not just text-type keys (includes numeric, boolean, housenumber)",
+    )
     args = parser.parse_args()
 
     if not args.data_dir and not args.feather_dirs and not args.pano_v2_base:
@@ -245,7 +250,7 @@ def main():
 
     if args.data_dir:
         print("Collecting from JSONL responses...")
-        value_counts += collect_unique_text_values(args.data_dir)
+        value_counts += collect_unique_text_values(args.data_dir, all_value_types=args.all_value_types)
 
     if args.feather_dirs:
         print(f"Collecting from {len(args.feather_dirs)} feather directories...")

--- a/experimental/overhead_matching/swag/scripts/run_correspondence_ablation.py
+++ b/experimental/overhead_matching/swag/scripts/run_correspondence_ablation.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Run feature ablation sweep for the correspondence classifier.
+
+Trains the classifier multiple times, each with a different set of features
+disabled, to identify which feature groups matter most.
+
+Usage:
+    bazel run //experimental/overhead_matching/swag/scripts:run_correspondence_ablation -- \
+        --base_config /path/to/config.yaml \
+        --output_base /data/overhead_matching/training_outputs/landmark_correspondence/ablation_sweep
+"""
+
+import argparse
+import json
+import copy
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401 - Must import before torch
+
+from experimental.overhead_matching.swag.scripts.correspondence_configs import (
+    CorrespondenceTrainConfig,
+    load_config,
+    save_config,
+)
+from experimental.overhead_matching.swag.scripts.train_landmark_correspondence import (
+    train,
+)
+
+
+ABLATION_VARIANTS = {
+    # name -> list of ablation flags
+    "full": [],                                                          # baseline
+    "no_cross": ["no_cross"],                                            # encoder only
+    "no_text": ["no_text"],                                              # no text embeddings
+    "no_numeric_bool_hn": ["no_numeric", "no_boolean", "no_housenumber"],  # text + keys + cross
+    "no_encoder": ["no_encoder"],                                        # cross features only
+    "no_keys": ["no_keys"],                                              # no key embeddings
+    "text_cross_only": ["no_numeric", "no_boolean", "no_housenumber", "no_keys"],  # text + cross
+    "keys_cross_only": ["no_text", "no_numeric", "no_boolean", "no_housenumber"],  # keys + cross
+    "minimal": ["no_numeric", "no_boolean", "no_housenumber", "only_text_cross"],  # keys + text + 3 text cosine cross
+    "minimal_no_keys": ["no_numeric", "no_boolean", "no_housenumber", "no_keys", "only_text_cross"],  # text + 3 text cosine cross
+    "minimal_no_text": ["no_numeric", "no_boolean", "no_housenumber", "no_text", "only_text_cross"],  # keys + 3 text cosine cross
+}
+
+
+def run_sweep(base_config: CorrespondenceTrainConfig, output_base: Path,
+              variants: list[str] | None = None) -> None:
+    results = {}
+    variant_names = variants if variants else list(ABLATION_VARIANTS.keys())
+
+    for name in variant_names:
+        if name not in ABLATION_VARIANTS:
+            print(f"Unknown variant: {name}, skipping")
+            continue
+
+        ablation_flags = ABLATION_VARIANTS[name]
+        print(f"\n{'=' * 70}")
+        print(f"ABLATION: {name} (flags: {ablation_flags or 'none'})")
+        print(f"{'=' * 70}\n")
+
+        # Create a modified config for this variant
+        config = copy.copy(base_config)
+        config = CorrespondenceTrainConfig(
+            data_dir=base_config.data_dir,
+            text_embeddings_path=base_config.text_embeddings_path,
+            output_dir=output_base / name,
+            train_city=base_config.train_city,
+            val_city=base_config.val_city,
+            include_difficulties=base_config.include_difficulties,
+            batch_size=base_config.batch_size,
+            num_epochs=base_config.num_epochs,
+            lr=base_config.lr,
+            weight_decay=base_config.weight_decay,
+            warmup_fraction=base_config.warmup_fraction,
+            gradient_clip_norm=base_config.gradient_clip_norm,
+            use_amp=base_config.use_amp,
+            num_workers=base_config.num_workers,
+            seed=base_config.seed,
+            encoder=base_config.encoder,
+            classifier=base_config.classifier,
+            cosine_schedule=base_config.cosine_schedule,
+            ablation=ablation_flags,
+            all_text=base_config.all_text,
+        )
+
+        train(config)
+
+        # Read back best model's val metrics from the last checkpoint
+        best_model_path = config.output_dir / "best_model.pt"
+        if best_model_path.exists():
+            results[name] = {"ablation": ablation_flags, "model_saved": True}
+        else:
+            results[name] = {"ablation": ablation_flags, "model_saved": False}
+
+    # Print summary
+    print(f"\n{'=' * 70}")
+    print("ABLATION SWEEP COMPLETE")
+    print(f"{'=' * 70}")
+    print(f"\nResults saved to: {output_base}")
+    print(f"Variants run: {list(results.keys())}")
+    print(f"\nCompare with tensorboard:")
+    print(f"  bazel run //common/torch:run_tensorboard -- --logdir {output_base}")
+
+    # Save results index
+    with open(output_base / "sweep_index.json", "w") as f:
+        json.dump(results, f, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Correspondence classifier ablation sweep")
+    parser.add_argument("--base_config", type=Path, required=True,
+                        help="Base YAML config (ablation and output_dir will be overridden)")
+    parser.add_argument("--output_base", type=Path, required=True,
+                        help="Base output directory (each variant gets a subdirectory)")
+    parser.add_argument("--variants", nargs="+", default=None,
+                        help=f"Which variants to run (default: all). "
+                             f"Options: {', '.join(ABLATION_VARIANTS.keys())}")
+    args = parser.parse_args()
+
+    base_config = load_config(args.base_config)
+    output_base = args.output_base
+    output_base.mkdir(parents=True, exist_ok=True)
+
+    run_sweep(base_config, output_base, args.variants)
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
+++ b/experimental/overhead_matching/swag/scripts/train_landmark_correspondence.py
@@ -318,11 +318,16 @@ def train(config: CorrespondenceTrainConfig) -> None:
             PARSE_REPORT_PATH.unlink()
         print("  No parse failures found")
 
+    all_text = config.all_text
+    if all_text:
+        print("all_text mode: encoding all tag values as text")
     train_dataset = LandmarkCorrespondenceDataset(
         train_pairs, text_embeddings, text_input_dim, include_difficulties,
+        all_text=all_text,
     )
     val_dataset = LandmarkCorrespondenceDataset(
         val_pairs, text_embeddings, text_input_dim, include_difficulties,
+        all_text=all_text,
     )
     print(f"After filtering: train={len(train_dataset):,}, val={len(val_dataset):,}")
     if len(train_dataset) == 0:
@@ -345,6 +350,7 @@ def train(config: CorrespondenceTrainConfig) -> None:
     )
 
     # Create model
+    ablation = frozenset(config.ablation)
     encoder_config = TagBundleEncoderConfig(
         text_input_dim=text_input_dim,
         text_proj_dim=config.encoder.text_proj_dim,
@@ -353,10 +359,13 @@ def train(config: CorrespondenceTrainConfig) -> None:
         encoder=encoder_config,
         mlp_hidden_dim=config.classifier.mlp_hidden_dim,
         dropout=config.classifier.dropout,
+        ablation=ablation,
     )
     model = CorrespondenceClassifier(classifier_config).to(device)
     num_params = sum(p.numel() for p in model.parameters())
     print(f"\nModel: {num_params:,} parameters")
+    if ablation:
+        print(f"Ablation: {sorted(ablation)}")
 
     # Optimizer
     optimizer = AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)


### PR DESCRIPTION
## Summary

Ablation infrastructure for the landmark correspondence classifier, plus the sweep orchestration scripts that use it. Bundled so the full ablation story lands or is archived as one unit.

- **Model / dataset / eval wiring**: adds `ablation: frozenset[str]` and `all_text: bool` to the classifier config and threads them through the model forward pass, dataset encoding, correspondence matching, and the export script.
  - Ablations: `no_text`, `no_numeric`, `no_boolean`, `no_housenumber`, `no_keys`, `no_encoder`, `no_cross`, `only_text_cross`, `only_text_hn_cross`.
  - `all_text` routes every tag value through the text branch, with zero fallback for values missing from the text-embedding vocabulary.
- **Bug fix in `encode_tag_bundle`**: the previous `if v not in text_embeddings: append(text_embeddings[v])` was inverted in both branches; now appends only when `v in text_embeddings` and falls back to zeros when `all_text=True`.
- **`precompute_value_embeddings.py --all_value_types`**: embeds the full tag vocabulary (not just text-type keys) so `all_text` inference has values available.
- **New scripts**:
  - `run_correspondence_ablation.py`: orchestrates training the 11 variants by importing `train()` from the new `train_landmark_correspondence_lib` `py_library`.
  - `evaluate_ablation_sweep.py`: evaluates per-variant ROC-AUC on held-out cities.
- **`export_correspondence_similarity.py`**: `--ablation`/`--all_text` flags for inference.

## Test plan

- [ ] `bazel build //experimental/overhead_matching/swag/...` passes.
- [ ] `bazel test //experimental/overhead_matching/swag/model:landmark_correspondence_model_test //experimental/overhead_matching/swag/data:landmark_correspondence_dataset_test` passes.
- [ ] Smoke-train one ablation variant (`--ablation no_cross`) and one `--all_text` run; confirm loss decreases.
- [ ] Run `run_correspondence_ablation` with a tiny epoch count; confirm per-variant output dirs are readable by `evaluate_ablation_sweep`.
- [ ] Run `export_correspondence_similarity --ablation no_cross --all_text --save_raw` end-to-end; confirm it produces a cost matrix.