### PR TITLE
CVG-Text: stage dataset into VIGOR layout (with HF zip auto-extract)

### DIFF
--- a/experimental/overhead_matching/swag/crosstext2loc_comparison.md
+++ b/experimental/overhead_matching/swag/crosstext2loc_comparison.md
@@ -394,21 +394,3 @@ ranking including R@1/5/10.
    without re-running the expensive P(match) inference, pass
    `--from_raw <path>/<tag>_raw.pt --compute_similarity ...` to load the
    cached cost matrix and only re-aggregate. Seconds, no GPU.
-
-## Future work / knobs to sweep
-
-1. **Param sweep on Exp B** for Tokyo: lower `--prob_threshold` (0.8 →
-   0.5 / 0.3), try `--aggregation max` / `log_odds`, toggle
-   `--uniqueness_weighted`. Unlikely to close the Tokyo gap fully but
-   worth a data point.
-2. **Multilingual embedding model for Tokyo**: re-run
-   `precompute_value_embeddings.py` with `gemini-embedding-001` or a
-   multilingual `text-embedding-*` variant and retrain the classifier,
-   or use a classifier that cross-embeds Japanese↔romanized pairs.
-3. **Bootstrap confidence intervals** on recall@k and MRR (n=1000 test
-   queries → σ on R@k around 0.5–1.5 pp). Closes the Brisbane question
-   ("tie" vs "slight win").
-4. **CrossText2Loc OSM in-distribution**: reproducing their paper's
-   100-nearest-prior numbers would give an upper bound for the CT2L OSM
-   baseline, not relevant for our fair comparison but useful as a
-   sanity anchor.

--- a/experimental/overhead_matching/swag/crosstext2loc_comparison.md
+++ b/experimental/overhead_matching/swag/crosstext2loc_comparison.md
@@ -1,0 +1,414 @@
+# CVG-Text evaluation
+
+The results directory `/data/overhead_matching/evaluation/results/cvgtext/`
+holds the outputs of three retrieval comparisons on the CVG-Text benchmark
+([yejy53/CVG-Text](https://github.com/yejy53/CVG-Text), ICCV 2025).
+
+All evaluations use the **full per-city gallery** (16983 Brisbane / 9974
+NewYork / 6107 Tokyo satellite tiles, and the same counts for the OSM
+gallery) and the **1000 pano test split** per city. The 100-nearest-neighbour
+location prior from the CVG-Text paper is not applied.
+
+## Quick reproduction (assumes classifier / artifacts are already trained and staged)
+
+Environment:
+```
+export GOOGLE_CLOUD_PROJECT=<your-project>
+export GOOGLE_CLOUD_LOCATION=global
+export GOOGLE_GENAI_USE_VERTEXAI=True
+```
+
+Project setup (one-time, per GCP project):
+- Enable `aiplatform.googleapis.com`.
+- In Vertex AI → Model Garden, enable `gemini-3-flash-preview` and
+  `text-embedding-005` (or your chosen embedding model).
+- Create a GCS bucket (any region works — we used `us-central1`):
+  `gcloud storage buckets create gs://<bucket> --location=us-central1 --uniform-bucket-level-access`
+- `gcloud auth application-default login` and
+  `gcloud auth application-default set-quota-project <project>`.
+
+CVG-Text data: the dataset itself is not downloadable by this pipeline.
+Pull `LHL3341/CVG-Text_full` from HuggingFace (panos + sat/OSM imagery +
+annotations all ship in the HF repo) and place at
+`/data/overhead_matching/datasets/cvgtext/`:
+
+```
+uvx --from huggingface_hub hf download --repo-type dataset \
+  LHL3341/CVG-Text_full \
+  --local-dir /data/overhead_matching/datasets/cvgtext
+```
+
+Given that, one-shot stage CVG-Text into the VIGOR-shaped directory layout
+this pipeline expects:
+
+```
+bazel run //experimental/overhead_matching/swag/scripts:stage_cvgtext_for_vigor
+```
+
+The script writes `satellite_bbox.json`, populates `satellite/` (full
+gallery, VIGOR-format symlinks) and `panorama/` (test-only, VIGOR-format
+symlinks) per city under `/data/overhead_matching/datasets/VIGOR/cvgtext_<City>/`.
+
+**Always stage before running Gemini.** Point
+`extract_gemini_landmarks_from_panoramas.py --panorama_dir` at
+`<vigor_root>/cvgtext_<City>/panorama/` (the staged dir with VIGOR-format
+filenames) so the resulting pickle keys line up with VigorDataset's pano_ids
+automatically. Running Gemini on the raw CVG-Text dir first produces
+pickle keys that silently fail the correspondence pipeline's key lookup
+(all pano landmarks drop, recall ~0.1%).
+
+If you're re-running after retraining the correspondence classifier and
+nothing else changed, only Step 2.5 below needs to re-run (~3 min total
+for all three cities). `--from_raw` makes parameter sweeps near-free.
+
+## Directory layout
+
+```
+/data/overhead_matching/evaluation/results/cvgtext/
+├── comparison_tables.txt                  ← rendered comparison tables, MRR-first
+├── crosstext2loc_train-<X>_test-<Y>_<kind>/
+│   ├── similarity.pt                      (num_queries, num_gallery) cosine sim
+│   ├── metrics.json                       {recall@1, recall@5, recall@10, mrr}
+│   └── config.json                        run metadata
+├── expA_test-<City>_260218_093851_all_chicago_dinov3_wag_bs18_v2/
+│   ├── similarity.pt
+│   ├── metrics.json
+│   └── config.json
+└── expB_<City>/
+    ├── simple_v1_raw.pt                   metadata dict (pano_id→lm_rows, cost_matrix_path, …)
+    ├── simple_v1_raw_cost_matrix.npy      (total_pano_lms, total_osm_lms) P(match)
+    └── simple_v1_raw_similarity.pt        (num_panos, num_sats) similarity
+```
+
+For `crosstext2loc_train-X_test-Y_<kind>`: `X,Y ∈ {Brisbane, NewYork, Tokyo}`,
+`kind ∈ {sat, osm}` → 3×3×2 = 18 directories.
+
+## Step 0 — CrossText2Loc baseline (full gallery, all 18 train/test/kind combos)
+
+**Checkpoints**: the 6 `long_model_<City>-mixed_1e-05_128_{sat,osm}_epoch*_*.pth`
+files are hosted on the official `CVG-Text/CrossText2Loc` HuggingFace model
+repo (not bundled with the `LHL3341/CVG-Text_full` dataset repo). Grab
+them into `<cvgtext_root>/models/`:
+
+```
+uvx --from huggingface_hub hf download \
+  --repo-type model CVG-Text/CrossText2Loc \
+  --local-dir /data/overhead_matching/datasets/cvgtext/models
+```
+
+`evaluate_cvgtext_crosstext2loc.py` globs that directory with
+`long_model_{train_city}-mixed_1e-05_128_{kind}_epoch*_*.pth`, so any
+unrelated files in `models/` are ignored but the filename pattern must
+be preserved as published.
+
+**Driver**: `experimental/overhead_matching/swag/scripts/evaluate_cvgtext_crosstext2loc.py`.
+Takes `--train_city X --test_city Y --gallery_kind {sat,osm}` and writes
+`similarity.pt` + `metrics.json` + `config.json` per `{train × test × kind}`
+triple (18 directories total).
+
+The upstream `crosstext2loc` package is pinned in
+`third_party/python/requirements_3_12.in` as
+`crosstext2loc @ git+…@c3b5727…`; the driver calls
+`crosstext2loc.load_model(...)` directly. The `long_model_*.pth`
+checkpoints are CLIP ViT-L/14@336 with text positional embedding
+interpolated from 77 → 300 tokens.
+
+**Vertex AI setup**:
+1. `gcloud auth login` + `gcloud auth application-default login`
+2. `gcloud config set project <project>`
+3. `gcloud storage buckets create gs://<name> --location=us-central1 --uniform-bucket-level-access`
+   (any GCS region works; `GOOGLE_CLOUD_LOCATION=global` is the Vertex
+   *endpoint* setting and is independent of the bucket region)
+4. Ensure `gemini-3-flash-preview` and the relevant text-embedding model are
+   enabled in the project's Vertex AI Model Garden.
+
+## Step 1 — WAG pano→satellite (Experiment A)
+
+**Driver**: `experimental/overhead_matching/swag/scripts/evaluate_cvgtext_swag.py`.
+Loads pano + sat `WagPatchEmbedding` weights via
+`load_models_from_training_output`, runs `evaluate_swag.compute_similarity_matrix`,
+writes metrics. Per-city output lives under `expA_test-<City>_<wag_tag>/`.
+
+**WAG checkpoint**:
+`/data/overhead_matching/training_outputs/260215_baseline_retraining/260218_093851_all_chicago_dinov3_wag_bs18_v2/`.
+DINOv3 backbone, `patch_dims=[320,320]` sat, `[320,640]` pano, trained on
+Chicago only (zero-shot on Brisbane / NewYork / Tokyo).
+
+**Dataset adapter**: `CVGTextDataset` exposes `get_pano_view()` /
+`get_sat_patch_view()` matching `VigorDataset`'s nested-torch-Dataset
+pattern, with a `_MinimalConfig` stub so `vigor_dataset.get_dataloader`'s
+`worker_init_fn` runs unchanged.
+
+**Sanity checks in the driver**:
+1. **Dataset-init filename GT** — asserts each query's
+   `positive_satellite_idxs[0]` points at a gallery row whose filename
+   matches the query.
+2. **Embedding row-order check** — builds sat and pano embedding matrices,
+   asserts `sim[i,i]` is tied for the row max on both sides (stronger
+   invariant than strict `argmax==i`, which false-positives on CVG-Text's
+   byte-identical duplicate tiles).
+
+CVG-Text has 6 duplicate-sat-tile pairs (Brisbane 2, NewYork 0, Tokyo 4):
+byte-identical PNGs with slightly-different filename lat/lon. Doesn't
+meaningfully affect retrieval.
+
+## Step 2 — Correspondence-classifier pano→OSM-landmark (Experiment B)
+
+Uses the `simple_v1` text-only correspondence classifier trained on
+Chicago + Seattle.
+
+### 2.1 — Gemini landmark extraction on CVG-Text test panos
+
+**Prerequisite**: `stage_cvgtext_for_vigor.py` has run so the staged
+`panorama/` dir (with VIGOR-format symlink names) exists per city.
+
+**What to run**, per city:
+
+```
+bazel run //experimental/overhead_matching/swag/scripts:extract_gemini_landmarks_from_panoramas -- \
+  --name <City> \
+  --panorama_dir /data/overhead_matching/datasets/VIGOR/cvgtext_<City>/panorama \
+  --output_base <pano_v2_base> \
+  --gcs_bucket <bucket> \
+  --media_resolution MEDIA_RESOLUTION_ULTRA_HIGH \
+  --force
+```
+
+`<pano_v2_base>` is the directory under which per-city pickles are written
+(e.g. `/data/overhead_matching/datasets/semantic_landmark_embeddings/panov2_tuned_prompt_cvgtext/`).
+The orchestrator nests a `<City>/` subdir under `<pano_v2_base>` (driven by
+`--name`), matching what `extract_panorama_data_across_cities` walks.
+
+Settings used:
+
+- `--model gemini-3-flash-preview` (default)
+- `--prompt_type osm_tags` (default)
+- `--media_resolution MEDIA_RESOLUTION_ULTRA_HIGH` (override the default HIGH)
+- `--thinking_level HIGH` (default)
+
+`GOOGLE_CLOUD_LOCATION=global` is required — batch prediction for
+`gemini-3-flash-preview` is only available at the `global` endpoint;
+region-specific endpoints return `MODEL_NOT_SUPPORTED_FOR_BATCH`.
+
+7-stage pipeline: PINHOLE → REQUESTS → UPLOAD → SUBMIT → WAIT → DOWNLOAD → EMBEDDINGS.
+Each run takes ~70-80 min end-to-end (mostly Vertex batch queue).
+
+**Artifacts written under** `<pano_v2_base>/<City>/`:
+
+```
+├── sentence_requests/panorama_sentence_requests/panorama_request_000.jsonl  (batch input)
+├── sentences/results/panorama_request_000/prediction-model-<ts>/predictions.jsonl  (batch output)
+├── embeddings/embeddings.pkl  (per-city pickle with 1536-dim Gemini text embeddings)
+└── submitted_job_names.txt
+```
+
+Pano-landmark counts (post-filter, per city):
+
+| city | mean landmarks/pano | % panos with 0 landmarks |
+|---|---|---|
+| NewYork | 3.03 | 6.2% |
+| Tokyo | 2.75 | 7.7% |
+| Brisbane | 1.40 | 38.3% (suburban bias — Gemini prompt correctly rejects generic houses) |
+
+### 2.2 — Historical OSM landmark extraction
+
+Downloaded Geofabrik historical PBF snapshots for the dates bracketing
+the pano capture times (panos span 2022-05 through 2023-10). All from
+the public `download.geofabrik.de` archive (no auth required):
+
+- Brisbane — `https://download.geofabrik.de/australia-oceania/australia-230101.osm.pbf` (~601 MB)
+- NewYork — `https://download.geofabrik.de/north-america/us/new-york-230101.osm.pbf` (~396 MB)
+- Tokyo — `https://download.geofabrik.de/asia/japan-230101.osm.pbf` (~1.70 GB)
+
+All placed in `/data/overhead_matching/datasets/osm_dumps/`.
+
+**Driver**: `experimental/overhead_matching/swag/scripts/extract_landmarks_historical.py`,
+run per city with `--dataset_path <staging_root>` (reads `satellite_bbox.json`)
+and `--pbf_file <geofabrik_pbf>`.
+
+**Pre-requisite**: staging dir with `satellite_bbox.json` computed from the
+sat-tile lat/lon extents + 500 m buffer. See §2.4 for the full staging layout.
+
+**Feather counts**:
+
+| city | raw OSM features | unique values after prune | feather size |
+|---|---|---|---|
+| Brisbane | 243,211 | 29,024 | 40 MB |
+| NewYork | 200,081 | 85,880 | 31 MB |
+| Tokyo | 127,611 | 45,824 | 17 MB |
+
+Brisbane's huge bbox (~20×30 km) produces 1.2× as many raw features as
+NewYork but far fewer *distinct* tag values after `prune_landmark` — a
+lot of Brisbane OSM is cookie-cutter residential features with no
+distinguishing name/housenumber.
+
+### 2.3 — Text embedding extension
+
+The classifier expects 768-dim `text-embedding-005` embeddings. The base
+pickle `/data/overhead_matching/datasets/landmark_correspondence/eval_text_embeddings_panov2_tuned_v3_all.pkl`
+has 152,871 entries from Chicago + Seattle + VIGOR mapillary cities and
+doesn't cover Tokyo / Brisbane OSM tag values or CVG-Text pano landmarks.
+
+**Driver**: `experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py`
+with `--pano_v2_base` (all 3 CVG-Text `cvgtext_pano_v2_base` symlinks),
+`--feather_dirs` (the 3 staging dirs), `--base_embeddings` pointing at
+the base pickle, and the default `--model text-embedding-005
+--output_dimensionality 768`. Runs in ~12 min.
+
+**Output**: 219,712 entries (152,871 base + 66,841 new CVG-Text values)
+at `/data/overhead_matching/datasets/landmark_correspondence/eval_text_embeddings_panov2_tuned_v3_all_plus_cvgtext.pkl`
+(656 MB).
+
+### 2.4 — VIGOR-compatible staging
+
+Handled by `stage_cvgtext_for_vigor.py` (run as step 1 of the Quick
+reproduction block above). Per city:
+
+```
+/data/overhead_matching/datasets/VIGOR/cvgtext_<City>/
+├── satellite_bbox.json            (computed from sat gallery lat/lon + 500m buffer)
+├── satellite/                     (full gallery, VIGOR-format symlinks)
+├── panorama/                      (test-only, VIGOR-format symlinks)
+└── landmarks/
+    └── cvgtext_<City>_v1_230101.feather   (populated by step 2.2)
+```
+
+`VigorDataset.load_satellite_metadata` and `load_panorama_metadata` hardcode
+specific filename patterns:
+
+- sat: `<anything>_<lat>_<lon>.<ext>`
+- pano: `<panoid>,<lat>,<lon>,.<ext>`
+
+CVG-Text's native `<lat>,<lon>_<date>_<panoid>_d<yaw>_z<zoom>.<ext>` fails
+both, so the staging script creates a symlink layer with VIGOR-format names.
+The panos and pinhole outputs carry those names forward into the pickle
+keys — which is why step 2.1 must run on the staged `panorama/` dir.
+
+**Brisbane orphan**: one of the 16983 Brisbane panos
+(`-27.39043692,152.95798883_2022-12_1_VLlX4egz-3UZkwiMMWtA_d261_z3.png`)
+has no matching sat tile in the gallery — a CVG-Text data quirk.
+VigorDataset's `_verify_all_panos_have_satellites` refuses this. Since
+it's a train-set pano (not in `annotation/Brisbane/test.json`), the staging
+script's restriction of `panorama/` to the 1000 test panos already excludes
+the orphan.
+
+### 2.5 — Correspondence similarity
+
+**Command** (per city):
+
+```bash
+GOOGLE_CLOUD_PROJECT=<project> GOOGLE_CLOUD_LOCATION=global GOOGLE_GENAI_USE_VERTEXAI=True \
+bazel run //experimental/overhead_matching/swag/scripts:export_correspondence_similarity -- \
+  --model_path /data/overhead_matching/training_outputs/landmark_correspondence/simple_v1/best_model.pt \
+  --text_embeddings_path /data/overhead_matching/datasets/landmark_correspondence/eval_text_embeddings_panov2_tuned_v3_all_plus_cvgtext.pkl \
+  --dataset_path /data/overhead_matching/datasets/VIGOR/cvgtext_<City> \
+  --pano_v2_base <pano_v2_base> \
+  --output_path /data/overhead_matching/evaluation/results/cvgtext/expB_<City>/simple_v1_raw.pt \
+  --compute_similarity --prob_threshold 0.8 --uniqueness_weighted
+```
+
+`<pano_v2_base>` is the same value passed to Gemini in step 2.1
+(`<pano_v2_base>/<City>/embeddings/embeddings.pkl` exists).
+
+Settings for `simple_v1`:
+- `--prob_threshold 0.8` (Hungarian matching threshold)
+- `--uniqueness_weighted` (each matched pair weighted by `1/log2(1 + n_matches_above_threshold)`)
+- `--method hungarian` (default)
+- `--aggregation sum` (default)
+
+Each city's run takes ~1 min (1000 panos × 6-17k sats, GPU inference).
+
+Metric computation happens in the same script (`retrieval_metrics.compute_top_k_metrics`
+on the Hungarian-aggregated similarity matrix, filename-based single-positive GT).
+
+## Summary of results (MRR, fair comparisons only)
+
+All zero-shot / cross-region numbers — no method trained on the test city.
+
+| test city | best fair method | MRR | Exp B MRR |
+|---|---|---|---|
+| Brisbane | CT2L text→OSM (NewYork-trained) | 0.081 | 0.072 |
+| NewYork | **Exp B pano→OSM-landmark** | **0.231** | 0.231 |
+| Tokyo | WAG pano→sat (Chicago-trained) | 0.142 | 0.028 |
+
+See `comparison_tables.txt` in the results directory for the full per-city
+ranking including R@1/5/10.
+
+**Headline** (fair comparisons):
+
+- **NewYork** — raw landmarks > rasterised OSM. Exp B (pano → OSM
+  landmarks, Chicago+Seattle-trained classifier) beats both CT2L
+  text→OSM cross-region runs (16.4, 15.8) at R@1 (18.0) and wins on MRR
+  (0.231 vs 0.223, 0.218).
+
+- **Brisbane** — ~tie. Exp B and CT2L cross-region OSM are within noise
+  of each other (R@1 5.1 vs 4.9; MRR 0.072 vs 0.081). Both limited by
+  Brisbane's 38% empty-landmark rate and sparse OSM unique values.
+
+- **Tokyo** — Exp B loses (MRR 0.028 vs CT2L cross-region 0.073, 0.046).
+  Likely explanation: `simple_v1` trained only on English
+  Chicago+Seattle OSM, so it can't bridge kanji / romanized-Japanese
+  name variants the way CLIP's multilingual pretraining does.
+
+## Gotchas worth knowing before you touch this pipeline
+
+1. **Vertex batch for `gemini-3-flash-preview` only works at
+   `locations/global`.** Submitting a batch job under `us-central1` returns
+   `MODEL_NOT_SUPPORTED_FOR_BATCH` even though online / `generateContent`
+   works there. Set `GOOGLE_CLOUD_LOCATION=global` for Exp B Gemini runs.
+2. **Fresh GCP projects have tight text-embedding rate limits.**
+   `precompute_value_embeddings.py` retries 10 times with backoff capped
+   at 60 s to ride through per-minute quota windows. If you re-run on a
+   new project and still hit 429s, bump further.
+3. **VigorDataset's filename parsers are format-specific.**
+   `load_satellite_metadata` does `_, lat, lon = p.stem.split("_")`;
+   `load_panorama_metadata` does `pano_id, lat, lon, _ = p.stem.split(",")`.
+   CVG-Text's native `<lat>,<lon>_<date>_<panoid>_d<yaw>_z<zoom>.<ext>`
+   fails both. `stage_cvgtext_for_vigor.py` creates a symlink layer with
+   VIGOR-format names; don't point `VigorDataset` directly at the CVG-Text
+   source dirs.
+4. **`extract_tags_from_pano_data` strips `pano_id.split(",")[0]`.**
+   This means the pano_v2 pickle keys must be in VIGOR-shape
+   (`<panoid>_<date>_d<yaw>,<lat>,<lon>,`) so the first comma-separated
+   field matches the VigorDataset pano_id. The fix is to run Gemini
+   (step 2.1) on the staged `panorama/` dir — the VIGOR-format filenames
+   carry through to the stage-7 pickle keys automatically. Running
+   Gemini on the raw CVG-Text dir produces broken pickle keys and the
+   correspondence pipeline will silently find 0 pano landmarks.
+5. **`VigorDataset._verify_all_panos_have_satellites` rejects any pano
+   without a geometric-near sat.** CVG-Text Brisbane has at least one
+   train-set pano without a matching sat tile; the staging script already
+   restricts `panorama/` to test-split panos, which drops the orphan.
+6. **Two pickles, two embedding models.**
+   `panov2_tuned_prompt/<City>/embeddings/embeddings.pkl` (from Stage 7
+   of the Gemini orchestrator) is **1536-dim `gemini-embedding-001`** and
+   is *not* consumed by the correspondence classifier — it's side data
+   for other downstream uses. The classifier consumes
+   `eval_text_embeddings_panov2_tuned_v3_all*.pkl` which is
+   **768-dim `text-embedding-005`** built by `precompute_value_embeddings.py`.
+   Easy to waste time chasing a dim mismatch if you don't know which is
+   which.
+7. **`--from_raw` for cheap parameter sweeps.** Each Exp B run writes
+   `<tag>_raw.pt` + `<tag>_raw_cost_matrix.npy` (the P(match) output). To
+   sweep `--prob_threshold`, `--aggregation`, or `--uniqueness_weighted`
+   without re-running the expensive P(match) inference, pass
+   `--from_raw <path>/<tag>_raw.pt --compute_similarity ...` to load the
+   cached cost matrix and only re-aggregate. Seconds, no GPU.
+
+## Future work / knobs to sweep
+
+1. **Param sweep on Exp B** for Tokyo: lower `--prob_threshold` (0.8 →
+   0.5 / 0.3), try `--aggregation max` / `log_odds`, toggle
+   `--uniqueness_weighted`. Unlikely to close the Tokyo gap fully but
+   worth a data point.
+2. **Multilingual embedding model for Tokyo**: re-run
+   `precompute_value_embeddings.py` with `gemini-embedding-001` or a
+   multilingual `text-embedding-*` variant and retrain the classifier,
+   or use a classifier that cross-embeds Japanese↔romanized pairs.
+3. **Bootstrap confidence intervals** on recall@k and MRR (n=1000 test
+   queries → σ on R@k around 0.5–1.5 pp). Closes the Brisbane question
+   ("tie" vs "slight win").
+4. **CrossText2Loc OSM in-distribution**: reproducing their paper's
+   100-nearest-prior numbers would give an upper bound for the CT2L OSM
+   baseline, not relevant for our fair comparison but useful as a
+   sanity anchor.

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -3,6 +3,11 @@ load("@pip//:requirements.bzl", "requirement")
 load("@rules_python//python:packaging.bzl", "py_wheel", "py_package")
 
 py_binary(
+  name="stage_cvgtext_for_vigor",
+  srcs=["stage_cvgtext_for_vigor.py"],
+)
+
+py_binary(
   name="evaluate_cvgtext_crosstext2loc",
   srcs=["evaluate_cvgtext_crosstext2loc.py"],
   deps=[

--- a/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
+++ b/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
@@ -174,9 +174,14 @@ def embed_texts_vertex(
     all_embeddings = []
     num_batches = (len(texts) + batch_size - 1) // batch_size
 
+    # Vertex embedding quotas on new projects are tight enough that a 3-attempt,
+    # 1s/2s/4s backoff can't ride through a per-minute window. Bump retries and
+    # cap the backoff at 60 s so transient 429s recover without losing all progress.
+    max_retries = 10
+
     for i in tqdm(range(0, len(texts), batch_size), desc="Embedding", total=num_batches):
         batch = texts[i:i + batch_size]
-        for attempt in range(3):
+        for attempt in range(max_retries):
             try:
                 response = client.models.embed_content(
                     model=model,
@@ -186,10 +191,10 @@ def embed_texts_vertex(
                 all_embeddings.extend([emb.values for emb in response.embeddings])
                 break
             except Exception as e:
-                if attempt == 2:
+                if attempt == max_retries - 1:
                     raise
-                wait = 2 ** attempt
-                print(f"\nRetry {attempt + 1}/3 after {wait}s: {e}")
+                wait = min(2 ** attempt, 60)
+                print(f"\nRetry {attempt + 1}/{max_retries} after {wait}s: {e}")
                 time.sleep(wait)
 
     return np.array(all_embeddings, dtype=np.float32)

--- a/experimental/overhead_matching/swag/scripts/stage_cvgtext_for_vigor.py
+++ b/experimental/overhead_matching/swag/scripts/stage_cvgtext_for_vigor.py
@@ -1,0 +1,299 @@
+"""Stage the CVG-Text dataset (ICCV 2025, yejy53/CVG-Text) into the VIGOR-shaped
+directory layout required by `VigorDataset` / `export_correspondence_similarity.py`.
+
+Accepts either a CVG-Text root that is already unpacked (contains
+`reference/<City>-satellite/`, `data/query/<City>-ground/`, `annotation/<City>/test.json`)
+or one freshly downloaded from HuggingFace (`LHL3341/CVG-Text_full`, i.e.
+`images.zip` + `data/query.zip` + `annotation/`). In the latter case this
+script extracts the zips in place, stripping the upstream
+`mnt/hwfile/opendatalab/air/linhonglin/CVG-text/` prefix that wraps
+`images.zip`. The original zips are left on disk. Then, per city, writes:
+
+    <vigor_root>/cvgtext_<City>/
+      satellite_bbox.json              (from sat filenames + buffer, same schema
+                                        as Ethan's mapillary cities)
+      satellite/                       symlinks with VIGOR-format names
+        satellite_<lat>_<lon>.<ext>   → reference/<City>-satellite/<real>.png
+      panorama/                        test-only symlinks with VIGOR-format names
+        <panoid>_<date>_d<yaw>,<lat>,<lon>,.<ext>
+                                      → data/query/<City>-ground/<real>.png
+      landmarks/                       empty; populate via extract_landmarks_historical.py
+
+Why the renames: `VigorDataset.load_satellite_metadata` hardcodes
+`_, lat, lon = p.stem.split("_")` and `load_panorama_metadata` hardcodes
+`pano_id, lat, lon, _ = p.stem.split(",")`. CVG-Text filenames
+(`<lat>,<lon>_<date>_<panoid>_d<yaw>_z<zoom>.<ext>`) fail both parsers.
+
+After staging, point every downstream tool at the staged `panorama/` dir —
+especially `extract_gemini_landmarks_from_panoramas.py`. Running Gemini on
+the staged dir means the stage-7 pickle's keys are the staged VIGOR-format
+filenames, which `extract_tags_from_pano_data`'s `pano_id.split(",")[0]`
+lookup lines up with `VigorDataset.load_panorama_metadata` automatically.
+(If you run Gemini on the raw CVG-Text dir first, the pickle keys are in
+the wrong format and the correspondence pipeline silently drops all pano
+landmarks. Stage first.)
+
+The script does NOT download CVG-Text itself. If it's not on disk, pull
+`LHL3341/CVG-Text_full` from HuggingFace (panoramas + satellite + OSM
+imagery all ship in the HF repo; the upstream repo's Google Maps API
+fetch scripts are NOT needed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import shutil
+import zipfile
+from pathlib import Path
+
+
+CITIES_DEFAULT = ("Brisbane", "NewYork", "Tokyo")
+
+# LHL3341/CVG-Text_full's images.zip wraps every entry under this path. The
+# query.zip in the same repo has no such prefix (top-level is `query/`).
+_IMAGES_ZIP_PREFIX = "mnt/hwfile/opendatalab/air/linhonglin/CVG-text/"
+
+_FILENAME_RE = re.compile(
+    r"^(?P<lat>-?[\d.]+),(?P<lon>-?[\d.]+)_"
+    r"(?P<date>\d{4}-\d{2})_"
+    r"(?P<pano_id>.+)_"
+    r"d(?P<yaw>\d+)_"
+    r"z(?P<zoom>\d+)"
+    r"\.(?P<ext>png|jpg|jpeg)$"
+)
+
+
+def _parse_filename(fn: str) -> dict:
+    m = _FILENAME_RE.match(fn)
+    if m is None:
+        raise ValueError(f"Filename does not match CVG-Text pattern: {fn!r}")
+    return m.groupdict()
+
+
+def _clean_dir(p: Path) -> None:
+    if p.is_symlink() or p.is_file():
+        p.unlink()
+    elif p.exists():
+        shutil.rmtree(p)
+    p.mkdir(parents=True)
+
+
+def _meters_to_deg_lat(m: float) -> float:
+    return m / 110574.0
+
+
+def _meters_to_deg_lon(m: float, lat_deg: float) -> float:
+    return m / (111320.0 * math.cos(math.radians(lat_deg)))
+
+
+def _extract_zip(zip_path: Path, dest: Path, *, strip_prefix: str = "") -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        members = zf.infolist()
+        n_total = len(members)
+        n_skipped = 0
+        for i, info in enumerate(members):
+            if strip_prefix:
+                if not info.filename.startswith(strip_prefix):
+                    n_skipped += 1
+                    continue
+                info.filename = info.filename[len(strip_prefix):]
+                if not info.filename:
+                    continue
+            zf.extract(info, dest)
+            if (i + 1) % 5000 == 0 or i + 1 == n_total:
+                print(f"    ...{i + 1}/{n_total} entries", flush=True)
+    if n_skipped:
+        print(f"    ({n_skipped} entries skipped — outside '{strip_prefix}')")
+
+
+def ensure_extracted(cvgtext_root: Path) -> None:
+    """Extract HF zips in place if the expected directory layout is missing.
+
+    No-op when `reference/` and `data/query/` already exist. Leaves the
+    original zip files on disk.
+    """
+    images_zip = cvgtext_root / "images.zip"
+    reference_dir = cvgtext_root / "reference"
+    if not reference_dir.exists():
+        if not images_zip.exists():
+            raise FileNotFoundError(
+                f"Neither extracted {reference_dir} nor {images_zip} exists. "
+                "Download LHL3341/CVG-Text_full from HuggingFace first."
+            )
+        print(f"Extracting {images_zip} -> {reference_dir} (this takes a while)")
+        _extract_zip(images_zip, cvgtext_root, strip_prefix=_IMAGES_ZIP_PREFIX)
+
+    query_zip = cvgtext_root / "data" / "query.zip"
+    query_dir = cvgtext_root / "data" / "query"
+    if not query_dir.exists():
+        if not query_zip.exists():
+            raise FileNotFoundError(
+                f"Neither extracted {query_dir} nor {query_zip} exists. "
+                "Download LHL3341/CVG-Text_full from HuggingFace first."
+            )
+        print(f"Extracting {query_zip} -> {query_dir} (this takes a while)")
+        _extract_zip(query_zip, cvgtext_root / "data")
+
+
+def stage_city(
+    *,
+    cvgtext_root: Path,
+    vigor_root: Path,
+    city: str,
+    buffer_m: float,
+) -> None:
+    sat_src = cvgtext_root / "reference" / f"{city}-satellite"
+    pano_src = cvgtext_root / "data" / "query" / f"{city}-ground"
+    test_json = cvgtext_root / "annotation" / city / "test.json"
+    for p, what in [(sat_src, "satellite reference"),
+                    (pano_src, "panorama queries"),
+                    (test_json, "test annotation")]:
+        if not p.exists():
+            raise FileNotFoundError(f"{what} missing: {p}")
+
+    stage = vigor_root / f"cvgtext_{city}"
+    stage.mkdir(parents=True, exist_ok=True)
+    (stage / "landmarks").mkdir(exist_ok=True)
+
+    # --- bbox from sat filenames + buffer ---
+    lats, lons = [], []
+    for p in sorted(sat_src.iterdir()):
+        if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+            continue
+        g = _parse_filename(p.name)
+        lats.append(float(g["lat"]))
+        lons.append(float(g["lon"]))
+    if not lats:
+        raise RuntimeError(f"no satellite files parsed in {sat_src}")
+    south, north = min(lats), max(lats)
+    west, east = min(lons), max(lons)
+    mid_lat = (south + north) / 2
+    dlat = _meters_to_deg_lat(buffer_m)
+    dlon = _meters_to_deg_lon(buffer_m, mid_lat)
+    bbox = {
+        "south": south - dlat,
+        "west": west - dlon,
+        "north": north + dlat,
+        "east": east + dlon,
+        "buffer_m": buffer_m,
+        "n_tiles": len(lats),
+        "raw_south": south,
+        "raw_west": west,
+        "raw_north": north,
+        "raw_east": east,
+    }
+    (stage / "satellite_bbox.json").write_text(json.dumps(bbox, indent=2))
+
+    # --- satellite symlinks (full gallery, dedupe by (lat_str, lon_str)) ---
+    sat_dst = stage / "satellite"
+    _clean_dir(sat_dst)
+    seen_latlon: set[tuple[str, str]] = set()
+    sat_skipped = 0
+    for p in sorted(sat_src.iterdir()):
+        if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+            continue
+        g = _parse_filename(p.name)
+        key = (g["lat"], g["lon"])
+        if key in seen_latlon:
+            sat_skipped += 1
+            continue
+        seen_latlon.add(key)
+        (sat_dst / f"satellite_{g['lat']}_{g['lon']}.{g['ext']}").symlink_to(p.resolve())
+
+    # --- panorama symlinks (test-split only) ---
+    pano_dst = stage / "panorama"
+    _clean_dir(pano_dst)
+    test_filenames = list(json.loads(test_json.read_text()).keys())
+    pano_seen: set[str] = set()
+    pano_collisions = 0
+    pano_orphans = 0
+    for fn in test_filenames:
+        p = pano_src / fn
+        if not p.exists():
+            pano_orphans += 1
+            continue
+        g = _parse_filename(fn)
+        disambig_id = f"{g['pano_id']}_{g['date']}_d{g['yaw']}"
+        if disambig_id in pano_seen:
+            pano_collisions += 1
+            continue
+        pano_seen.add(disambig_id)
+        new_name = f"{disambig_id},{g['lat']},{g['lon']},.{g['ext']}"
+        (pano_dst / new_name).symlink_to(p.resolve())
+
+    print(
+        f"  {city}: sat={len(seen_latlon)} tiles ({sat_skipped} dupes skipped), "
+        f"pano={len(pano_seen)} test panos "
+        f"({pano_collisions} collisions, {pano_orphans} orphans)"
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--cvgtext_root", type=Path,
+        default=Path("/data/overhead_matching/datasets/cvgtext"),
+        help="CVG-Text dataset root (contains `reference/`, `data/`, `annotation/`).",
+    )
+    p.add_argument(
+        "--vigor_root", type=Path,
+        default=Path("/data/overhead_matching/datasets/VIGOR"),
+        help="Parent dir under which `cvgtext_<City>/` staging trees are created.",
+    )
+    p.add_argument(
+        "--cities", nargs="+", default=list(CITIES_DEFAULT),
+        help="Cities to stage (default: Brisbane NewYork Tokyo).",
+    )
+    p.add_argument(
+        "--buffer_m", type=float, default=500,
+        help="Meters of padding around the sat-gallery bbox in satellite_bbox.json.",
+    )
+    args = p.parse_args()
+
+    ensure_extracted(args.cvgtext_root)
+
+    print(f"Staging CVG-Text -> VIGOR at {args.vigor_root}")
+    for city in args.cities:
+        stage_city(
+            cvgtext_root=args.cvgtext_root,
+            vigor_root=args.vigor_root,
+            city=city,
+            buffer_m=args.buffer_m,
+        )
+
+    print("\nNext steps (run per city unless noted):")
+    print(
+        "  1. extract_gemini_landmarks_from_panoramas.py \\\n"
+        "       --panorama_dir <vigor_root>/cvgtext_<City>/panorama \\\n"
+        "       --name <City> --output_base <pano_v2_base> ...\n"
+        "     (Run on the staged panorama/ dir — keys line up with VigorDataset.)"
+    )
+    print(
+        "  2. extract_landmarks_historical.py \\\n"
+        "       --dataset_path <vigor_root>/cvgtext_<City> \\\n"
+        "       --pbf_file <geofabrik>.osm.pbf \\\n"
+        "       --output_path <vigor_root>/cvgtext_<City>/landmarks/cvgtext_<City>_v1_<YYMMDD>.feather"
+    )
+    print(
+        "  3. precompute_value_embeddings.py (once, covering all cities)\n"
+        "       --pano_v2_base <pano_v2_base> \\\n"
+        "       --feather_dirs <vigor_root>/cvgtext_Brisbane ... \\\n"
+        "       --base_embeddings <base_text_embeddings>.pkl \\\n"
+        "       --output <extended_text_embeddings>.pkl"
+    )
+    print(
+        "  4. export_correspondence_similarity.py (per city)\n"
+        "       --model_path <classifier>.pt \\\n"
+        "       --text_embeddings_path <extended_text_embeddings>.pkl \\\n"
+        "       --dataset_path <vigor_root>/cvgtext_<City> \\\n"
+        "       --pano_v2_base <pano_v2_base> \\\n"
+        "       --compute_similarity --prob_threshold 0.8 --uniqueness_weighted"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/stage_cvgtext_for_vigor.py
+++ b/experimental/overhead_matching/swag/scripts/stage_cvgtext_for_vigor.py
@@ -265,35 +265,6 @@ def main() -> None:
             buffer_m=args.buffer_m,
         )
 
-    print("\nNext steps (run per city unless noted):")
-    print(
-        "  1. extract_gemini_landmarks_from_panoramas.py \\\n"
-        "       --panorama_dir <vigor_root>/cvgtext_<City>/panorama \\\n"
-        "       --name <City> --output_base <pano_v2_base> ...\n"
-        "     (Run on the staged panorama/ dir — keys line up with VigorDataset.)"
-    )
-    print(
-        "  2. extract_landmarks_historical.py \\\n"
-        "       --dataset_path <vigor_root>/cvgtext_<City> \\\n"
-        "       --pbf_file <geofabrik>.osm.pbf \\\n"
-        "       --output_path <vigor_root>/cvgtext_<City>/landmarks/cvgtext_<City>_v1_<YYMMDD>.feather"
-    )
-    print(
-        "  3. precompute_value_embeddings.py (once, covering all cities)\n"
-        "       --pano_v2_base <pano_v2_base> \\\n"
-        "       --feather_dirs <vigor_root>/cvgtext_Brisbane ... \\\n"
-        "       --base_embeddings <base_text_embeddings>.pkl \\\n"
-        "       --output <extended_text_embeddings>.pkl"
-    )
-    print(
-        "  4. export_correspondence_similarity.py (per city)\n"
-        "       --model_path <classifier>.pt \\\n"
-        "       --text_embeddings_path <extended_text_embeddings>.pkl \\\n"
-        "       --dataset_path <vigor_root>/cvgtext_<City> \\\n"
-        "       --pano_v2_base <pano_v2_base> \\\n"
-        "       --compute_similarity --prob_threshold 0.8 --uniqueness_weighted"
-    )
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- Adds `experimental/overhead_matching/swag/scripts/stage_cvgtext_for_vigor.py`: one-shot converter from a CVG-Text tree into the VIGOR-shaped layout (`satellite_bbox.json` + VIGOR-named `satellite/` and `panorama/` symlink dirs per city) that `VigorDataset` and the correspondence pipeline expect. Accepts either an already-extracted CVG-Text tree or a freshly-downloaded `LHL3341/CVG-Text_full` HF dump; in the latter case `images.zip` and `data/query.zip` are extracted in place, stripping the `mnt/hwfile/opendatalab/air/linhonglin/CVG-text/` prefix wrapped around `images.zip`. Zips are left on disk. Registers a `py_binary` target.
- Bumps `precompute_value_embeddings.py`'s Vertex embed retry budget from 3 attempts / 4 s cap to 10 attempts / 60 s cap so transient 429s on tight per-minute quotas recover without losing all progress.
- Adds `experimental/overhead_matching/swag/crosstext2loc_comparison.md` as the reproduction doc for the three retrieval comparisons under `/data/overhead_matching/evaluation/results/cvgtext/`.

## Test plan

- [x] Fresh `hf download --repo-type dataset LHL3341/CVG-Text_full --local-dir /data/overhead_matching/datasets/cvgtext_repro` + `bazel run //…:stage_cvgtext_for_vigor`: zips auto-extract in place and produce `reference/<City>-{satellite,OSM,...}/` + `data/query/<City>-ground/`; per-city symlink counts match reference (Brisbane 16983/1000, NewYork 9974/1000, Tokyo 6107/1000); 0 dupes, 0 collisions, 0 orphans for all three.
- [x] Sampled symlinks in each city's `satellite/` and `panorama/` resolve to real files under the CVG-Text tree.
- [x] Re-running on an already-extracted tree is a no-op (existence check on `reference/` and `data/query/` short-circuits extraction).
- [x] End-to-end Step 2 rerun (Gemini landmark extraction + historical OSM + text-embedding extension + correspondence similarity) against the freshly staged tree: Exp B MRR reproduces README headline numbers to within Gemini non-determinism (Brisbane 0.080 vs 0.072, NewYork 0.227 vs 0.231, Tokyo 0.028 vs 0.028).

🤖 Generated with [Claude Code](https://claude.com/claude-code)