### PR TITLE
Exp A: WAG pano→satellite on CVG-Text

### DIFF
--- a/experimental/overhead_matching/swag/data/BUILD
+++ b/experimental/overhead_matching/swag/data/BUILD
@@ -39,7 +39,11 @@ py_library(
     "//experimental/overhead_matching/swag:__subpackages__",
   ],
   deps = [
+    ":vigor_dataset",
+    "//common/torch:load_torch_deps",
     requirement("pandas"),
+    requirement("torch"),
+    requirement("torchvision"),
   ],
 )
 

--- a/experimental/overhead_matching/swag/data/cvgtext_dataset.py
+++ b/experimental/overhead_matching/swag/data/cvgtext_dataset.py
@@ -11,10 +11,15 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
+import common.torch.load_torch_deps  # noqa: F401
 import pandas as pd
+import torch
+import torchvision as tv
+
+from experimental.overhead_matching.swag.data import vigor_dataset as vd
 
 _FILENAME_RE = re.compile(
     r"^(?P<lat>-?[\d.]+),(?P<lon>-?[\d.]+)_"
@@ -27,6 +32,17 @@ _FILENAME_RE = re.compile(
 
 CITIES = ("Brisbane", "NewYork", "Tokyo")
 GALLERY_KINDS = ("satellite", "OSM")
+
+
+@dataclass
+class _MinimalConfig:
+    """The subset of `VigorDatasetConfig` that `get_dataloader`'s `worker_init_fn`
+    reads from `dataset._config`. We don't run tensor caches on CVG-Text, so both
+    fields stay `None` and `load_tensor_caches` returns an empty dict.
+    """
+
+    panorama_tensor_cache_info: object | None = None
+    satellite_tensor_cache_info: object | None = None
 
 
 def _parse_filename(fn: str) -> dict:
@@ -55,6 +71,10 @@ class CVGTextDataset:
         gallery_kind: "satellite" or "OSM" — which reference gallery to retrieve against.
         query_view: "ground" (panoramas) or "photos-ground" (single-view). We default to
             "ground" — the paper's single-view variant is out of scope here.
+        panorama_size: `(H, W)` to which panoramas are resized when loading for image-
+            based retrieval (Exp A). Required if `get_pano_view()` is used.
+        satellite_patch_size: `(H, W)` to which satellite tiles are resized. Required if
+            `get_sat_patch_view()` is used.
     """
 
     root: Path
@@ -62,6 +82,8 @@ class CVGTextDataset:
     split: str = "test"
     gallery_kind: str = "satellite"
     query_view: str = "ground"
+    panorama_size: tuple[int, int] | None = None
+    satellite_patch_size: tuple[int, int] | None = None
 
     def __post_init__(self):
         self.root = Path(self.root)
@@ -122,6 +144,12 @@ class CVGTextDataset:
             )
         self._panorama_metadata = pd.DataFrame(query_rows).reset_index(drop=True)
 
+        # Minimal config for `get_dataloader`'s `worker_init_fn`; we don't use
+        # tensor caches so both entries stay `None`.
+        self._config = _MinimalConfig()
+        self._panorama_tensor_caches = {}
+        self._satellite_tensor_caches = {}
+
     @property
     def num_queries(self) -> int:
         return len(self._panorama_metadata)
@@ -141,3 +169,73 @@ class CVGTextDataset:
     @property
     def gallery_image_paths(self) -> list[str]:
         return self._satellite_metadata["path"].tolist()
+
+    # --- image-view methods used by `evaluate_swag.compute_similarity_matrix` --- #
+
+    def get_sat_patch_view(self) -> torch.utils.data.Dataset:
+        """torch Dataset over gallery images. Each item yields a VigorDatasetItem
+        with only `satellite` populated. Resize target is `satellite_patch_size`.
+        """
+        if self.satellite_patch_size is None:
+            raise RuntimeError(
+                "satellite_patch_size is not set; pass it to CVGTextDataset() "
+                "to use get_sat_patch_view()."
+            )
+        return _SatPatchView(self)
+
+    def get_pano_view(self) -> torch.utils.data.Dataset:
+        """torch Dataset over query panoramas. Each item yields a VigorDatasetItem
+        with only `panorama` populated. Resize target is `panorama_size`.
+        """
+        if self.panorama_size is None:
+            raise RuntimeError(
+                "panorama_size is not set; pass it to CVGTextDataset() "
+                "to use get_pano_view()."
+            )
+        return _PanoView(self)
+
+
+class _SatPatchView(torch.utils.data.Dataset):
+    def __init__(self, dataset: CVGTextDataset):
+        super().__init__()
+        self.dataset = dataset
+
+    def __len__(self) -> int:
+        return len(self.dataset._satellite_metadata)
+
+    def __getitem__(self, idx: int) -> vd.VigorDatasetItem:
+        if idx >= len(self):
+            raise IndexError
+        row = self.dataset._satellite_metadata.iloc[idx]
+        sat, _ = vd.load_image(Path(row.path), self.dataset.satellite_patch_size)
+        return vd.VigorDatasetItem(
+            panorama_metadata=None,
+            satellite_metadata={"index": int(row.name), "filename": row.filename},
+            panorama=None,
+            satellite=sat,
+            cached_panorama_tensors=None,
+            cached_satellite_tensors={},
+        )
+
+
+class _PanoView(torch.utils.data.Dataset):
+    def __init__(self, dataset: CVGTextDataset):
+        super().__init__()
+        self.dataset = dataset
+
+    def __len__(self) -> int:
+        return len(self.dataset._panorama_metadata)
+
+    def __getitem__(self, idx: int) -> vd.VigorDatasetItem:
+        if idx >= len(self):
+            raise IndexError
+        row = self.dataset._panorama_metadata.iloc[idx]
+        pano, _ = vd.load_image(Path(row.path), self.dataset.panorama_size)
+        return vd.VigorDatasetItem(
+            panorama_metadata={"index": int(row.name), "filename": row.filename},
+            satellite_metadata=None,
+            panorama=pano,
+            satellite=None,
+            cached_panorama_tensors={},
+            cached_satellite_tensors=None,
+        )

--- a/experimental/overhead_matching/swag/data/cvgtext_dataset.py
+++ b/experimental/overhead_matching/swag/data/cvgtext_dataset.py
@@ -144,6 +144,22 @@ class CVGTextDataset:
             )
         self._panorama_metadata = pd.DataFrame(query_rows).reset_index(drop=True)
 
+        # Filename GT consistency check: every query's positive_satellite_idxs must
+        # point at the gallery row whose filename matches the query's. If the
+        # filename parser or gallery-to-query join ever gets mis-wired, retrieval
+        # metrics would silently report noise instead of real performance.
+        for i, pano_row in self._panorama_metadata.iterrows():
+            pos_idxs = pano_row["positive_satellite_idxs"]
+            assert len(pos_idxs) == 1, (
+                f"Expected exactly one positive satellite for query {pano_row['filename']!r}, "
+                f"got {pos_idxs}"
+            )
+            gallery_fn = self._satellite_metadata.iloc[pos_idxs[0]]["filename"]
+            assert pano_row["filename"] == gallery_fn, (
+                f"Query/gallery filename mismatch at pano row {i}: "
+                f"{pano_row['filename']!r} vs gallery row {pos_idxs[0]} {gallery_fn!r}"
+            )
+
         # Minimal config for `get_dataloader`'s `worker_init_fn`; we don't use
         # tensor caches so both entries stay `None`.
         self._config = _MinimalConfig()

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -16,6 +16,19 @@ py_binary(
   ],
 )
 
+py_binary(
+  name="evaluate_cvgtext_swag",
+  srcs=["evaluate_cvgtext_swag.py"],
+  deps=[
+    ":export_similarity_matrix",
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:cvgtext_dataset",
+    "//experimental/overhead_matching/swag/evaluation:evaluate_swag",
+    "//experimental/overhead_matching/swag/evaluation:retrieval_metrics",
+    requirement("torch"),
+  ],
+)
+
 py_library(
   name="pairing",
   srcs=["pairing.py"],

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -23,11 +23,13 @@ py_binary(
     ":export_similarity_matrix",
     "//common/torch:load_torch_deps",
     "//experimental/overhead_matching/swag/data:cvgtext_dataset",
-    "//experimental/overhead_matching/swag/evaluation:evaluate_swag",
+    "//experimental/overhead_matching/swag/data:satellite_embedding_database",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
     "//experimental/overhead_matching/swag/evaluation:retrieval_metrics",
     requirement("torch"),
   ],
 )
+
 
 py_library(
   name="pairing",

--- a/experimental/overhead_matching/swag/scripts/evaluate_cvgtext_swag.py
+++ b/experimental/overhead_matching/swag/scripts/evaluate_cvgtext_swag.py
@@ -1,0 +1,136 @@
+"""Run our WAG pano-to-satellite retrieval model on CVG-Text.
+
+Experiment A of the CVG-Text comparison plan: a direct image-to-image
+retrieval baseline, measured against the full per-city satellite gallery
+(same galleries as Step 0's CrossText2Loc runs, no 100-nearest prior).
+
+Loads a trained `WagPatchEmbedding` pano/sat pair from the directory layout
+produced by our training pipeline (e.g.
+`/data/overhead_matching/training_outputs/260215_baseline_retraining/260218_093851_all_chicago_dinov3_wag_bs18_v2/`),
+builds a `CVGTextDataset` for the requested test city, and writes
+`similarity.pt` + `metrics.json` + `config.json` under
+`<output_base>/expA_test-<city>_<wag_tag>/`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+
+from experimental.overhead_matching.swag.data.cvgtext_dataset import CVGTextDataset
+from experimental.overhead_matching.swag.evaluation import evaluate_swag, retrieval_metrics
+from experimental.overhead_matching.swag.scripts.export_similarity_matrix import (
+    load_models_from_training_output,
+)
+
+
+def _git_sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=Path(__file__).parent, text=True
+    ).strip()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dataset_root",
+        type=Path,
+        default=Path("/data/overhead_matching/datasets/cvgtext"),
+    )
+    parser.add_argument("--test_city", required=True, choices=("Brisbane", "NewYork", "Tokyo"))
+    parser.add_argument("--split", default="test")
+    parser.add_argument(
+        "--wag_checkpoint_dir",
+        type=Path,
+        required=True,
+        help="Directory containing `<checkpoint>_panorama/` and `<checkpoint>_satellite/` subdirs.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default="best",
+        help="Which checkpoint tag to load — typically 'best', 'last', or a numeric epoch tag.",
+    )
+    parser.add_argument(
+        "--wag_tag",
+        default=None,
+        help="Output dir suffix. Defaults to the checkpoint dir's basename.",
+    )
+    parser.add_argument(
+        "--output_base",
+        type=Path,
+        default=Path("/data/overhead_matching/evaluation/results/cvgtext"),
+    )
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+
+    pano_model, sat_model, resolved_ckpt = load_models_from_training_output(
+        args.wag_checkpoint_dir,
+        device=device,
+        checkpoint=args.checkpoint,
+        fallback_to_config=True,
+    )
+
+    pano_patch_dims = tuple(pano_model.patch_dims)
+    sat_patch_dims = tuple(sat_model.patch_dims)
+    print(f"pano patch_dims={pano_patch_dims}  sat patch_dims={sat_patch_dims}")
+
+    dataset = CVGTextDataset(
+        root=args.dataset_root,
+        city=args.test_city,
+        split=args.split,
+        gallery_kind="satellite",
+        panorama_size=pano_patch_dims,
+        satellite_patch_size=sat_patch_dims,
+    )
+    print(
+        f"CVG-Text: test={args.test_city}  |  "
+        f"{dataset.num_queries} queries, {dataset.num_gallery} gallery entries"
+    )
+
+    similarity = evaluate_swag.compute_similarity_matrix(
+        sat_model=sat_model,
+        pano_model=pano_model,
+        dataset=dataset,
+        device=device,
+    )
+    print(f"similarity shape: {tuple(similarity.shape)}")
+
+    metrics = retrieval_metrics.compute_top_k_metrics(
+        similarity.cpu(), dataset, ks=[1, 5, 10]
+    )
+    print("Metrics:", metrics)
+
+    wag_tag = args.wag_tag or args.wag_checkpoint_dir.name
+    out_dir = args.output_base / f"expA_test-{args.test_city}_{wag_tag}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    torch.save(similarity.cpu(), out_dir / "similarity.pt")
+    with open(out_dir / "metrics.json", "w") as f:
+        json.dump(metrics, f, indent=2)
+    with open(out_dir / "config.json", "w") as f:
+        json.dump(
+            {
+                "test_city": args.test_city,
+                "split": args.split,
+                "wag_checkpoint_dir": str(args.wag_checkpoint_dir),
+                "resolved_checkpoint": resolved_ckpt,
+                "pano_patch_dims": list(pano_patch_dims),
+                "sat_patch_dims": list(sat_patch_dims),
+                "num_queries": dataset.num_queries,
+                "num_gallery": dataset.num_gallery,
+                "git_sha": _git_sha(),
+            },
+            f,
+            indent=2,
+        )
+    print(f"Wrote outputs to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/evaluate_cvgtext_swag.py
+++ b/experimental/overhead_matching/swag/scripts/evaluate_cvgtext_swag.py
@@ -22,11 +22,46 @@ from pathlib import Path
 import common.torch.load_torch_deps  # noqa: F401
 import torch
 
+from experimental.overhead_matching.swag.data import satellite_embedding_database as sed
+from experimental.overhead_matching.swag.data import vigor_dataset as vd
 from experimental.overhead_matching.swag.data.cvgtext_dataset import CVGTextDataset
-from experimental.overhead_matching.swag.evaluation import evaluate_swag, retrieval_metrics
+from experimental.overhead_matching.swag.evaluation import retrieval_metrics
 from experimental.overhead_matching.swag.scripts.export_similarity_matrix import (
     load_models_from_training_output,
 )
+
+
+def _check_self_retrieval(embeddings: torch.Tensor, label: str, tol: float = 1e-5) -> None:
+    """Cosine-similarity self-retrieval sanity.
+
+    The invariant we care about is indexing-alignment: embedding[i] must be the
+    representation of the i-th metadata row. The strict "argmax == i" check is
+    too strong whenever two rows have identical images (duplicate tiles in the
+    dataset produce identical embeddings and therefore tied cosine similarities).
+    We instead assert `sim[i, i] >= sim[i].max() - tol` — i.e. self-similarity
+    is tied for max — which is exactly the alignment invariant.
+    """
+    emb = embeddings.squeeze()
+    assert emb.ndim == 2, f"Expected 2D embedding tensor for {label}, got shape {tuple(emb.shape)}"
+    n = emb.shape[0]
+    sim = emb @ emb.T
+    self_sim = sim.diagonal()
+    row_max = sim.max(dim=1).values
+    gap = row_max - self_sim
+    failing = (gap > tol).nonzero(as_tuple=True)[0]
+    assert failing.numel() == 0, (
+        f"{label}: self-similarity fell below row max on {failing.numel()}/{n} rows. "
+        f"First 5 rows: {failing[:5].tolist()} with gaps {gap[failing[:5]].tolist()}"
+    )
+    top1 = sim.argmax(dim=1)
+    tied = (top1 != torch.arange(n, device=top1.device)).nonzero(as_tuple=True)[0]
+    if tied.numel() > 0:
+        print(
+            f"[sanity] {label}: self-similarity == row-max on all {n} rows; "
+            f"{tied.numel()} rows have tied top-1 (duplicate entries in the data)"
+        )
+    else:
+        print(f"[sanity] {label}: self-retrieval R@1 = 1.0 across all {n} rows")
 
 
 def _git_sha() -> str:
@@ -94,11 +129,25 @@ def main():
         f"{dataset.num_queries} queries, {dataset.num_gallery} gallery entries"
     )
 
-    similarity = evaluate_swag.compute_similarity_matrix(
-        sat_model=sat_model,
-        pano_model=pano_model,
-        dataset=dataset,
-        device=device,
+    # Build the two embedding databases separately so we can run self-retrieval
+    # sanity checks on each before computing the cross-modal similarity.
+    sat_loader = vd.get_dataloader(
+        dataset.get_sat_patch_view(), batch_size=96, num_workers=8
+    )
+    pano_loader = vd.get_dataloader(
+        dataset.get_pano_view(), batch_size=96, num_workers=8
+    )
+    with torch.no_grad():
+        print("building satellite embedding database")
+        sat_embeddings = sed.build_satellite_db(sat_model, sat_loader, device=device)
+        print("building panorama embedding database")
+        pano_embeddings = sed.build_panorama_db(pano_model, pano_loader, device=device)
+
+    _check_self_retrieval(sat_embeddings, "sat")
+    _check_self_retrieval(pano_embeddings, "pano")
+
+    similarity = sed.calculate_cos_similarity_against_database(
+        pano_embeddings.squeeze(), sat_embeddings.squeeze()
     )
     print(f"similarity shape: {tuple(similarity.shape)}")
 


### PR DESCRIPTION
## Summary

Step 1 of the CVG-Text comparison plan: direct image-to-image retrieval using our `WagPatchEmbedding` model, measured against the full per-city satellite gallery (same galleries as Step 0's CrossText2Loc runs in #619, no 100-nearest prior).

### Changes

- **Extends `CVGTextDataset`** with `get_pano_view()` / `get_sat_patch_view()` that mirror `VigorDataset`'s nested-torch-Dataset pattern. Items yield `VigorDatasetItem` NamedTuples with only the relevant image tensor populated. Adds `panorama_size` / `satellite_patch_size` dataclass fields; resize goes through `vigor_dataset.load_image`. Adds a `_MinimalConfig` stub so `get_dataloader`'s `worker_init_fn` (which traverses up to the outer dataset's `_config`) runs unchanged.
- **Adds `scripts/evaluate_cvgtext_swag.py`**: loads a WAG pano/sat pair via `load_models_from_training_output`, runs `evaluate_swag.compute_similarity_matrix`, computes recall@k + MRR, and writes `similarity.pt` / `metrics.json` / `config.json` to `<output_base>/expA_test-<city>_<wag_tag>/`.

### Results

Run with checkpoint `260218_093851_all_chicago_dinov3_wag_bs18_v2/best_*` (Chicago-only training, zero-shot on all three cities):

| city | R@1 | R@5 | R@10 | MRR |
|---|---|---|---|---|
| Brisbane | 3.1 | 9.5 | 13.5 | 0.069 |
| NewYork | 12.8 | 27.9 | 34.2 | 0.202 |
| Tokyo | 7.4 | 20.8 | 26.8 | 0.142 |

Side-by-side with Step 0 (#619) on R@1:

| city | WAG pano→sat | CT2L text→sat | CT2L text→OSM |
|---|---|---|---|
| Brisbane | **3.1** | 4.9 | 9.2 |
| NewYork | **12.8** | 10.3 | 25.8 |
| Tokyo | **7.4** | 5.4 | 8.0 |

WAG beats CrossText2Loc's text→sat on NewYork and Tokyo but loses on Brisbane. None of the "pano-as-query" or "text-as-query" image-side methods clear CrossText2Loc's text→OSM R@1 — that's the bar the correspondence-classifier experiment (Step 2) has to clear.

## Test plan

- [x] `bazel build //experimental/overhead_matching/swag/scripts:evaluate_cvgtext_swag`
- [x] `bazel build //experimental/overhead_matching/swag/data:cvgtext_dataset`
- [x] Full runs on Brisbane, NewYork, Tokyo. Outputs under `/data/overhead_matching/evaluation/results/cvgtext/expA_test-<city>_260218_093851_all_chicago_dinov3_wag_bs18_v2/`.
- [ ] Follow-up: Step 2 (correspondence classifier pano→OSM landmarks) once Ethan's artifacts are synced from aspen and the historical PBFs are in place, then tabulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)