### PR TITLE
WIP: σ-calibration tooling + learned aggregator + SAFA + normalized-landmark fusion (archive — do not merge)

### DIFF
--- a/experimental/overhead_matching/swag/data/vigor_dataset.py
+++ b/experimental/overhead_matching/swag/data/vigor_dataset.py
@@ -132,9 +132,14 @@ def series_to_dict_with_index(series: pd.Series, index_key: str = "index"):
     return d
 
 
+_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png"}
+
+
 def load_satellite_metadata(path: Path, zoom_level: int):
     out = []
     for p in sorted(list(path.iterdir())):
+        if p.suffix.lower() not in _IMAGE_SUFFIXES:
+            continue  # skip cache/.pt sidecars that share filename stems
         _, lat, lon = p.stem.split("_")
         lat = float(lat)
         lon = float(lon)
@@ -146,6 +151,8 @@ def load_satellite_metadata(path: Path, zoom_level: int):
 def load_panorama_metadata(path: Path, zoom_level: int):
     out = []
     for p in sorted(list(path.iterdir())):
+        if p.suffix.lower() not in _IMAGE_SUFFIXES:
+            continue  # skip cache/.pt sidecars that share filename stems
         pano_id, lat, lon, _ = p.stem.split(",")
         lat = float(lat)
         lon = float(lon)

--- a/experimental/overhead_matching/swag/evaluation/correspondence_matching.py
+++ b/experimental/overhead_matching/swag/evaluation/correspondence_matching.py
@@ -23,6 +23,7 @@ import math
 import os
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 
 import common.torch.load_torch_deps  # noqa: F401
 
@@ -469,8 +470,16 @@ def precompute_raw_cost_data(
     device: torch.device,
     max_pairs_per_batch: int = 50000,
     allow_missing_text_embeddings: bool = False,
+    cost_matrix_memmap_path: Path | None = None,
 ) -> RawCorrespondenceData:
-    """Precompute the flat (total_pano_lm × total_osm_lm) P(match) matrix."""
+    """Precompute the flat (total_pano_lm × total_osm_lm) P(match) matrix.
+
+    When `cost_matrix_memmap_path` is provided, the cost matrix is written
+    directly to a .npy file via `np.lib.format.open_memmap` so it never lives
+    fully in RAM (needed for large cities like NewYork where the matrix is
+    ~25 GB). The returned `RawCorrespondenceData.cost_matrix` is then the
+    memmap; callers should rely on the on-disk file rather than re-saving it.
+    """
     num_sats = len(dataset._satellite_metadata)
 
     # Collect unique OSM landmarks from satellite metadata
@@ -509,7 +518,6 @@ def precompute_raw_cost_data(
 
     pano_ids = sorted(dataset._panorama_metadata.pano_id.values)
     pano_id_to_lm_rows: dict[str, list[int]] = {}
-    all_cost_rows = []
     all_pano_lm_tags: list = []
     current_row = 0
 
@@ -522,6 +530,21 @@ def precompute_raw_cost_data(
         pano_list.append((pano_id, pano_tags_dicts, pano_landmarks))
 
     _log(f"  {len(pano_list)} panoramas with tags")
+
+    total_pano_lm = sum(len(pano_tags_dicts) for _, pano_tags_dicts, _ in pano_list)
+    if cost_matrix_memmap_path is not None:
+        cost_matrix_memmap_path.parent.mkdir(parents=True, exist_ok=True)
+        flat_cost = np.lib.format.open_memmap(
+            cost_matrix_memmap_path, mode="w+",
+            dtype=np.float32, shape=(total_pano_lm, n_osm),
+        )
+        all_cost_rows = None
+        _log(f"  Streaming cost matrix to {cost_matrix_memmap_path} "
+             f"(shape={(total_pano_lm, n_osm)}, "
+             f"~{total_pano_lm * n_osm * 4 / 1e9:.1f} GB)")
+    else:
+        flat_cost = None
+        all_cost_rows = []
 
     batch_size = 64
     for batch_start in tqdm(
@@ -594,12 +617,17 @@ def precompute_raw_cost_data(
             cost = all_cost[offset:offset + n_lm]
             row_indices = list(range(current_row, current_row + n_lm))
             pano_id_to_lm_rows[pano_id] = row_indices
-            all_cost_rows.append(cost)
+            if flat_cost is not None:
+                flat_cost[current_row:current_row + n_lm] = cost
+            else:
+                all_cost_rows.append(cost)
             for lm in pano_landmarks:
                 all_pano_lm_tags.append(lm["tags"])
             current_row += n_lm
 
-    if all_cost_rows:
+    if flat_cost is not None:
+        flat_cost.flush()
+    elif all_cost_rows:
         flat_cost = np.vstack(all_cost_rows)
     else:
         flat_cost = np.zeros((0, n_osm), dtype=np.float32)

--- a/experimental/overhead_matching/swag/filter/BUILD
+++ b/experimental/overhead_matching/swag/filter/BUILD
@@ -55,6 +55,43 @@ py_library(
         requirement("torch"),
         "//common/python:serialization",
         "//common/torch:load_torch_deps",
+        "//experimental/overhead_matching/swag/data:vigor_dataset",
         ":particle_filter",
+    ],
+)
+
+py_test(
+    name = "adaptive_aggregators_test",
+    srcs = ["adaptive_aggregators_test.py"],
+    deps = [
+        requirement("torch"),
+        requirement("pandas"),
+        "//common/torch:load_torch_deps",
+        ":adaptive_aggregators",
+        ":particle_filter",
+    ],
+)
+
+py_library(
+    name = "learned_aggregator",
+    srcs = ["learned_aggregator.py"],
+    visibility = ["//experimental/overhead_matching/swag:__subpackages__"],
+    deps = [
+        requirement("pandas"),
+        requirement("torch"),
+        "//common/torch:load_torch_deps",
+        ":adaptive_aggregators",
+    ],
+)
+
+py_test(
+    name = "learned_aggregator_test",
+    srcs = ["learned_aggregator_test.py"],
+    deps = [
+        requirement("torch"),
+        requirement("pandas"),
+        "//common/torch:load_torch_deps",
+        ":adaptive_aggregators",
+        ":learned_aggregator",
     ],
 )

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -114,6 +114,15 @@ class SingleSimilarityMatrixAggregator(ObservationLogLikelihoodAggregator):
     def __call__(self, pano_id: str) -> torch.Tensor:
         pano_index = self._pano_id_index.get_loc(pano_id)
         similarity = self.similarity_matrix[pano_index]
+        if similarity.numel() == 0:
+            raise RuntimeError(
+                f"SingleSimilarityMatrixAggregator: empty similarity slice for "
+                f"pano_id={pano_id!r}. matrix shape={tuple(self.similarity_matrix.shape)}, "
+                f"pano_index={pano_index!r} ({type(pano_index).__name__}), "
+                f"slice shape={tuple(similarity.shape)}. Likely cause: duplicate "
+                f"pano_id in panorama_metadata producing a boolean mask that selects "
+                f"zero rows, or a pano_id in the path JSON not present in the dataset."
+            )
         log_ll = wag_observation_log_likelihood_from_similarity_matrix(
             similarity, self.sigma
         )

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -36,11 +36,30 @@ class ImageLandmarkPrivilegedInformationFusionConfig(
 
 
 class EntropyAdaptiveAggregatorConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
-    """Config for entropy-adaptive weighted fusion aggregator."""
+    """Config for entropy-adaptive weighted fusion aggregator.
+
+    Set per-source sigmas via `image_sigma` and `landmark_sigma`. For
+    backward compatibility, a single `sigma` is also accepted and applied
+    to both sources (legacy behavior). At least one of (sigma) or
+    (image_sigma + landmark_sigma) must be supplied.
+    """
 
     image_similarity_matrix_path: Path
     landmark_similarity_matrix_path: Path
-    sigma: float
+    sigma: float | None = None
+    image_sigma: float | None = None
+    landmark_sigma: float | None = None
+
+    def resolve_sigmas(self) -> tuple[float, float]:
+        """Return (image_sigma, landmark_sigma), filling from `sigma` if needed."""
+        img = self.image_sigma if self.image_sigma is not None else self.sigma
+        lm = self.landmark_sigma if self.landmark_sigma is not None else self.sigma
+        if img is None or lm is None:
+            raise ValueError(
+                "EntropyAdaptiveAggregatorConfig requires either `sigma` "
+                "or both `image_sigma` and `landmark_sigma` to be set."
+            )
+        return float(img), float(lm)
 
 
 # Union type for polymorphic deserialization
@@ -213,6 +232,10 @@ class EntropyAdaptiveAggregator(ObservationLogLikelihoodAggregator):
 
     Computes a per-source peak sharpness confidence score (max - mean of log-probs)
     and uses it to blend the two similarity vectors before converting to log-likelihoods.
+
+    Image and landmark similarities are normalized through `log_softmax(x / sigma)`
+    with their own per-source sigmas (`image_sigma`, `landmark_sigma`) — these
+    parameterize how peaky each source's posterior is before fusion.
     """
 
     def __init__(
@@ -220,12 +243,14 @@ class EntropyAdaptiveAggregator(ObservationLogLikelihoodAggregator):
         image_similarity_matrix: torch.Tensor,
         landmark_similarity_matrix: torch.Tensor,
         panorama_metadata: pd.DataFrame,
-        sigma: float,
+        image_sigma: float,
+        landmark_sigma: float,
         device: torch.device,
     ):
         self.image_similarity_matrix = image_similarity_matrix
         self.landmark_similarity_matrix = landmark_similarity_matrix
-        self.sigma = sigma
+        self.image_sigma = image_sigma
+        self.landmark_sigma = landmark_sigma
         self.device = device
         self._pano_id_index = pd.Index(panorama_metadata["pano_id"])
 
@@ -252,14 +277,14 @@ class EntropyAdaptiveAggregator(ObservationLogLikelihoodAggregator):
         lm_sim = self.landmark_similarity_matrix[pano_index]
 
         # Normalize to log-probability space first (makes different scales commensurate)
-        log_p_img = torch.log_softmax(img_sim / self.sigma, dim=0)
+        log_p_img = torch.log_softmax(img_sim / self.image_sigma, dim=0)
 
         # Fall back to image-only when landmark data is missing (all -inf)
         lm_finite_mask = torch.isfinite(lm_sim)
         if not lm_finite_mask.any():
             return _replace_nan_with_zero(log_p_img).to(self.device)
 
-        log_p_lm = torch.log_softmax(lm_sim / self.sigma, dim=0)
+        log_p_lm = torch.log_softmax(lm_sim / self.landmark_sigma, dim=0)
 
         img_conf = self._compute_confidence(log_p_img)
         lm_conf = self._compute_confidence(log_p_lm)
@@ -280,11 +305,13 @@ class EntropyAdaptiveAggregator(ObservationLogLikelihoodAggregator):
     ) -> "EntropyAdaptiveAggregator":
         image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
         landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
+        image_sigma, landmark_sigma = config.resolve_sigmas()
         return cls(
             image_sim,
             landmark_sim,
             vigor_dataset._panorama_metadata,
-            config.sigma,
+            image_sigma,
+            landmark_sigma,
             device,
         )
 

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -62,11 +62,44 @@ class EntropyAdaptiveAggregatorConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
         return float(img), float(lm)
 
 
-# Union type for polymorphic deserialization
+class LearnedAggregatorConfig(msgspec.Struct, **MSGSPEC_STRUCT_OPTS):
+    """Config for the learned per-step fusion policy.
+
+    The policy implementation lives in ``learned_aggregator`` (separate
+    module so this file has no torch.nn dependency); we only declare the
+    config here so it can join the polymorphic ``AggregatorConfig`` union.
+    """
+
+    image_similarity_matrix_path: Path
+    landmark_similarity_matrix_path: Path
+    policy_weights_path: Path
+
+
+class SafaPlusNormalizedLandmarkAggregatorConfig(
+    msgspec.Struct, **MSGSPEC_STRUCT_OPTS
+):
+    """Config for ``SafaPlusNormalizedLandmarkAggregator``.
+
+    Image stream uses SAFA-style Gaussian-on-residuals at ``image_sigma``.
+    Landmark stream divides each row by its ``row_max`` and applies
+    Gaussian-on-residuals to ``r_norm = 1 − sim_t / row_max`` at
+    ``landmark_sigma``. All-zero / constant landmark rows fall through
+    to image-only.
+    """
+
+    image_similarity_matrix_path: Path
+    landmark_similarity_matrix_path: Path
+    image_sigma: float
+    landmark_sigma: float
+
+
+# Union type for polymorphic deserialization.
 AggregatorConfig = (
     SingleSimilarityMatrixAggregatorConfig
     | ImageLandmarkPrivilegedInformationFusionConfig
     | EntropyAdaptiveAggregatorConfig
+    | LearnedAggregatorConfig
+    | SafaPlusNormalizedLandmarkAggregatorConfig
 )
 
 
@@ -316,6 +349,107 @@ class EntropyAdaptiveAggregator(ObservationLogLikelihoodAggregator):
         )
 
 
+class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
+    """Per-patch observation likelihood by *summing* two Gaussian-on-residuals
+    log-likelihoods — image stream as in SAFA, landmark stream on a per-row
+    normalized residual.
+
+    Motivation. The EA softmax fusion implicitly normalizes mass over space
+    (sums to 1 across patches), which is incompatible with treating the
+    aggregator's output as a true per-patch ``log p(z | patch_j)`` that the
+    downstream histogram filter can multiply through its belief. This
+    aggregator is properly per-patch:
+
+      log_p_img[j] = -log(σ_img √2π) - 0.5 ((sim_max_img − img[j]) / σ_img)^2
+      log_p_lm[j]  = -log(σ_lm  √2π) - 0.5 ((1 − lm[j]/sim_max_lm) / σ_lm )^2
+
+      log_p[j] = log_p_img[j] + log_p_lm[j]   (conditional independence)
+
+    Why divide-by-row-max for the landmark stream? Because absolute landmark
+    similarity scales differ across cities (per-pair MLE on raw residuals
+    ranges 0.44–0.62 across Chicago/Seattle/NewYork/post_hurricane_ian),
+    while the per-row ``1 − sim_t / sim_max`` distribution overlaps
+    tightly across cities (σ_MLE ranges 0.66–0.74; ~12% spread). The
+    normalization makes a single ``σ_lm`` transfer cleanly.
+
+    All-zero / constant landmark rows are handled with a hard fall-through
+    to image-only: those rows are uninformative and we don't want them to
+    contaminate the fused log-likelihood with noise from the / row_max
+    division.
+    """
+
+    def __init__(
+        self,
+        image_similarity_matrix: torch.Tensor,
+        landmark_similarity_matrix: torch.Tensor,
+        panorama_metadata: pd.DataFrame,
+        image_sigma: float,
+        landmark_sigma: float,
+        device: torch.device,
+    ):
+        self.image_similarity_matrix = image_similarity_matrix
+        self.landmark_similarity_matrix = landmark_similarity_matrix
+        self.image_sigma = float(image_sigma)
+        self.landmark_sigma = float(landmark_sigma)
+        self.device = device
+        self._pano_id_index = pd.Index(panorama_metadata["pano_id"])
+
+    def __call__(self, pano_id: str) -> torch.Tensor:
+        pano_index = self._pano_id_index.get_loc(pano_id)
+
+        img_sim = self.image_similarity_matrix[pano_index].to(self.device)
+        lm_sim = self.landmark_similarity_matrix[pano_index].to(self.device)
+
+        # Image-side Gaussian-on-residuals (SAFA form).
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim, self.image_sigma
+        )
+
+        # Landmark-side: per-row /max normalization, then Gaussian-on-r_norm.
+        # Fall through to image-only when the landmark row is uninformative.
+        lm_finite_mask = torch.isfinite(lm_sim)
+        if not lm_finite_mask.any():
+            return _replace_nan_with_zero(log_p_img)
+        lm_finite = lm_sim[lm_finite_mask]
+        sim_max_lm = lm_finite.max()
+        sim_min_lm = lm_finite.min()
+        if (sim_max_lm <= 0) or (sim_max_lm == sim_min_lm):
+            # All-zero or constant row → landmark is uninformative.
+            return _replace_nan_with_zero(log_p_img)
+
+        norm_sim = lm_sim / sim_max_lm
+        r_norm = 1.0 - norm_sim
+        sigma_lm = self.landmark_sigma
+        log_norm_const = -torch.log(
+            torch.sqrt(torch.tensor(2 * torch.pi, device=lm_sim.device))
+        ) - torch.log(torch.tensor(sigma_lm, device=lm_sim.device))
+        log_p_lm = log_norm_const - 0.5 * torch.square(r_norm / sigma_lm)
+
+        # If a single entry is non-finite (e.g., -inf landmark), pass through
+        # image-only at that entry to avoid NaN propagation downstream.
+        log_p_lm = torch.where(lm_finite_mask, log_p_lm, torch.zeros_like(log_p_lm))
+
+        return _replace_nan_with_zero(log_p_img + log_p_lm)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: SafaPlusNormalizedLandmarkAggregatorConfig,
+        vigor_dataset: vd.VigorDataset,
+        device: torch.device,
+    ) -> "SafaPlusNormalizedLandmarkAggregator":
+        image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
+        landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
+        return cls(
+            image_similarity_matrix=image_sim,
+            landmark_similarity_matrix=landmark_sim,
+            panorama_metadata=vigor_dataset._panorama_metadata,
+            image_sigma=config.image_sigma,
+            landmark_sigma=config.landmark_sigma,
+            device=device,
+        )
+
+
 def aggregator_from_config(
     config: AggregatorConfig,
     vigor_dataset: vd.VigorDataset,
@@ -338,6 +472,17 @@ def aggregator_from_config(
         )
     elif isinstance(config, EntropyAdaptiveAggregatorConfig):
         return EntropyAdaptiveAggregator.from_config(config, vigor_dataset, device)
+    elif isinstance(config, LearnedAggregatorConfig):
+        # Lazy import to avoid pulling torch.nn into modules that only need
+        # the per-config aggregators.
+        from experimental.overhead_matching.swag.filter import learned_aggregator
+        return learned_aggregator.LearnedAggregator.from_config(
+            config, vigor_dataset, device
+        )
+    elif isinstance(config, SafaPlusNormalizedLandmarkAggregatorConfig):
+        return SafaPlusNormalizedLandmarkAggregator.from_config(
+            config, vigor_dataset, device
+        )
     else:
         raise ValueError(f"Unknown config type: {type(config)}")
 

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
@@ -1,0 +1,116 @@
+import math
+import unittest
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import pandas as pd
+
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    SafaPlusNormalizedLandmarkAggregator,
+)
+from experimental.overhead_matching.swag.filter.particle_filter import (
+    wag_observation_log_likelihood_from_similarity_matrix,
+)
+
+
+def _make_metadata(n: int = 4) -> pd.DataFrame:
+    return pd.DataFrame({"pano_id": [f"p{i}" for i in range(n)]})
+
+
+class TestSafaPlusNormalizedLandmarkAggregator(unittest.TestCase):
+    """The new aggregator's contract is: per-patch ``log p(z|patch_j)`` =
+    SAFA Gaussian-on-residuals (image) + Gaussian-on-r_norm (landmark),
+    with image-only fall-through on all-zero / constant landmark rows."""
+
+    def _make(self, img_sim, lm_sim, image_sigma=0.187, landmark_sigma=0.72):
+        meta = _make_metadata(img_sim.shape[0])
+        return SafaPlusNormalizedLandmarkAggregator(
+            image_similarity_matrix=img_sim,
+            landmark_similarity_matrix=lm_sim,
+            panorama_metadata=meta,
+            image_sigma=image_sigma,
+            landmark_sigma=landmark_sigma,
+            device=torch.device("cpu"),
+        )
+
+    def test_all_zero_landmark_row_falls_through_to_image_only(self):
+        torch.manual_seed(0)
+        img_sim = torch.randn(2, 50) * 0.3 + 0.4
+        lm_sim = torch.zeros(2, 50)        # row 0 is all-zero
+        lm_sim[1] = torch.rand(50)         # row 1 has signal
+        agg = self._make(img_sim, lm_sim)
+
+        out_zero = agg("p0")
+        expected = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        # The image-only fall-through path goes through ``_replace_nan_with_zero``,
+        # which mutates the input in-place. Re-derive the expected value the
+        # same way to avoid a stale comparison.
+        expected = torch.where(torch.isnan(expected), torch.zeros_like(expected), expected)
+        self.assertTrue(torch.allclose(out_zero, expected, atol=1e-6),
+                        "all-zero landmark row must equal image-only log_p")
+
+    def test_constant_landmark_row_falls_through_to_image_only(self):
+        """Even a non-zero constant row carries no information after / row_max
+        normalization (every entry has r_norm = 0), so we route to image-only
+        rather than divide-by-anything fragile."""
+        img_sim = torch.randn(1, 30) * 0.3 + 0.4
+        lm_sim = torch.full((1, 30), 0.42)
+        agg = self._make(img_sim, lm_sim)
+
+        out = agg("p0")
+        expected = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        expected = torch.where(torch.isnan(expected), torch.zeros_like(expected), expected)
+        self.assertTrue(torch.allclose(out, expected, atol=1e-6))
+
+    def test_patch_at_row_max_gets_zero_landmark_residual(self):
+        """If sim_lm[j*] == row_max, then r_norm[j*] = 0 and log_p_lm[j*] =
+        -log(σ_lm √2π). The fused log_p[j*] = log_p_img[j*] + that constant.
+        """
+        img_sim = torch.zeros(1, 5)
+        lm_sim = torch.tensor([[0.0, 0.3, 1.0, 0.7, 0.0]])  # row_max = 1.0 at idx 2
+        sigma_lm = 0.5
+        agg = self._make(img_sim, lm_sim, landmark_sigma=sigma_lm)
+
+        out = agg("p0")
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        log_p_img = torch.where(
+            torch.isnan(log_p_img), torch.zeros_like(log_p_img), log_p_img
+        )
+        expected_lm_at_max = -math.log(sigma_lm * math.sqrt(2 * math.pi))
+        self.assertAlmostEqual(
+            (out[2] - log_p_img[2]).item(), expected_lm_at_max, places=4
+        )
+
+    def test_landmark_residual_decreases_likelihood_quadratically(self):
+        """log_p_lm[j] − log_p_lm[j*] should be exactly −0.5 (r_norm / σ_lm)^2."""
+        img_sim = torch.zeros(1, 4)
+        lm_sim = torch.tensor([[0.0, 0.5, 1.0, 0.25]])  # row_max = 1.0 at idx 2
+        sigma_lm = 0.3
+        agg = self._make(img_sim, lm_sim, landmark_sigma=sigma_lm)
+        out = agg("p0")
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        log_p_img = torch.where(
+            torch.isnan(log_p_img), torch.zeros_like(log_p_img), log_p_img
+        )
+        log_p_lm = out - log_p_img
+
+        # Reference at idx 2 (row_max → r_norm=0):
+        ref = log_p_lm[2]
+        for j, expected_r_norm in [(0, 1.0), (1, 0.5), (3, 0.75)]:
+            expected_drop = -0.5 * (expected_r_norm / sigma_lm) ** 2
+            self.assertAlmostEqual(
+                (log_p_lm[j] - ref).item(), expected_drop, places=4,
+                msg=f"residual at idx {j} should be −0.5·(r/σ)^2",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/overhead_matching/swag/filter/histogram_belief.py
+++ b/experimental/overhead_matching/swag/filter/histogram_belief.py
@@ -488,6 +488,24 @@ class HistogramBelief:
         lat, lon = self.grid_spec.cell_indices_to_latlon(mean_row, mean_col)
         return torch.stack([lat, lon])
 
+    def get_mode_latlon(self) -> torch.Tensor:
+        """Return lat/lon of the highest-probability cell (MAP estimate).
+
+        Useful when the posterior is multimodal — the weighted mean can sit
+        in a low-probability valley between peaks, while the mode points at
+        the dominant peak. Ties broken by lowest flat-index.
+
+        Returns:
+            (2,) tensor [lat, lon]
+        """
+        belief_probs = self.get_belief()
+        flat_idx = torch.argmax(belief_probs)
+        n_cols = self.grid_spec.num_cols
+        row = (flat_idx // n_cols).to(torch.float32)
+        col = (flat_idx % n_cols).to(torch.float32)
+        lat, lon = self.grid_spec.cell_indices_to_latlon(row, col)
+        return torch.stack([lat, lon])
+
     def get_variance_deg_sq(self) -> torch.Tensor:
         """Compute variance of belief in degrees squared.
 

--- a/experimental/overhead_matching/swag/filter/histogram_belief.py
+++ b/experimental/overhead_matching/swag/filter/histogram_belief.py
@@ -547,14 +547,23 @@ class HistogramBelief:
     def apply_motion(
         self,
         motion_delta_deg: torch.Tensor,
-        noise_percent: float,
+        motion_noise_frac: float,
         reference_latlon: torch.Tensor | None = None,
     ) -> None:
-        """Apply motion model: shift by delta and blur by noise.
+        """Apply motion model: shift by delta and Wiener-blur by noise.
+
+        Wiener (Brownian) scaling: per-step variance is linear in step distance,
+        so per-step std is `motion_noise_frac × √d` where `d` is the step
+        distance in meters. Units of `motion_noise_frac` are m/√m, matching
+        `OdometryNoiseConfig.sigma_noise_frac`. With this convention you can
+        set the filter's process model equal to the (true) input-noise constant
+        and the filter is calibrated by construction.
 
         Args:
             motion_delta_deg: (2,) tensor [delta_lat, delta_lon] in degrees
-            noise_percent: Noise as fraction of motion magnitude
+            motion_noise_frac: Wiener noise intensity in m/√m. For a step of
+                distance d meters, the blur std is `motion_noise_frac × √d`
+                meters (then converted to cells for the Gaussian blur).
             reference_latlon: Reference point for coordinate conversion.
                 If None, uses current belief mean.
         """
@@ -578,10 +587,19 @@ class HistogramBelief:
         shift_rows = delta_row_px / self.grid_spec.cell_size_px
         shift_cols = delta_col_px / self.grid_spec.cell_size_px
 
-        # Compute noise sigma in cell units
+        # Compute noise sigma via Wiener scaling in meters, then convert back
+        # to cells for the Gaussian blur. Doing the scaling in meters keeps
+        # `motion_noise_frac` in m/√m (matching OdometryNoiseConfig) so that
+        # input and process-model noise share units and can be set equal for
+        # a calibrated filter.
+        ref_lat_deg = float(reference_latlon[0]) if isinstance(
+            reference_latlon[0], torch.Tensor) else reference_latlon[0]
+        m_per_px = web_mercator.get_meters_per_pixel(
+            ref_lat_deg, self.grid_spec.zoom_level)
         delta_magnitude_px = torch.sqrt(delta_row_px**2 + delta_col_px**2)
-        sigma_px = delta_magnitude_px * noise_percent
-        sigma_cells = sigma_px / self.grid_spec.cell_size_px
+        delta_magnitude_m = delta_magnitude_px * m_per_px
+        sigma_m = motion_noise_frac * torch.sqrt(delta_magnitude_m)
+        sigma_cells = (sigma_m / m_per_px) / self.grid_spec.cell_size_px
 
         # Apply shift
         self._log_belief = _shift_grid(self._log_belief, shift_rows, shift_cols)

--- a/experimental/overhead_matching/swag/filter/histogram_belief.py
+++ b/experimental/overhead_matching/swag/filter/histogram_belief.py
@@ -634,25 +634,46 @@ class HistogramBelief:
         self,
         observation_log_likelihoods: torch.Tensor,
         mapping: CellToPatchMapping,
+        surrogate_tau: float | None = None,
     ) -> None:
         """Apply observation update using pre-computed log-likelihoods.
 
-        For each cell, uses the maximum log-likelihood among all overlapping
-        patches. This is similar to how the particle filter works (each particle
-        uses its nearest/best patch) and avoids artifacts from varying overlap
-        counts at patch boundaries.
+        For each cell, aggregates the per-patch log-likelihoods over the
+        overlapping patches. Two aggregation modes:
+
+        * ``surrogate_tau is None`` (default): hard ``max`` over patches.
+          This matches the production particle-filter analogue (each particle
+          uses its nearest/best patch) and avoids artifacts from varying
+          overlap counts at patch boundaries. Non-differentiable in the
+          patch-similarity inputs.
+        * ``surrogate_tau > 0``: soft-max via
+          ``tau * logsumexp(values / tau)``. As ``tau → 0`` this recovers
+          the hard max; at ``tau = 1`` it is the natural log-of-sum
+          (combining overlapping patches as "OR of evidence"). This branch
+          is differentiable end-to-end and is used to train a learned
+          aggregator with backprop through the filter.
 
         Args:
-            observation_log_likelihoods: (num_patches,) log-likelihoods for each satellite patch
-            mapping: Precomputed cell-to-patch mapping
+            observation_log_likelihoods: (num_patches,) log-likelihoods.
+            mapping: Precomputed cell-to-patch mapping.
+            surrogate_tau: If not None, use soft-max with this temperature
+                (units: log-likelihood) instead of hard max. Smaller values
+                produce sharper aggregations; ``tau=1.0`` is the natural
+                logsumexp scale.
         """
         # Gather log-likelihoods for all overlapping patches
         all_log_ll = observation_log_likelihoods[mapping.patch_indices]  # (total_overlaps,)
 
-        # Take max log-likelihood over overlapping patches for each cell
-        cell_log_ll = segment_max(
-            all_log_ll, mapping.cell_offsets, mapping.segment_ids
-        )
+        # Aggregate over overlapping patches per cell
+        if surrogate_tau is None:
+            cell_log_ll = segment_max(
+                all_log_ll, mapping.cell_offsets, mapping.segment_ids
+            )
+        else:
+            inv_tau = 1.0 / float(surrogate_tau)
+            cell_log_ll = surrogate_tau * segment_logsumexp(
+                all_log_ll * inv_tau, mapping.cell_offsets, mapping.segment_ids,
+            )
 
         # Reshape to grid and apply to belief
         cell_log_ll_grid = cell_log_ll.reshape(

--- a/experimental/overhead_matching/swag/filter/histogram_belief_test.py
+++ b/experimental/overhead_matching/swag/filter/histogram_belief_test.py
@@ -298,7 +298,7 @@ class TestHistogramBelief(unittest.TestCase):
 
         # Apply motion: move north (+lat) and east (+lon)
         motion_delta = torch.tensor([0.001, 0.001])
-        belief.apply_motion(motion_delta, noise_percent=0.02)
+        belief.apply_motion(motion_delta, motion_noise_frac=0.05)
 
         mean_after = belief.get_mean_latlon()
 

--- a/experimental/overhead_matching/swag/filter/histogram_belief_test.py
+++ b/experimental/overhead_matching/swag/filter/histogram_belief_test.py
@@ -701,5 +701,64 @@ class TestApplyObservation(unittest.TestCase):
         self.assertAlmostEqual(prob_sum, 1.0, places=4)
 
 
+class TestApplyObservationSurrogate(unittest.TestCase):
+    """The differentiable soft-max surrogate must approximate the hard max
+    aggregation as ``surrogate_tau → 0`` and must propagate gradients back to
+    the input log-likelihoods (the production hard-max path does not)."""
+
+    def _make_setup(self):
+        grid_spec = GridSpec(
+            zoom_level=20, cell_size_px=100.0,
+            origin_row_px=0.0, origin_col_px=0.0,
+            num_rows=3, num_cols=3,
+        )
+        patch_positions = torch.tensor([
+            [50.0, 50.0], [50.0, 150.0], [50.0, 250.0],
+            [150.0, 50.0], [150.0, 150.0], [150.0, 250.0],
+            [250.0, 50.0], [250.0, 150.0], [250.0, 250.0],
+        ])
+        # patch_half_size > cell_size makes adjacent cells share patches,
+        # so segment_max and segment_logsumexp differ meaningfully.
+        patch_half_size = 90.0
+        mapping = build_cell_to_patch_mapping(
+            grid_spec, patch_positions, patch_half_size, torch.device("cpu")
+        )
+        torch.manual_seed(0)
+        obs_log_ll = wag_observation_log_likelihood_from_similarity_matrix(
+            torch.rand(9), sigma=0.1
+        )
+        return grid_spec, mapping, obs_log_ll
+
+    def test_surrogate_recovers_max_in_low_tau_limit(self):
+        """At small ``surrogate_tau`` the soft-max belief should match hard max."""
+        grid_spec, mapping, obs_log_ll = self._make_setup()
+
+        belief_max = HistogramBelief.from_uniform(grid_spec, torch.device("cpu"))
+        belief_max.apply_observation(obs_log_ll, mapping)
+
+        belief_soft = HistogramBelief.from_uniform(grid_spec, torch.device("cpu"))
+        belief_soft.apply_observation(obs_log_ll, mapping, surrogate_tau=1e-3)
+
+        diff = (belief_max.get_belief() - belief_soft.get_belief()).abs().max().item()
+        self.assertLess(diff, 1e-3)
+
+    def test_surrogate_propagates_gradients(self):
+        """Gradients must flow through the differentiable path."""
+        grid_spec, mapping, obs_log_ll = self._make_setup()
+        obs_log_ll = obs_log_ll.detach().requires_grad_(True)
+
+        belief = HistogramBelief.from_uniform(grid_spec, torch.device("cpu"))
+        belief.apply_observation(obs_log_ll, mapping, surrogate_tau=0.5)
+
+        # Some scalar functional of the resulting belief, then differentiate.
+        loss = belief.get_belief().sum() + (belief._log_belief * 1e-6).sum()
+        loss.backward()
+        self.assertIsNotNone(obs_log_ll.grad)
+        self.assertTrue(torch.isfinite(obs_log_ll.grad).all())
+        # The hard-max path silently drops gradients, so the surrogate path
+        # must produce a non-zero grad on at least one log-likelihood entry.
+        self.assertGreater(obs_log_ll.grad.abs().max().item(), 0.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/experimental/overhead_matching/swag/filter/learned_aggregator.py
+++ b/experimental/overhead_matching/swag/filter/learned_aggregator.py
@@ -1,0 +1,491 @@
+"""Learned per-step fusion policy for the histogram filter.
+
+Replaces the constant-σ EA aggregator with a small MLP that, given a row of
+image and landmark similarities (plus optional belief / trajectory features),
+emits per-step (σ_img, σ_lm, α). The fused log-likelihood is then
+
+    log_p_img = log_softmax(img_sim / σ_img)
+    log_p_lm  = log_softmax(lm_sim  / σ_lm)
+    fused     = α · log_p_img + (1 − α) · log_p_lm
+
+α is *not* the EA peak_sharpness ratio — that formula was σ-coupled and
+caused the calibration trap we documented (small σ_lm artificially sharpens
+the landmark posterior, falsely amplifying landmark weight on no-signal
+rows). Here α is a free output of the policy.
+
+State features are deliberately city-agnostic (statistics of the row /
+belief) so the same policy can transfer from Seattle to Chicago.
+
+The policy is trained by ``train_learned_aggregator.py`` end-to-end through
+the differentiable histogram filter (``apply_observation`` with
+``surrogate_tau`` enabled).
+"""
+
+from dataclasses import dataclass
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import pandas as pd
+
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    ObservationLogLikelihoodAggregator,
+    LearnedAggregatorConfig,
+    _replace_nan_with_zero,
+    _load_similarity_matrix,
+)
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+
+
+# ============ Constants ============
+
+# Floor on σ to keep ``log_softmax(sim / σ)`` numerically stable.
+SIGMA_MIN: float = 0.02
+
+# Reference σ used when computing σ-independent features (so the feature
+# values do not depend on the action the policy is about to take).
+SIGMA_REF_FEATURES: float = 1.0
+
+# Number of belief features (used only when belief context is provided).
+NUM_BELIEF_FEATURES: int = 4
+
+# Number of trajectory-context features.
+NUM_STEP_FEATURES: int = 3
+
+# Compact per-step features that appear in the policy's history window.
+# Each entry summarizes a single past step: belief state + how informative
+# that step's observation was. Pure scalars so the buffer is small and
+# city-agnostic. Order MUST match `HistoryEntry.to_list`.
+NUM_HISTORY_ENTRY_FEATURES: int = 5
+
+# Number of past steps the policy sees alongside its current features.
+# Padded with zero entries on the left when fewer than HISTORY_DEPTH steps
+# have elapsed at the start of a path.
+HISTORY_DEPTH: int = 10
+
+
+# ============ Feature extraction ============
+
+
+@dataclass
+class StreamRowStats:
+    """Per-row statistics for one similarity stream (image OR landmark).
+
+    All entries are scalar tensors so they can be stacked into a feature
+    vector without a Python loop. Computed over the *finite* entries of the
+    row to be robust to -inf / NaN values.
+    """
+
+    max: torch.Tensor
+    mean: torch.Tensor
+    std: torch.Tensor
+    median: torch.Tensor
+    top1_minus_top2: torch.Tensor
+    top1_minus_top5: torch.Tensor
+    frac_finite: torch.Tensor
+    frac_nonzero: torch.Tensor
+    softmax_entropy: torch.Tensor      # entropy of softmax(sim / σ_ref)
+    softmax_peak_sharp: torch.Tensor   # max − mean of log_softmax(sim / σ_ref)
+
+    NUM_FEATURES = 10
+
+    def to_tensor(self) -> torch.Tensor:
+        return torch.stack([
+            self.max, self.mean, self.std, self.median,
+            self.top1_minus_top2, self.top1_minus_top5,
+            self.frac_finite, self.frac_nonzero,
+            self.softmax_entropy, self.softmax_peak_sharp,
+        ])
+
+
+def compute_row_stats(
+    sim_row: torch.Tensor,
+    sigma_ref: float = SIGMA_REF_FEATURES,
+) -> StreamRowStats:
+    """Compute σ-independent statistics of a similarity row.
+
+    All features are scale-normalized in the sense that they're functions of
+    the row's distribution rather than absolute identifiers, so they should
+    be city-transferable. The only σ involved is ``sigma_ref`` for the two
+    log-softmax features, which is held *fixed* across cities.
+    """
+    finite_mask = torch.isfinite(sim_row)
+    n_total = sim_row.numel()
+    n_finite = int(finite_mask.sum().item())
+    device = sim_row.device
+    dtype = sim_row.dtype
+
+    if n_finite == 0:
+        zero = torch.zeros((), device=device, dtype=dtype)
+        return StreamRowStats(
+            max=zero, mean=zero, std=zero, median=zero,
+            top1_minus_top2=zero, top1_minus_top5=zero,
+            frac_finite=zero, frac_nonzero=zero,
+            softmax_entropy=zero, softmax_peak_sharp=zero,
+        )
+
+    finite_vals = sim_row[finite_mask]
+    sorted_desc, _ = torch.sort(finite_vals, descending=True)
+
+    max_v = sorted_desc[0]
+    mean_v = finite_vals.mean()
+    std_v = (
+        finite_vals.std(unbiased=False)
+        if n_finite > 1 else torch.zeros((), device=device, dtype=dtype)
+    )
+    median_v = finite_vals.median()
+    top2 = sorted_desc[1] if n_finite >= 2 else sorted_desc[0]
+    top5 = sorted_desc[4] if n_finite >= 5 else sorted_desc[-1]
+
+    # softmax-on-row stats at fixed σ_ref (decoupled from policy output).
+    log_p = torch.log_softmax(finite_vals / sigma_ref, dim=0)
+    p = log_p.exp()
+    softmax_entropy = -(p * log_p).sum()
+    softmax_peak_sharp = log_p.max() - log_p.mean()
+
+    frac_finite = torch.tensor(n_finite / max(n_total, 1), device=device, dtype=dtype)
+    n_nonzero = int((finite_vals != 0).sum().item())
+    frac_nonzero = torch.tensor(
+        n_nonzero / max(n_total, 1), device=device, dtype=dtype
+    )
+
+    return StreamRowStats(
+        max=max_v, mean=mean_v, std=std_v, median=median_v,
+        top1_minus_top2=(max_v - top2),
+        top1_minus_top5=(max_v - top5),
+        frac_finite=frac_finite, frac_nonzero=frac_nonzero,
+        softmax_entropy=softmax_entropy,
+        softmax_peak_sharp=softmax_peak_sharp,
+    )
+
+
+@dataclass
+class HistoryEntry:
+    """Compact per-step summary appended to the policy's history buffer.
+
+    Captures *what the filter has seen recently* without including raw
+    similarity rows (those are summarized elsewhere) — five scalars that
+    describe how the belief evolved and how informative each observation
+    was. ``last_obs_max_log_p`` is the max of the fused log-likelihood that
+    was applied at this step (a proxy for "how peaky was the observation").
+    """
+
+    belief_entropy: float = 0.0
+    belief_log_trace_var: float = 0.0
+    belief_top_cell_mass: float = 0.0
+    log_step_distance: float = 0.0
+    last_obs_max_log_p: float = 0.0
+
+    def to_list(self) -> list[float]:
+        return [
+            self.belief_entropy, self.belief_log_trace_var,
+            self.belief_top_cell_mass, self.log_step_distance,
+            self.last_obs_max_log_p,
+        ]
+
+
+@dataclass
+class StepContext:
+    """Optional per-step features the training loop can attach to the
+    aggregator before each __call__. None → use neutral defaults.
+
+    All fields are floats; the aggregator turns them into a tensor.
+    """
+
+    # Belief features
+    belief_entropy: float = 0.0
+    belief_log_trace_var: float = 0.0
+    belief_top_cell_mass: float = 0.0
+    belief_step_index_norm: float = 0.0
+    # Trajectory context
+    norm_cum_distance: float = 0.0
+    log_step_distance: float = 0.0
+    step_idx_over_path_len: float = 0.0
+    # Sliding window of past steps. Newest at the end. None → zero-filled.
+    history: list[HistoryEntry] | None = None
+
+
+def history_to_tensor(
+    history: list[HistoryEntry] | None,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Flatten the history window to a fixed-length tensor.
+
+    Pads on the left with zero entries when fewer than ``HISTORY_DEPTH``
+    past steps are available, and truncates from the left if longer.
+    """
+    if history is None:
+        history = []
+    history = history[-HISTORY_DEPTH:]
+    n_pad = HISTORY_DEPTH - len(history)
+    flat: list[float] = [0.0] * (n_pad * NUM_HISTORY_ENTRY_FEATURES)
+    for h in history:
+        flat.extend(h.to_list())
+    return torch.tensor(flat, device=device, dtype=dtype)
+
+
+def step_context_to_tensor(
+    ctx: StepContext | None,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Pack a StepContext (current scalars + history window) into a tensor.
+
+    Produces a zero-filled fallback if ``ctx is None``.
+    """
+    history_dim = HISTORY_DEPTH * NUM_HISTORY_ENTRY_FEATURES
+    if ctx is None:
+        return torch.zeros(
+            NUM_BELIEF_FEATURES + NUM_STEP_FEATURES + history_dim,
+            device=device, dtype=dtype,
+        )
+    current = torch.tensor([
+        ctx.belief_entropy, ctx.belief_log_trace_var,
+        ctx.belief_top_cell_mass, ctx.belief_step_index_norm,
+        ctx.norm_cum_distance, ctx.log_step_distance,
+        ctx.step_idx_over_path_len,
+    ], device=device, dtype=dtype)
+    history = history_to_tensor(ctx.history, device, dtype)
+    return torch.cat([current, history], dim=0)
+
+
+def extract_belief_features(belief) -> tuple[float, float, float]:
+    """(entropy, log_trace_var, top_cell_mass) from a HistogramBelief."""
+    probs = belief.get_belief()
+    flat = probs.reshape(-1)
+    # Numerically-safe entropy on probabilities.
+    entropy = -(flat * torch.log(flat.clamp(min=1e-40))).sum().item()
+    var = belief.get_variance_deg_sq().sum().item()
+    log_trace_var = float(torch.log(torch.tensor(max(var, 1e-30))))
+    top_cell_mass = float(flat.max().item())
+    return entropy, log_trace_var, top_cell_mass
+
+
+# Total feature dimensionality.
+FEATURE_DIM: int = (
+    2 * StreamRowStats.NUM_FEATURES
+    + NUM_BELIEF_FEATURES
+    + NUM_STEP_FEATURES
+    + HISTORY_DEPTH * NUM_HISTORY_ENTRY_FEATURES
+)
+
+
+# ============ Policy ============
+
+
+class FeatureStandardizer(nn.Module):
+    """Per-feature running standardizer.
+
+    Estimates running mean / std on the training set and applies frozen
+    statistics at eval time. Lives inside the policy module so it serializes
+    with the weights and is automatically applied to each inference.
+    """
+
+    def __init__(self, num_features: int):
+        super().__init__()
+        self.register_buffer("mean", torch.zeros(num_features))
+        self.register_buffer("var", torch.ones(num_features))
+        self.register_buffer("count", torch.zeros(()))
+        self.frozen: bool = False
+
+    @torch.no_grad()
+    def update(self, x: torch.Tensor) -> None:
+        if self.frozen:
+            return
+        # Welford's online algorithm, batched.
+        x = x.detach()
+        batch_n = float(x.shape[0]) if x.dim() == 2 else 1.0
+        batch_mean = x.mean(0) if x.dim() == 2 else x
+        batch_var = x.var(0, unbiased=False) if x.dim() == 2 else torch.zeros_like(x)
+        new_count = self.count + batch_n
+        delta = batch_mean - self.mean
+        self.mean += delta * (batch_n / new_count.clamp(min=1.0))
+        # Combine running and batch variance via parallel-algorithm formula.
+        self.var = (
+            self.var * (self.count / new_count.clamp(min=1.0))
+            + batch_var * (batch_n / new_count.clamp(min=1.0))
+            + (delta ** 2) * (self.count * batch_n / (new_count.clamp(min=1.0) ** 2))
+        )
+        self.count = new_count
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        std = (self.var + 1e-6).sqrt()
+        return (x - self.mean) / std
+
+
+class SigmaPolicy(nn.Module):
+    """Tiny MLP that maps state features to (u_img, u_lm, u_α).
+
+    Output post-processing (softplus + sigmoid + SIGMA_MIN floor) is done in
+    :class:`LearnedAggregator` so this module's outputs are unconstrained
+    and the policy can be queried at training time without coupling to the
+    aggregator's interface.
+    """
+
+    def __init__(self, num_features: int = FEATURE_DIM, hidden: int = 64):
+        super().__init__()
+        self.standardizer = FeatureStandardizer(num_features)
+        self.trunk = nn.Sequential(
+            nn.LayerNorm(num_features),
+            nn.Linear(num_features, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+        self.head_sigma = nn.Linear(hidden, 2)  # (u_img, u_lm)
+        self.head_alpha = nn.Linear(hidden, 1)  # (u_alpha)
+
+        # Initialize sigma head so initial outputs are near σ ≈ 0.13 — close
+        # to the per-stream NLL-softmax optima — to avoid pathological starts.
+        with torch.no_grad():
+            self.head_sigma.weight.zero_()
+            self.head_sigma.bias.fill_(_softplus_inv(0.13 - SIGMA_MIN))
+            # Initial α ≈ 0.5: balanced fusion.
+            self.head_alpha.weight.zero_()
+            self.head_alpha.bias.zero_()
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        x = self.standardizer(features)
+        h = self.trunk(x)
+        u_sigma = self.head_sigma(h)        # (..., 2)
+        u_alpha = self.head_alpha(h)        # (..., 1)
+        return torch.cat([u_sigma, u_alpha], dim=-1)  # (..., 3)
+
+
+def _softplus_inv(y: float) -> float:
+    """Inverse of softplus, used to seed the σ-head bias at a target value."""
+    import math
+    if y <= 0:
+        return -10.0
+    return math.log(math.expm1(y))
+
+
+# ============ Aggregator ============
+
+
+class LearnedAggregator(ObservationLogLikelihoodAggregator):
+    """Aggregator that consults a learned policy each step.
+
+    Per-step interface:
+      1. Optional: training loop calls :meth:`set_step_context` with the
+         current belief and trajectory metadata.
+      2. ``__call__(pano_id)`` extracts row stats, queries the policy for
+         (σ_img, σ_lm, α), computes the fused log-softmax, and returns it.
+
+    Production code that doesn't have belief context can simply call
+    ``__call__`` directly; the policy then operates on row stats only with
+    zero-filled belief / step features.
+    """
+
+    def __init__(
+        self,
+        image_similarity_matrix: torch.Tensor,
+        landmark_similarity_matrix: torch.Tensor,
+        panorama_metadata: pd.DataFrame,
+        policy: SigmaPolicy,
+        device: torch.device,
+        sigma_ref: float = SIGMA_REF_FEATURES,
+    ):
+        self.image_similarity_matrix = image_similarity_matrix
+        self.landmark_similarity_matrix = landmark_similarity_matrix
+        self.policy = policy.to(device)
+        self.device = device
+        self.sigma_ref = sigma_ref
+        self._pano_id_index = pd.Index(panorama_metadata["pano_id"])
+        self._step_context: StepContext | None = None
+
+    def set_step_context(self, ctx: StepContext | None) -> None:
+        """Attach optional belief / trajectory features for the next call."""
+        self._step_context = ctx
+
+    def _compute_features(
+        self,
+        img_row: torch.Tensor,
+        lm_row: torch.Tensor,
+    ) -> torch.Tensor:
+        img_stats = compute_row_stats(img_row, sigma_ref=self.sigma_ref).to_tensor()
+        lm_stats = compute_row_stats(lm_row, sigma_ref=self.sigma_ref).to_tensor()
+        ctx_t = step_context_to_tensor(
+            self._step_context, device=img_row.device, dtype=img_row.dtype
+        )
+        return torch.cat([img_stats, lm_stats, ctx_t], dim=0)
+
+    def _policy_outputs(
+        self,
+        features: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return (σ_img, σ_lm, α) with positivity / [0,1] constraints applied."""
+        u = self.policy(features.unsqueeze(0)).squeeze(0)  # (3,)
+        sigma_img = SIGMA_MIN + F.softplus(u[0])
+        sigma_lm = SIGMA_MIN + F.softplus(u[1])
+        alpha = torch.sigmoid(u[2])
+        return sigma_img, sigma_lm, alpha
+
+    def fused_log_likelihood(
+        self,
+        img_row: torch.Tensor,
+        lm_row: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Compute fused log-likelihood and return (log_ll, σ_img, σ_lm, α).
+
+        Exposed as a separate method so the training loop can keep gradients
+        flowing through to the policy without going through the public
+        ``__call__`` (which post-processes via ``_replace_nan_with_zero`` /
+        ``.to(device)``).
+        """
+        features = self._compute_features(img_row, lm_row)
+        sigma_img, sigma_lm, alpha = self._policy_outputs(features)
+
+        log_p_img = torch.log_softmax(img_row / sigma_img, dim=0)
+
+        # Fall-through to image-only when the landmark row is missing or
+        # uninformative. log_softmax of a constant row is uniform and adds
+        # only a constant to fused log-likelihoods (cancelled by the
+        # subsequent normalize), but routing through image-only keeps the
+        # path more numerically stable and unambiguous.
+        lm_finite_mask = torch.isfinite(lm_row)
+        lm_finite = lm_row[lm_finite_mask]
+        if lm_finite.numel() == 0 or torch.allclose(
+            lm_finite.max(), lm_finite.min()
+        ):
+            return log_p_img, sigma_img, sigma_lm, alpha
+
+        log_p_lm = torch.log_softmax(lm_row / sigma_lm, dim=0)
+        fused = alpha * log_p_img + (1.0 - alpha) * log_p_lm
+        # Where landmark is -inf at a single entry, fall back to image-only
+        # at that entry.
+        fused = torch.where(lm_finite_mask, fused, log_p_img)
+        return fused, sigma_img, sigma_lm, alpha
+
+    def __call__(self, pano_id: str) -> torch.Tensor:
+        pano_index = self._pano_id_index.get_loc(pano_id)
+        img_row = self.image_similarity_matrix[pano_index].to(self.device)
+        lm_row = self.landmark_similarity_matrix[pano_index].to(self.device)
+        log_ll, *_ = self.fused_log_likelihood(img_row, lm_row)
+        return _replace_nan_with_zero(log_ll)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: LearnedAggregatorConfig,
+        vigor_dataset: vd.VigorDataset,
+        device: torch.device,
+    ) -> "LearnedAggregator":
+        image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
+        landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
+        policy = SigmaPolicy()
+        state_dict = torch.load(
+            config.policy_weights_path, map_location="cpu", weights_only=False,
+        )
+        policy.load_state_dict(state_dict)
+        policy.standardizer.frozen = True
+        policy.eval()
+        return cls(
+            image_similarity_matrix=image_sim,
+            landmark_similarity_matrix=landmark_sim,
+            panorama_metadata=vigor_dataset._panorama_metadata,
+            policy=policy,
+            device=device,
+        )

--- a/experimental/overhead_matching/swag/filter/learned_aggregator_test.py
+++ b/experimental/overhead_matching/swag/filter/learned_aggregator_test.py
@@ -1,0 +1,169 @@
+import unittest
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import pandas as pd
+
+from experimental.overhead_matching.swag.filter.learned_aggregator import (
+    SigmaPolicy,
+    LearnedAggregator,
+    SIGMA_MIN,
+    StreamRowStats,
+    StepContext,
+    HistoryEntry,
+    HISTORY_DEPTH,
+    NUM_HISTORY_ENTRY_FEATURES,
+    compute_row_stats,
+    extract_belief_features,
+    history_to_tensor,
+    FEATURE_DIM,
+)
+
+
+def _make_metadata(num_panos: int = 3) -> pd.DataFrame:
+    return pd.DataFrame({"pano_id": [f"p{i}" for i in range(num_panos)]})
+
+
+class TestRowStats(unittest.TestCase):
+    def test_features_match_expected_count(self):
+        row = torch.linspace(-0.5, 0.9, 100)
+        stats = compute_row_stats(row).to_tensor()
+        self.assertEqual(stats.numel(), StreamRowStats.NUM_FEATURES)
+        self.assertTrue(torch.isfinite(stats).all())
+
+    def test_constant_row_yields_zero_top1_minus_top2(self):
+        row = torch.zeros(50)
+        stats = compute_row_stats(row)
+        self.assertEqual(stats.top1_minus_top2.item(), 0.0)
+        self.assertEqual(stats.top1_minus_top5.item(), 0.0)
+        # softmax over a constant row is uniform → zero peak sharpness
+        self.assertAlmostEqual(stats.softmax_peak_sharp.item(), 0.0, places=5)
+
+    def test_handles_inf_entries(self):
+        row = torch.tensor([0.1, 0.5, float("-inf"), 0.7, float("nan")])
+        stats = compute_row_stats(row).to_tensor()
+        self.assertTrue(torch.isfinite(stats).all())
+
+
+class TestLearnedAggregator(unittest.TestCase):
+    def _make_aggregator(self, num_panos: int = 3, num_patches: int = 100):
+        torch.manual_seed(42)
+        img_sim = torch.randn(num_panos, num_patches) * 0.3 + 0.2
+        # First pano has constant landmark row (the "no-signal" fall-through case)
+        lm_sim = torch.randn(num_panos, num_patches).abs()
+        lm_sim[0] = 0.0
+        meta = _make_metadata(num_panos)
+        policy = SigmaPolicy()
+        return LearnedAggregator(
+            image_similarity_matrix=img_sim,
+            landmark_similarity_matrix=lm_sim,
+            panorama_metadata=meta,
+            policy=policy,
+            device=torch.device("cpu"),
+        )
+
+    def test_feature_dim_consistent(self):
+        agg = self._make_aggregator()
+        features = agg._compute_features(
+            agg.image_similarity_matrix[1].to(agg.device),
+            agg.landmark_similarity_matrix[1].to(agg.device),
+        )
+        self.assertEqual(features.numel(), FEATURE_DIM)
+
+    def test_call_returns_correct_shape(self):
+        agg = self._make_aggregator(num_panos=3, num_patches=100)
+        out = agg("p1")
+        self.assertEqual(out.shape, (100,))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_constant_landmark_row_falls_back_to_image_only(self):
+        """If the landmark row is constant, output should equal image-only
+        log-softmax — no contribution from the landmark stream regardless of α.
+        """
+        agg = self._make_aggregator()
+        img_row = agg.image_similarity_matrix[0].to(agg.device)
+        lm_row = agg.landmark_similarity_matrix[0].to(agg.device)
+        # Sanity: this row should be the all-zero fall-through case.
+        self.assertEqual(lm_row.max().item(), lm_row.min().item())
+        log_ll, sigma_img, _, _ = agg.fused_log_likelihood(img_row, lm_row)
+        expected = torch.log_softmax(img_row / sigma_img, dim=0)
+        self.assertTrue(torch.allclose(log_ll, expected, atol=1e-6))
+
+    def test_gradient_flows_to_policy(self):
+        """Gradients on a downstream loss must reach the policy parameters."""
+        agg = self._make_aggregator()
+        img_row = agg.image_similarity_matrix[1].to(agg.device)
+        lm_row = agg.landmark_similarity_matrix[1].to(agg.device)
+        log_ll, _, _, _ = agg.fused_log_likelihood(img_row, lm_row)
+        loss = -log_ll[0]   # arbitrary scalar functional
+        loss.backward()
+        any_grad = any(
+            p.grad is not None and p.grad.abs().sum() > 0
+            for p in agg.policy.parameters()
+        )
+        self.assertTrue(any_grad, "no policy parameter received gradient")
+
+    def test_sigma_outputs_respect_min(self):
+        agg = self._make_aggregator()
+        img_row = agg.image_similarity_matrix[1].to(agg.device)
+        lm_row = agg.landmark_similarity_matrix[1].to(agg.device)
+        _, sigma_img, sigma_lm, alpha = agg.fused_log_likelihood(img_row, lm_row)
+        self.assertGreaterEqual(sigma_img.item(), SIGMA_MIN)
+        self.assertGreaterEqual(sigma_lm.item(), SIGMA_MIN)
+        self.assertGreaterEqual(alpha.item(), 0.0)
+        self.assertLessEqual(alpha.item(), 1.0)
+
+    def test_step_context_changes_features(self):
+        agg = self._make_aggregator()
+        img_row = agg.image_similarity_matrix[1].to(agg.device)
+        lm_row = agg.landmark_similarity_matrix[1].to(agg.device)
+        feats_default = agg._compute_features(img_row, lm_row)
+        agg.set_step_context(StepContext(belief_entropy=2.0, norm_cum_distance=0.5))
+        feats_with_ctx = agg._compute_features(img_row, lm_row)
+        # Same row stats (first 2*NUM_ROW_FEATURES dims) but trailing context
+        # features should change.
+        n_row = 2 * StreamRowStats.NUM_FEATURES
+        self.assertTrue(torch.equal(feats_default[:n_row], feats_with_ctx[:n_row]))
+        self.assertFalse(torch.equal(feats_default[n_row:], feats_with_ctx[n_row:]))
+
+
+class TestHistory(unittest.TestCase):
+    def test_history_tensor_zero_padded_when_empty(self):
+        out = history_to_tensor(None, torch.device("cpu"), torch.float32)
+        self.assertEqual(out.numel(), HISTORY_DEPTH * NUM_HISTORY_ENTRY_FEATURES)
+        self.assertEqual(out.abs().sum().item(), 0.0)
+
+    def test_history_tensor_left_pads_partial_history(self):
+        h = [HistoryEntry(belief_entropy=1.0, last_obs_max_log_p=0.5)]
+        out = history_to_tensor(h, torch.device("cpu"), torch.float32)
+        self.assertEqual(out.numel(), HISTORY_DEPTH * NUM_HISTORY_ENTRY_FEATURES)
+        # Newest entry sits at the *end* of the flattened tensor.
+        last_entry_start = (HISTORY_DEPTH - 1) * NUM_HISTORY_ENTRY_FEATURES
+        self.assertAlmostEqual(out[last_entry_start].item(), 1.0, places=5)
+        self.assertAlmostEqual(
+            out[last_entry_start + NUM_HISTORY_ENTRY_FEATURES - 1].item(), 0.5, places=5
+        )
+        # Everything before the last entry is zero (left-padding).
+        self.assertEqual(out[:last_entry_start].abs().sum().item(), 0.0)
+
+    def test_history_tensor_truncates_long_history(self):
+        h = [HistoryEntry(belief_entropy=float(i)) for i in range(HISTORY_DEPTH + 5)]
+        out = history_to_tensor(h, torch.device("cpu"), torch.float32)
+        # Only the last HISTORY_DEPTH entries kept; entropy of newest = HISTORY_DEPTH+4.
+        last_entry_start = (HISTORY_DEPTH - 1) * NUM_HISTORY_ENTRY_FEATURES
+        self.assertAlmostEqual(
+            out[last_entry_start].item(), float(HISTORY_DEPTH + 4), places=4
+        )
+        # Oldest kept entry corresponds to index `5` (truncation drops 0..4).
+        self.assertAlmostEqual(out[0].item(), 5.0, places=4)
+
+    def test_feature_dim_includes_history(self):
+        # Net input dim must equal current scalars + history window.
+        n_row = 2 * StreamRowStats.NUM_FEATURES
+        n_ctx = 4 + 3  # NUM_BELIEF_FEATURES + NUM_STEP_FEATURES
+        expected = n_row + n_ctx + HISTORY_DEPTH * NUM_HISTORY_ENTRY_FEATURES
+        self.assertEqual(FEATURE_DIM, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -1015,3 +1015,14 @@ py_binary(
   ]
 )
 
+py_binary(
+  name="compare_simple_v1_v3_vs_v6",
+  srcs=["compare_simple_v1_v3_vs_v6.py"],
+  deps=[
+    requirement("torch"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/evaluation:retrieval_metrics",
+  ]
+)
+

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -997,6 +997,109 @@ py_binary(
 )
 
 py_binary(
+  name="calibrate_sigma",
+  srcs=["calibrate_sigma.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    requirement("scipy"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+  ]
+)
+
+py_binary(
+  name="calibrate_fusion_sigma",
+  srcs=["calibrate_fusion_sigma.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+  ]
+)
+
+py_binary(
+  name="grid_search_convergence",
+  srcs=["grid_search_convergence.py"],
+  deps=[
+    ":evaluate_histogram_on_paths",
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    requirement("tqdm"),
+    "//common/torch:load_torch_deps",
+    "//common/gps:web_mercator",
+    "//common/math:haversine",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/evaluation:evaluate_swag",
+    "//experimental/overhead_matching/swag/evaluation:convergence_metrics",
+    "//experimental/overhead_matching/swag/evaluation:odometry_noise",
+    "//experimental/overhead_matching/swag/filter:histogram_belief",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+  ]
+)
+
+py_binary(
+  name="train_learned_aggregator",
+  srcs=["train_learned_aggregator.py"],
+  deps=[
+    ":evaluate_histogram_on_paths",
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("tqdm"),
+    "//common/torch:load_torch_deps",
+    "//common/gps:web_mercator",
+    "//common/math:haversine",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/evaluation:evaluate_swag",
+    "//experimental/overhead_matching/swag/evaluation:convergence_metrics",
+    "//experimental/overhead_matching/swag/evaluation:odometry_noise",
+    "//experimental/overhead_matching/swag/filter:histogram_belief",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+    "//experimental/overhead_matching/swag/filter:learned_aggregator",
+  ]
+)
+
+py_binary(
+  name="landmark_residual_exploration",
+  srcs=["landmark_residual_exploration.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+  ]
+)
+
+py_binary(
+  name="evaluate_learned_aggregator",
+  srcs=["evaluate_learned_aggregator.py"],
+  deps=[
+    ":evaluate_histogram_on_paths",
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("tqdm"),
+    "//common/torch:load_torch_deps",
+    "//common/gps:web_mercator",
+    "//common/math:haversine",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/evaluation:evaluate_swag",
+    "//experimental/overhead_matching/swag/evaluation:convergence_metrics",
+    "//experimental/overhead_matching/swag/evaluation:odometry_noise",
+    "//experimental/overhead_matching/swag/filter:histogram_belief",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+    "//experimental/overhead_matching/swag/filter:learned_aggregator",
+  ]
+)
+
+py_binary(
   name="export_correspondence_similarity",
   srcs=["export_correspondence_similarity.py"],
   deps=[

--- a/experimental/overhead_matching/swag/scripts/calibrate_fusion_sigma.py
+++ b/experimental/overhead_matching/swag/scripts/calibrate_fusion_sigma.py
@@ -1,0 +1,426 @@
+"""Joint per-pair NLL calibration of (σ_img, σ_lm) under EA fused softmax.
+
+Sweeps a 2D grid of σ values for the image and landmark streams, computes the
+mean per-pair NLL of true patches under the entropy-adaptive fused posterior
+(matching :class:`EntropyAdaptiveAggregator`), and emits a heatmap + summary.
+
+This complements ``calibrate_sigma.py``: that script calibrates each stream
+independently; this one tells you whether independent calibration sits at the
+joint NLL minimum or whether the streams should be co-tuned.
+
+Outputs:
+- ``fusion_nll_heatmap.png`` - joint NLL surface with marked optimum and
+  marginal per-stream optima for comparison
+- ``fusion_calibration.json`` - σ grids, full NLL surface, summary statistics
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+
+
+def _peak_sharpness(log_p: torch.Tensor) -> torch.Tensor:
+    """``log_p.max(-1) - log_p.mean(-1)`` over the last axis, ignoring -inf.
+
+    Matches ``EntropyAdaptiveAggregator._compute_confidence``.
+    """
+    finite = torch.isfinite(log_p)
+    safe_for_sum = torch.where(finite, log_p, torch.zeros_like(log_p))
+    count = finite.sum(dim=-1).clamp(min=1).to(log_p.dtype)
+    mean = safe_for_sum.sum(dim=-1) / count
+    safe_for_max = torch.where(
+        finite, log_p, torch.full_like(log_p, float("-inf"))
+    )
+    maxv = safe_for_max.max(dim=-1).values
+    return maxv - mean
+
+
+def _raw_peak_sharpness_1d(sim: torch.Tensor) -> torch.Tensor:
+    """``max(sim) - mean(sim)`` over a 1-D tensor, clamped at 0, ignoring -inf."""
+    finite = sim[torch.isfinite(sim)]
+    if finite.numel() < 2:
+        return torch.tensor(0.0, dtype=sim.dtype, device=sim.device)
+    return (finite.max() - finite.mean()).clamp(min=0.0)
+
+
+def _raw_max_1d(sim: torch.Tensor) -> torch.Tensor:
+    """``max(sim, 0)`` over the finite entries; 0 when no finite entries."""
+    finite = sim[torch.isfinite(sim)]
+    if finite.numel() == 0:
+        return torch.tensor(0.0, dtype=sim.dtype, device=sim.device)
+    return finite.max().clamp(min=0.0)
+
+
+def fused_nll_grid(
+    img_sim_mat: torch.Tensor,
+    lm_sim_mat: torch.Tensor,
+    panorama_metadata,
+    sigmas_img: torch.Tensor,
+    sigmas_lm: torch.Tensor,
+    include_semipositive: bool,
+    device: torch.device,
+    exclude_constant_rows: bool = True,
+    landmark_pano_confidence_threshold: float | None = None,
+    landmark_pair_sim_threshold: float | None = None,
+    alpha_mode: str = "peak_sharpness",
+):
+    """Compute per-pair NLL on a 2D (σ_img, σ_lm) grid under the EA fusion.
+
+    For each pano, build ``log_softmax(sim_img / σ_img)`` and
+    ``log_softmax(sim_lm / σ_lm)`` for every grid σ, blend them with the EA
+    confidence-weighted ``α``, score the true patches, accumulate.
+
+    Optional landmark-confidence filters (mutually exclusive in spirit but can
+    be combined):
+      * ``landmark_pano_confidence_threshold``: drop panos whose landmark
+        ``row_max`` is at or below this value (per-pano filter — Option 1).
+      * ``landmark_pair_sim_threshold``: drop (pano, true_patch) pairs whose
+        landmark sim_t is at or below this value (per-pair filter — Option 3).
+
+    Returns the NLL surface (K_img × K_lm), the per-stream marginal NLLs, and
+    counts.
+    """
+    K_img = len(sigmas_img)
+    K_lm = len(sigmas_lm)
+    nll_fused = torch.zeros(K_img, K_lm, dtype=torch.float64)
+    nll_img_only = torch.zeros(K_img, dtype=torch.float64)
+    nll_lm_only = torch.zeros(K_lm, dtype=torch.float64)
+    pair_count = 0
+    pano_count = 0
+    n_excluded_constant = 0
+    n_excluded_no_truepatch = 0
+    n_excluded_pano_confidence = 0
+    n_excluded_pair_sim = 0
+
+    sigmas_img_dev = sigmas_img.to(device)
+    sigmas_lm_dev = sigmas_lm.to(device)
+    img_mat = img_sim_mat.to(device)
+    lm_mat = lm_sim_mat.to(device)
+    eps = 1e-12
+
+    for pano_idx in range(img_mat.shape[0]):
+        img_row = img_mat[pano_idx]
+        lm_row = lm_mat[pano_idx]
+        img_finite = torch.isfinite(img_row)
+        lm_finite = torch.isfinite(lm_row)
+        if not img_finite.any() or not lm_finite.any():
+            n_excluded_constant += 1
+            continue
+        if exclude_constant_rows:
+            i_finite = img_row[img_finite]
+            l_finite = lm_row[lm_finite]
+            if (i_finite.max() == i_finite.min()) or (
+                l_finite.max() == l_finite.min()
+            ):
+                n_excluded_constant += 1
+                continue
+        if landmark_pano_confidence_threshold is not None:
+            if lm_row[lm_finite].max().item() <= landmark_pano_confidence_threshold:
+                n_excluded_pano_confidence += 1
+                continue
+
+        row = panorama_metadata.iloc[pano_idx]
+        true_idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            true_idxs.extend(row["semipositive_satellite_idxs"])
+        if not true_idxs:
+            n_excluded_no_truepatch += 1
+            continue
+        true_idxs_t = torch.tensor(true_idxs, dtype=torch.long, device=device)
+        true_finite_mask = (
+            torch.isfinite(img_row[true_idxs_t])
+            & torch.isfinite(lm_row[true_idxs_t])
+        )
+        true_idxs_t = true_idxs_t[true_finite_mask]
+        if len(true_idxs_t) == 0:
+            n_excluded_no_truepatch += 1
+            continue
+        if landmark_pair_sim_threshold is not None:
+            keep_mask = lm_row[true_idxs_t] > landmark_pair_sim_threshold
+            true_idxs_t = true_idxs_t[keep_mask]
+            if len(true_idxs_t) == 0:
+                n_excluded_pair_sim += 1
+                continue
+
+        # log-softmax over each grid σ.
+        img_logits = img_row.unsqueeze(0) / sigmas_img_dev.unsqueeze(1)  # (Ki, M)
+        lm_logits = lm_row.unsqueeze(0) / sigmas_lm_dev.unsqueeze(1)  # (Kl, M)
+        log_p_img = torch.log_softmax(img_logits, dim=-1)  # (Ki, M)
+        log_p_lm = torch.log_softmax(lm_logits, dim=-1)  # (Kl, M)
+
+        if alpha_mode == "peak_sharpness":
+            img_conf = _peak_sharpness(log_p_img)  # (Ki,)
+            lm_conf = _peak_sharpness(log_p_lm)  # (Kl,)
+            alpha = img_conf.unsqueeze(1) / (
+                img_conf.unsqueeze(1) + lm_conf.unsqueeze(0) + eps
+            )  # (Ki, Kl)
+        elif alpha_mode == "raw_peak_sharpness":
+            img_raw_conf = _raw_peak_sharpness_1d(img_row)  # scalar
+            lm_raw_conf = _raw_peak_sharpness_1d(lm_row)  # scalar
+            alpha_s = (img_raw_conf / (img_raw_conf + lm_raw_conf + eps)).item()
+            alpha = torch.full((K_img, K_lm), alpha_s, device=device)
+        elif alpha_mode == "raw_max":
+            img_raw_conf = _raw_max_1d(img_row)  # scalar
+            lm_raw_conf = _raw_max_1d(lm_row)  # scalar
+            alpha_s = (img_raw_conf / (img_raw_conf + lm_raw_conf + eps)).item()
+            alpha = torch.full((K_img, K_lm), alpha_s, device=device)
+        else:
+            raise ValueError(f"Unknown alpha_mode {alpha_mode!r}")
+
+        log_p_img_t = log_p_img[:, true_idxs_t]  # (Ki, T)
+        log_p_lm_t = log_p_lm[:, true_idxs_t]  # (Kl, T)
+        # Fused log-prob at true patches: (Ki, Kl, T)
+        fused_t = (
+            alpha.unsqueeze(-1) * log_p_img_t.unsqueeze(1)
+            + (1 - alpha).unsqueeze(-1) * log_p_lm_t.unsqueeze(0)
+        )
+
+        nll_fused += (-fused_t.sum(dim=-1).detach().cpu().double())
+        nll_img_only += (-log_p_img_t.sum(dim=-1).detach().cpu().double())
+        nll_lm_only += (-log_p_lm_t.sum(dim=-1).detach().cpu().double())
+        pair_count += int(len(true_idxs_t))
+        pano_count += 1
+
+    if pair_count == 0:
+        raise RuntimeError("No panos contributed pairs.")
+    return {
+        "nll_fused": nll_fused / pair_count,
+        "nll_img_only": nll_img_only / pair_count,
+        "nll_lm_only": nll_lm_only / pair_count,
+        "pair_count": pair_count,
+        "pano_count": pano_count,
+        "num_excluded_constant": n_excluded_constant,
+        "num_excluded_no_truepatch": n_excluded_no_truepatch,
+        "num_excluded_pano_confidence": n_excluded_pano_confidence,
+        "num_excluded_pair_sim": n_excluded_pair_sim,
+    }
+
+
+def plot_heatmap(
+    sigmas_img: torch.Tensor,
+    sigmas_lm: torch.Tensor,
+    nll_fused: torch.Tensor,
+    sigma_img_star: float,
+    sigma_lm_star: float,
+    sigma_img_marginal_star: float,
+    sigma_lm_marginal_star: float,
+    output_path: Path,
+    pair_count: int,
+    title_suffix: str = "",
+) -> None:
+    fig, ax = plt.subplots(figsize=(9, 7))
+    si = sigmas_img.numpy()
+    sl = sigmas_lm.numpy()
+
+    # pcolormesh on log-scaled axes shows actual σ values on the ticks
+    pcm = ax.pcolormesh(si, sl, nll_fused.numpy().T, shading="auto", cmap="viridis")
+    cb = plt.colorbar(pcm, ax=ax)
+    cb.set_label("mean per-pair NLL")
+
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlabel("σ_img")
+    ax.set_ylabel("σ_lm")
+
+    # Joint optimum
+    ax.scatter([sigma_img_star], [sigma_lm_star], marker="*", color="white",
+               edgecolor="red", s=260, lw=1.5, zorder=5,
+               label=f"joint min ({sigma_img_star:.4f}, {sigma_lm_star:.4f})")
+
+    # Marginal-NLL optima from this same grid (each stream's softmax NLL min)
+    ax.scatter([sigma_img_marginal_star], [sigma_lm_marginal_star],
+               marker="o", facecolor="none", edgecolor="white", s=180, lw=2,
+               zorder=5,
+               label=f"marginal min ({sigma_img_marginal_star:.4f}, "
+                     f"{sigma_lm_marginal_star:.4f})")
+
+    ax.set_title(f"EA fusion NLL surface (n={pair_count} pairs, Seattle)"
+                 f"{title_suffix}")
+    ax.legend(loc="upper right", fontsize=9)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=130)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--img-sim-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle/"
+                "similarity_matrices/safa_dinov3_wag_chicago.pt")
+    parser.add_argument(
+        "--lm-sim-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle/"
+                "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt")
+    parser.add_argument(
+        "--dataset-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle")
+    parser.add_argument("--landmark-version", type=str, default="v4_202001")
+    parser.add_argument("--output-path", type=str, required=True)
+    # Defaults bracket the per-stream NLL_softmax optima we already found
+    # (image ≈ 0.049, landmark ≈ 0.130).
+    parser.add_argument("--sigma-img-min", type=float, default=0.01)
+    parser.add_argument("--sigma-img-max", type=float, default=0.4)
+    parser.add_argument("--sigma-lm-min", type=float, default=0.02)
+    parser.add_argument("--sigma-lm-max", type=float, default=0.8)
+    parser.add_argument("--sigma-num", type=int, default=25)
+    parser.add_argument(
+        "--include-semipositive", type=lambda s: s.lower() != "false",
+        default=True)
+    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument(
+        "--landmark-pano-confidence-threshold", type=float, default=None,
+        help="Option 1: drop panos whose landmark row_max ≤ this value. "
+             "Calibrates fusion only on panos where landmarks made a confident bid.")
+    parser.add_argument(
+        "--landmark-pair-sim-threshold", type=float, default=None,
+        help="Option 3: drop (pano,true_patch) pairs whose landmark sim_t ≤ this. "
+             "Calibrates only on pairs the landmark already scored highly.")
+    parser.add_argument(
+        "--output-suffix", type=str, default="",
+        help="Suffix appended to output filenames (e.g. 'pano_filter_1.0').")
+    parser.add_argument(
+        "--alpha-mode", type=str, default="peak_sharpness",
+        choices=["peak_sharpness", "raw_peak_sharpness", "raw_max"],
+        help="α formula for EA fusion. 'peak_sharpness' is the deployed EA "
+             "default (σ-dependent). 'raw_peak_sharpness' uses max-mean of raw "
+             "similarities. 'raw_max' uses raw row max. Last two are σ-independent.")
+    args = parser.parse_args()
+
+    output_path = Path(args.output_path).expanduser()
+    output_path.mkdir(parents=True, exist_ok=True)
+    with open(output_path / "fusion_args.json", "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    device = torch.device(args.device)
+
+    print(f"Loading image similarity matrix from {args.img_sim_path}")
+    img_sim = _load_similarity_matrix(Path(args.img_sim_path)).double()
+    print(f"  shape: {tuple(img_sim.shape)}")
+    print(f"Loading landmark similarity matrix from {args.lm_sim_path}")
+    lm_sim = _load_similarity_matrix(Path(args.lm_sim_path)).double()
+    print(f"  shape: {tuple(lm_sim.shape)}")
+    assert img_sim.shape == lm_sim.shape, (
+        f"shape mismatch: img {tuple(img_sim.shape)} vs lm {tuple(lm_sim.shape)}")
+
+    print(f"Loading dataset metadata from {args.dataset_path}")
+    cfg = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None,
+        panorama_tensor_cache_info=None,
+        should_load_images=False,
+        should_load_landmarks=False,
+        landmark_version=args.landmark_version,
+    )
+    ds = vd.VigorDataset(Path(args.dataset_path), cfg)
+    pano_metadata = ds._panorama_metadata
+    assert img_sim.shape[0] == len(pano_metadata)
+
+    sigmas_img = torch.tensor(
+        np.logspace(np.log10(args.sigma_img_min), np.log10(args.sigma_img_max),
+                    args.sigma_num),
+        dtype=torch.float64,
+    )
+    sigmas_lm = torch.tensor(
+        np.logspace(np.log10(args.sigma_lm_min), np.log10(args.sigma_lm_max),
+                    args.sigma_num),
+        dtype=torch.float64,
+    )
+
+    print(f"Sweeping {args.sigma_num}x{args.sigma_num} grid "
+          f"(σ_img ∈ [{args.sigma_img_min}, {args.sigma_img_max}], "
+          f"σ_lm ∈ [{args.sigma_lm_min}, {args.sigma_lm_max}]) ...")
+    res = fused_nll_grid(
+        img_sim, lm_sim, pano_metadata, sigmas_img, sigmas_lm,
+        include_semipositive=args.include_semipositive,
+        device=device, exclude_constant_rows=True,
+        landmark_pano_confidence_threshold=args.landmark_pano_confidence_threshold,
+        landmark_pair_sim_threshold=args.landmark_pair_sim_threshold,
+        alpha_mode=args.alpha_mode,
+    )
+    nll_fused = res["nll_fused"]
+    nll_img_only = res["nll_img_only"]
+    nll_lm_only = res["nll_lm_only"]
+    pair_count = res["pair_count"]
+    pano_count = res["pano_count"]
+    print(f"  contributing panos: {pano_count}")
+    print(f"  contributing (pano, true_patch) pairs: {pair_count}")
+    print(f"  excluded constant-row panos:           {res['num_excluded_constant']}")
+    print(f"  excluded no-truepatch panos:           {res['num_excluded_no_truepatch']}")
+    print(f"  excluded by pano-confidence filter:    {res['num_excluded_pano_confidence']}")
+    print(f"  excluded by pair-sim filter:           {res['num_excluded_pair_sim']}")
+
+    flat = int(torch.argmin(nll_fused))
+    bi, bl = flat // args.sigma_num, flat % args.sigma_num
+    sigma_img_star = float(sigmas_img[bi])
+    sigma_lm_star = float(sigmas_lm[bl])
+    nll_fused_min = float(nll_fused[bi, bl])
+
+    bi_marg = int(torch.argmin(nll_img_only))
+    bl_marg = int(torch.argmin(nll_lm_only))
+    sigma_img_marg = float(sigmas_img[bi_marg])
+    sigma_lm_marg = float(sigmas_lm[bl_marg])
+
+    print(f"  joint NLL min:    σ_img={sigma_img_star:.4f}  "
+          f"σ_lm={sigma_lm_star:.4f}  NLL={nll_fused_min:.4f}")
+    print(f"  marginal img NLL: σ_img={sigma_img_marg:.4f}  "
+          f"NLL={float(nll_img_only[bi_marg]):.4f}")
+    print(f"  marginal lm NLL:  σ_lm={sigma_lm_marg:.4f}  "
+          f"NLL={float(nll_lm_only[bl_marg]):.4f}")
+    nll_at_marg = float(nll_fused[bi_marg, bl_marg])
+    print(f"  fused NLL at marginal optima: {nll_at_marg:.4f}  "
+          f"(Δ from joint = {nll_at_marg - nll_fused_min:.4f})")
+
+    suffix = ("_" + args.output_suffix) if args.output_suffix else ""
+    title_pieces = [f"\nα = {args.alpha_mode}"]
+    if args.landmark_pano_confidence_threshold is not None:
+        title_pieces.append(
+            f"  | pano filter: lm row_max > {args.landmark_pano_confidence_threshold}")
+    if args.landmark_pair_sim_threshold is not None:
+        title_pieces.append(
+            f"  | pair filter: lm sim_t > {args.landmark_pair_sim_threshold}")
+    title_suffix = "".join(title_pieces)
+    plot_heatmap(
+        sigmas_img, sigmas_lm, nll_fused,
+        sigma_img_star, sigma_lm_star,
+        sigma_img_marg, sigma_lm_marg,
+        output_path / f"fusion_nll_heatmap{suffix}.png",
+        pair_count,
+        title_suffix=title_suffix,
+    )
+
+    summary = {
+        "img_sim_path": str(args.img_sim_path),
+        "lm_sim_path": str(args.lm_sim_path),
+        "num_pairs": int(pair_count),
+        "num_excluded_constant": int(res["num_excluded_constant"]),
+        "num_excluded_no_truepatch": int(res["num_excluded_no_truepatch"]),
+        "sigma_img_grid": sigmas_img.tolist(),
+        "sigma_lm_grid": sigmas_lm.tolist(),
+        "fused_nll_grid": nll_fused.tolist(),
+        "img_only_nll_grid": nll_img_only.tolist(),
+        "lm_only_nll_grid": nll_lm_only.tolist(),
+        "sigma_img_joint_star": sigma_img_star,
+        "sigma_lm_joint_star": sigma_lm_star,
+        "min_fused_nll": nll_fused_min,
+        "sigma_img_marginal_star": sigma_img_marg,
+        "sigma_lm_marginal_star": sigma_lm_marg,
+        "fused_nll_at_marginal_star": nll_at_marg,
+    }
+    with open(output_path / f"fusion_calibration{suffix}.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"\nDone. Outputs in {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/calibrate_sigma.py
+++ b/experimental/overhead_matching/swag/scripts/calibrate_sigma.py
@@ -1,0 +1,673 @@
+"""Calibrate the observation-likelihood sigma from a precomputed similarity matrix.
+
+Sigma is used by ``wag_observation_log_likelihood_from_similarity_matrix`` (the
+single-matrix aggregator) as the std of a Gaussian on score residuals
+``r = sim_max - sim``.  The entropy-adaptive aggregator instead uses sigma as
+softmax temperature (``log_softmax(sim / sigma)``).  This script computes
+several principled calibrations on a validation similarity matrix and emits
+diagnostic plots so a single value can be chosen with the tradeoff visible.
+
+Aggregation is per-pair: each (pano, true_patch) is its own positive sample.
+
+Outputs (under --output-path, prefixed with --name-prefix if given):
+- ``sigma_calibration.json`` - computed sigma values + summary stats
+- ``residual_histogram.png`` - residual distribution, true vs negative
+  (linear + log panels)
+- ``similarity_distribution.png`` - raw similarity, true vs negative
+  (linear + log panels)
+- ``nll_vs_sigma.png`` - per-pair NLL of true patches as a function of sigma
+- ``residuals.pt`` - residuals tensor for downstream analysis
+"""
+
+from pathlib import Path
+import argparse
+import json
+
+import common.torch.load_torch_deps  # noqa: F401  (must precede torch import)
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.optimize import minimize_scalar
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+
+
+def compute_samples(
+    similarity_matrix: torch.Tensor,
+    panorama_metadata,
+    include_semipositive: bool = True,
+    num_negative_samples_per_pano: int = 0,
+    rng_seed: int = 0,
+    exclude_constant_rows: bool = True,
+):
+    """Collect per-pair residuals and raw similarities for true and negative pairs.
+
+    Rows where every finite similarity is identical (e.g. the all-zero rows in
+    the landmark Hungarian matrix) are uninformative — they would assign every
+    patch the same likelihood, contributing only a constant offset to the NLL
+    while polluting the residual/similarity histograms with degenerate spikes.
+    They are excluded by default.
+
+    Returns a dict with keys:
+        residuals_pair, residuals_negative, sims_pair, sims_negative,
+        valid_pano_idx, num_excluded_constant_rows, num_excluded_no_truepatch.
+    """
+    residuals_pair = []
+    residuals_negative = []
+    sims_pair = []
+    sims_negative = []
+    valid_indices = []
+    n_constant = 0
+    n_no_truepatch = 0
+
+    rng = np.random.default_rng(rng_seed)
+    num_patches = similarity_matrix.shape[1]
+
+    for pano_idx in range(similarity_matrix.shape[0]):
+        sim_row = similarity_matrix[pano_idx]
+        finite_mask = torch.isfinite(sim_row)
+        if not finite_mask.any():
+            n_constant += 1
+            continue
+        finite_sims = sim_row[finite_mask]
+        sim_max = finite_sims.max().item()
+        sim_min = finite_sims.min().item()
+        if exclude_constant_rows and sim_max == sim_min:
+            n_constant += 1
+            continue
+
+        row = panorama_metadata.iloc[pano_idx]
+        true_idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            true_idxs.extend(row["semipositive_satellite_idxs"])
+        if not true_idxs:
+            n_no_truepatch += 1
+            continue
+
+        true_sims = sim_row[true_idxs]
+        true_finite = true_sims[torch.isfinite(true_sims)]
+        if len(true_finite) == 0:
+            n_no_truepatch += 1
+            continue
+
+        for ts in true_finite.tolist():
+            sims_pair.append(ts)
+            residuals_pair.append(sim_max - ts)
+        valid_indices.append(pano_idx)
+
+        if num_negative_samples_per_pano > 0:
+            true_set = set(true_idxs)
+            k = num_negative_samples_per_pano
+            candidates = rng.integers(0, num_patches, size=k * 2)
+            candidates = [int(c) for c in candidates if int(c) not in true_set]
+            candidates = candidates[:k]
+            cand_t = torch.tensor(candidates, dtype=torch.long)
+            neg_sims = sim_row[cand_t]
+            neg_finite = neg_sims[torch.isfinite(neg_sims)]
+            for ns in neg_finite.tolist():
+                sims_negative.append(ns)
+                residuals_negative.append(sim_max - ns)
+
+    def _t(xs):
+        return torch.tensor(xs, dtype=torch.float64)
+
+    return {
+        "residuals_pair": _t(residuals_pair),
+        "residuals_negative": _t(residuals_negative),
+        "sims_pair": _t(sims_pair),
+        "sims_negative": _t(sims_negative),
+        "valid_pano_idx": torch.tensor(valid_indices, dtype=torch.long),
+        "num_excluded_constant_rows": n_constant,
+        "num_excluded_no_truepatch": n_no_truepatch,
+    }
+
+
+def build_per_pano_cache(
+    similarity_matrix: torch.Tensor,
+    panorama_metadata,
+    valid_pano_idx: torch.Tensor,
+    include_semipositive: bool,
+    device: torch.device,
+) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    """Pre-extract (sims_finite, true_local_idx) per pano for fast scalar-σ NLL.
+
+    Iterating panos and rebuilding these tensors per σ-evaluation dominates the
+    cost of a Brent-method scalar minimizer.  Cache them once.
+    """
+    sim_mat = similarity_matrix.to(device)
+    cache: list[tuple[torch.Tensor, torch.Tensor]] = []
+    for pano_idx in valid_pano_idx.tolist():
+        sim_row = sim_mat[pano_idx]
+        finite_mask = torch.isfinite(sim_row)
+        sims = sim_row[finite_mask]
+
+        finite_idx = torch.nonzero(finite_mask, as_tuple=False).squeeze(1)
+        finite_to_local = -torch.ones(
+            sim_row.shape[0], dtype=torch.long, device=device
+        )
+        finite_to_local[finite_idx] = torch.arange(len(finite_idx), device=device)
+
+        row = panorama_metadata.iloc[pano_idx]
+        true_idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            true_idxs.extend(row["semipositive_satellite_idxs"])
+        true_idxs_t = torch.tensor(true_idxs, dtype=torch.long, device=device)
+        local_true = finite_to_local[true_idxs_t]
+        local_true = local_true[local_true >= 0]
+        if len(local_true) == 0:
+            continue
+        cache.append((sims, local_true))
+    return cache
+
+
+def scalar_nll_softmax(sigma: float, cache, dtype=torch.float64) -> float:
+    """Per-pair NLL of true patches under softmax(sim / σ) at a single σ."""
+    total = 0.0
+    pair_count = 0
+    inv_sigma = 1.0 / sigma
+    for sims, local_true in cache:
+        logits = sims.to(dtype) * inv_sigma
+        log_norm = torch.logsumexp(logits, dim=0)
+        log_p_true = logits[local_true] - log_norm
+        total += float(-log_p_true.sum().item())
+        pair_count += int(local_true.numel())
+    return total / max(pair_count, 1)
+
+
+def scalar_nll_gaussian_residual(sigma: float, cache, dtype=torch.float64) -> float:
+    """Per-pair NLL under the Gaussian-on-residuals model at a single σ."""
+    total = 0.0
+    pair_count = 0
+    inv_sigma2 = 1.0 / (sigma * sigma)
+    for sims, local_true in cache:
+        sims = sims.to(dtype)
+        sim_max = sims.max()
+        residuals = sim_max - sims
+        log_unnorm = -0.5 * residuals * residuals * inv_sigma2
+        log_norm = torch.logsumexp(log_unnorm, dim=0)
+        log_p_true = log_unnorm[local_true] - log_norm
+        total += float(-log_p_true.sum().item())
+        pair_count += int(local_true.numel())
+    return total / max(pair_count, 1)
+
+
+def nll_gaussian_residual_form_pair(
+    similarity_matrix: torch.Tensor,
+    panorama_metadata,
+    valid_pano_idx: torch.Tensor,
+    sigmas: torch.Tensor,
+    include_semipositive: bool,
+    device: torch.device,
+) -> torch.Tensor:
+    """Per-pair NLL under the Gaussian-on-residuals model.
+
+    Each patch's unnormalized log-likelihood is
+    ``-0.5 * ((sim_max - sim) / sigma)^2`` (constants cancel under categorical
+    normalization).  Returns mean per-(pano,true_patch) NLL of the true patch.
+    """
+    nll = torch.zeros_like(sigmas)
+    pair_count = 0
+    sim_mat = similarity_matrix.to(device)
+    sigmas_dev = sigmas.to(device)
+    inv_sigma2 = 1.0 / (sigmas_dev ** 2)
+
+    for pano_idx in valid_pano_idx.tolist():
+        sim_row = sim_mat[pano_idx]
+        finite_mask = torch.isfinite(sim_row)
+        sims = sim_row[finite_mask]
+        sim_max = sims.max()
+
+        row = panorama_metadata.iloc[pano_idx]
+        true_idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            true_idxs.extend(row["semipositive_satellite_idxs"])
+        true_idxs_t = torch.tensor(true_idxs, dtype=torch.long, device=device)
+        true_sims = sim_row[true_idxs_t]
+        true_finite = true_sims[torch.isfinite(true_sims)]
+        if len(true_finite) == 0:
+            continue
+        true_residuals = sim_max - true_finite  # (T,)
+
+        residuals = sim_max - sims  # (M,)
+        sq = residuals ** 2
+        log_unnorm = -0.5 * inv_sigma2.unsqueeze(1) * sq.unsqueeze(0)  # (K, M)
+        log_norm = torch.logsumexp(log_unnorm, dim=1)  # (K,)
+        log_unnorm_true = (
+            -0.5 * inv_sigma2.unsqueeze(1) * (true_residuals ** 2).unsqueeze(0)
+        )  # (K, T)
+        log_p_true = log_unnorm_true - log_norm.unsqueeze(1)  # (K, T)
+        nll = nll + (-log_p_true.sum(dim=1).detach().cpu())
+        pair_count += int(len(true_finite))
+
+    return nll / max(pair_count, 1)
+
+
+def nll_softmax_form_pair(
+    similarity_matrix: torch.Tensor,
+    panorama_metadata,
+    valid_pano_idx: torch.Tensor,
+    sigmas: torch.Tensor,
+    include_semipositive: bool,
+    device: torch.device,
+) -> torch.Tensor:
+    """Per-pair NLL under the EA softmax model ``log_softmax(sim / sigma)``."""
+    nll = torch.zeros_like(sigmas)
+    pair_count = 0
+    sim_mat = similarity_matrix.to(device)
+    sigmas_dev = sigmas.to(device)
+
+    for pano_idx in valid_pano_idx.tolist():
+        sim_row = sim_mat[pano_idx]
+        finite_mask = torch.isfinite(sim_row)
+        sims = sim_row[finite_mask]
+
+        finite_idx = torch.nonzero(finite_mask, as_tuple=False).squeeze(1)
+        finite_to_local = -torch.ones(
+            sim_row.shape[0], dtype=torch.long, device=device
+        )
+        finite_to_local[finite_idx] = torch.arange(len(finite_idx), device=device)
+
+        row = panorama_metadata.iloc[pano_idx]
+        true_idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            true_idxs.extend(row["semipositive_satellite_idxs"])
+        true_idxs_t = torch.tensor(true_idxs, dtype=torch.long, device=device)
+        local_true = finite_to_local[true_idxs_t]
+        local_true = local_true[local_true >= 0]
+        if len(local_true) == 0:
+            continue
+
+        logits = sims.unsqueeze(0) / sigmas_dev.unsqueeze(1)  # (K, M)
+        log_probs = logits - torch.logsumexp(logits, dim=1, keepdim=True)
+        true_log_probs = log_probs[:, local_true]  # (K, T)
+        nll = nll + (-true_log_probs.sum(dim=1).detach().cpu())
+        pair_count += int(len(local_true))
+
+    return nll / max(pair_count, 1)
+
+
+def _draw_two_pop_histogram(
+    ax_density, ax_log, true_vals, neg_vals, *, bins, xmax, xmin, vlines,
+    xlabel, title, fits_density=None, fits_count=None,
+):
+    """Two-panel histogram for two populations.
+
+    Left panel: normalized density (each population integrates to 1) — exposes
+    distribution shape independent of sample size.
+    Right panel: raw counts on log-y — exposes abundance / sample-size gap.
+
+    `fits_density` / `fits_count` are lists of ``(xs, ys, color, ls, label)``
+    overlays drawn on the density / count panel respectively.
+    """
+    bin_w = bins[1] - bins[0]
+
+    # Density panel
+    ax_density.hist(true_vals, bins=bins, density=True, color="steelblue",
+                    alpha=0.65, label=f"true (n={len(true_vals)})")
+    ax_density.hist(neg_vals, bins=bins, density=True, histtype="step",
+                    color="darkorange", lw=1.5,
+                    label=f"negative (n={len(neg_vals)})")
+    if fits_density is not None:
+        for xs, ys, color, ls, label in fits_density:
+            ax_density.plot(xs, ys, color=color, ls=ls, lw=2, label=label)
+    for x, color, ls, label in vlines:
+        ax_density.axvline(x, color=color, ls=ls, alpha=0.7, label=label)
+    ax_density.set_xlim(xmin, xmax)
+    ax_density.set_xlabel(xlabel)
+    ax_density.set_ylabel("density")
+    ax_density.set_title(f"{title} (density)")
+    ax_density.legend(loc="upper right", fontsize=7)
+
+    # Log-count panel
+    ax_log.hist(true_vals, bins=bins, color="steelblue", alpha=0.65,
+                label=f"true (n={len(true_vals)})")
+    ax_log.hist(neg_vals, bins=bins, histtype="step", color="darkorange",
+                lw=1.5, label=f"negative (n={len(neg_vals)})")
+    if fits_count is not None:
+        for xs, ys, color, ls, label in fits_count:
+            ax_log.plot(xs, ys, color=color, ls=ls, lw=2, label=label)
+    for x, color, ls, label in vlines:
+        ax_log.axvline(x, color=color, ls=ls, alpha=0.7, label=label)
+    ax_log.set_xlim(xmin, xmax)
+    ax_log.set_xlabel(xlabel)
+    ax_log.set_ylabel("count (log)")
+    ax_log.set_yscale("log")
+    ax_log.set_ylim(bottom=0.5)
+    ax_log.set_title(f"{title} (log count)")
+    ax_log.legend(loc="upper right", fontsize=7)
+
+
+def plot_residual_histogram(
+    residuals_pair: torch.Tensor,
+    residuals_negative: torch.Tensor,
+    sigma_mle_pair: float,
+    sigma_nll_gauss_pair: float,
+    sigma_nll_soft_pair: float,
+    output_path: Path,
+) -> None:
+    r_pair = residuals_pair.numpy()
+    r_neg = residuals_negative.numpy()
+    pool = [r_pair, r_neg]
+    xmax = float(max(np.quantile(p, 0.999) for p in pool)) * 1.05
+    bins = np.linspace(0.0, xmax, 81)
+
+    # HalfNormal: pdf for the density panel; pdf * bin_w * n_pair for counts.
+    xs = np.linspace(0.0, xmax, 400)
+    bin_w = bins[1] - bins[0]
+    n_pair = len(r_pair)
+
+    def _half_normal_pdf(sigma):
+        return (2.0 / (sigma * np.sqrt(2 * np.pi))) * np.exp(
+            -0.5 * (xs / sigma) ** 2
+        )
+
+    fits_density = [
+        (xs, _half_normal_pdf(sigma_mle_pair), "C3", "-",
+         f"HalfNormal(σ={sigma_mle_pair:.4f}) [MLE per-pair]"),
+        (xs, _half_normal_pdf(sigma_nll_gauss_pair), "C0", "-",
+         f"HalfNormal(σ={sigma_nll_gauss_pair:.4f}) [NLL Gaussian]"),
+    ]
+    fits_count = [
+        (xs, _half_normal_pdf(sigma_mle_pair) * bin_w * n_pair,
+         "C3", "-", f"HalfNormal(σ={sigma_mle_pair:.4f}) [MLE per-pair]"),
+        (xs, _half_normal_pdf(sigma_nll_gauss_pair) * bin_w * n_pair,
+         "C0", "-", f"HalfNormal(σ={sigma_nll_gauss_pair:.4f}) [NLL Gaussian]"),
+    ]
+    vlines = [
+        (sigma_mle_pair, "C3", "--", None),
+        (sigma_nll_gauss_pair, "C0", "--", None),
+        (np.median(r_pair), "k", ":", f"true median={np.median(r_pair):.4f}"),
+    ]
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5))
+    _draw_two_pop_histogram(
+        axes[0], axes[1], r_pair, r_neg,
+        bins=bins, xmin=0.0, xmax=xmax, vlines=vlines,
+        fits_density=fits_density, fits_count=fits_count,
+        xlabel="residual = sim_max - sim_t",
+        title="Per-pair residuals (true vs negative)",
+    )
+    fig.suptitle(
+        f"σ candidates: MLE={sigma_mle_pair:.4f}  "
+        f"NLL_gauss={sigma_nll_gauss_pair:.4f}  "
+        f"NLL_softmax={sigma_nll_soft_pair:.4f}"
+    )
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=130)
+    plt.close(fig)
+
+
+def plot_similarity_distribution(
+    sims_pair: torch.Tensor,
+    sims_negative: torch.Tensor,
+    sigma_softmax_pair: float,
+    output_path: Path,
+) -> None:
+    s_pair = sims_pair.numpy()
+    s_neg = sims_negative.numpy()
+    lo = float(min(s_pair.min(), s_neg.min()))
+    hi = float(max(np.quantile(s_pair, 0.999), np.quantile(s_neg, 0.999)))
+    pad = 0.02 * (hi - lo + 1e-9)
+    bins = np.linspace(lo - pad, hi + pad, 81)
+    gap_in_sigma = (s_pair.mean() - s_neg.mean()) / sigma_softmax_pair
+
+    vlines = [
+        (s_pair.mean(), "steelblue", "--", f"true mean={s_pair.mean():.3f}"),
+        (s_neg.mean(), "darkorange", "--", f"neg mean={s_neg.mean():.3f}"),
+    ]
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5))
+    _draw_two_pop_histogram(
+        axes[0], axes[1], s_pair, s_neg,
+        bins=bins, xmin=lo - pad, xmax=hi + pad, vlines=vlines,
+        xlabel="raw similarity sim_t",
+        title="Per-pair similarity (true vs negative)",
+    )
+    fig.suptitle(
+        f"σ_softmax (NLL per-pair) = {sigma_softmax_pair:.4f}    "
+        f"(true−neg mean) = {s_pair.mean()-s_neg.mean():.3f} = "
+        f"{gap_in_sigma:.2f} σ"
+    )
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=130)
+    plt.close(fig)
+
+
+def plot_nll_vs_sigma(
+    sigmas: torch.Tensor,
+    nll_gauss_pair: torch.Tensor,
+    nll_soft_pair: torch.Tensor,
+    sigma_mle_pair: float,
+    output_path: Path,
+) -> None:
+    s = sigmas.numpy()
+    g = nll_gauss_pair.numpy()
+    sm = nll_soft_pair.numpy()
+    g_best = int(np.argmin(g))
+    s_best = int(np.argmin(sm))
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5), sharex=True)
+
+    ax = axes[0]
+    ax.plot(s, g, "C0-", lw=2,
+            label=f"NLL [σ*={s[g_best]:.4f}]")
+    ax.axvline(s[g_best], color="C0", ls=":", alpha=0.7)
+    ax.axvline(sigma_mle_pair, color="C3", ls="--", alpha=0.6,
+               label=f"σ_MLE={sigma_mle_pair:.4f}")
+    ax.set_xlabel("σ"); ax.set_ylabel("mean per-pair NLL")
+    ax.set_title("Single-matrix (Gaussian-on-residuals)")
+    ax.set_xscale("log")
+    ax.legend(loc="upper right", fontsize=9)
+
+    ax = axes[1]
+    ax.plot(s, sm, "C2-", lw=2,
+            label=f"NLL [σ*={s[s_best]:.4f}]")
+    ax.axvline(s[s_best], color="C2", ls=":", alpha=0.7)
+    ax.set_xlabel("σ"); ax.set_ylabel("mean per-pair NLL")
+    ax.set_title("Entropy-adaptive softmax")
+    ax.set_xscale("log")
+    ax.legend(loc="upper right", fontsize=9)
+
+    fig.suptitle("Per-pair NLL vs σ (lower is better)")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=130)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--similarity-matrix-path",
+        type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle/"
+                "similarity_matrices/safa_dinov3_wag_chicago.pt")
+    parser.add_argument(
+        "--dataset-path",
+        type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle")
+    parser.add_argument("--landmark-version", type=str, default="v4_202001")
+    parser.add_argument("--output-path", type=str, required=True)
+    parser.add_argument("--sigma-min", type=float, default=0.005)
+    parser.add_argument("--sigma-max", type=float, default=2.0)
+    parser.add_argument("--sigma-num", type=int, default=80)
+    parser.add_argument(
+        "--include-semipositive", type=lambda s: s.lower() != "false",
+        default=True)
+    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument(
+        "--num-negative-samples-per-pano", type=int, default=200,
+        help="Per-pano random negative-patch samples to overlay on plots. "
+             "0 disables the overlay.")
+    parser.add_argument("--negative-sample-seed", type=int, default=0)
+    parser.add_argument(
+        "--name-prefix", type=str, default="",
+        help="Filename prefix for outputs (e.g. 'image' or 'landmark') so "
+             "multiple matrices can write into the same output directory")
+    args = parser.parse_args()
+
+    output_path = Path(args.output_path).expanduser()
+    output_path.mkdir(parents=True, exist_ok=True)
+    prefix = (args.name_prefix + "_") if args.name_prefix else ""
+    with open(output_path / f"{prefix}args.json", "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    device = torch.device(args.device)
+
+    print(f"Loading similarity matrix from {args.similarity_matrix_path}")
+    sim_mat = _load_similarity_matrix(Path(args.similarity_matrix_path))
+    print(f"  shape: {tuple(sim_mat.shape)}, dtype: {sim_mat.dtype}")
+
+    print(f"Loading dataset metadata from {args.dataset_path}")
+    dataset_config = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None,
+        panorama_tensor_cache_info=None,
+        should_load_images=False,
+        should_load_landmarks=False,
+        landmark_version=args.landmark_version,
+    )
+    vigor_dataset = vd.VigorDataset(Path(args.dataset_path), dataset_config)
+    pano_metadata = vigor_dataset._panorama_metadata
+    assert sim_mat.shape[0] == len(pano_metadata)
+    assert sim_mat.shape[1] == len(vigor_dataset._satellite_metadata)
+
+    print("Computing per-pair residuals and similarity samples...")
+    rd = compute_samples(
+        sim_mat, pano_metadata,
+        include_semipositive=args.include_semipositive,
+        num_negative_samples_per_pano=args.num_negative_samples_per_pano,
+        rng_seed=args.negative_sample_seed,
+        exclude_constant_rows=True,
+    )
+    residuals_pair = rd["residuals_pair"]
+    residuals_neg = rd["residuals_negative"]
+    sims_pair = rd["sims_pair"]
+    sims_neg = rd["sims_negative"]
+    valid_pano_idx = rd["valid_pano_idx"]
+    print(f"  excluded {rd['num_excluded_constant_rows']} constant/all-equal rows")
+    print(f"  excluded {rd['num_excluded_no_truepatch']} rows with no finite true patch")
+    print(f"  contributing panos: {len(valid_pano_idx)} / {sim_mat.shape[0]}")
+    print(f"  positive (pano,true) pairs: {len(residuals_pair)}")
+    if len(residuals_neg) > 0:
+        print(f"  sampled negative pairs: {len(residuals_neg)}")
+
+    r_pair = residuals_pair.numpy()
+    sigma_mle_pair = float(np.sqrt(np.mean(r_pair ** 2)))
+    sigma_median_pair = float(np.median(r_pair))
+    print(f"  σ_MLE per-pair = {sigma_mle_pair:.6f}  "
+          f"(median residual = {sigma_median_pair:.6f})")
+
+    sigmas = torch.tensor(
+        np.logspace(np.log10(args.sigma_min), np.log10(args.sigma_max),
+                    args.sigma_num),
+        dtype=torch.float64,
+    )
+
+    print(f"Sweeping σ over {len(sigmas)} log-spaced values "
+          f"in [{args.sigma_min}, {args.sigma_max}]...")
+    print("  computing Gaussian-on-residuals per-pair NLL...")
+    nll_g_pair = nll_gaussian_residual_form_pair(
+        sim_mat.double(), pano_metadata, valid_pano_idx, sigmas,
+        include_semipositive=args.include_semipositive, device=device,
+    )
+    print("  computing softmax per-pair NLL...")
+    nll_s_pair = nll_softmax_form_pair(
+        sim_mat.double(), pano_metadata, valid_pano_idx, sigmas,
+        include_semipositive=args.include_semipositive, device=device,
+    )
+
+    g_best = int(torch.argmin(nll_g_pair))
+    s_best = int(torch.argmin(nll_s_pair))
+    sigma_nll_gauss_grid = float(sigmas[g_best])
+    sigma_nll_soft_grid = float(sigmas[s_best])
+    print(f"  [grid] σ min Gaussian-form NLL = {sigma_nll_gauss_grid:.6f} "
+          f"(NLL={float(nll_g_pair[g_best]):.4f})")
+    print(f"  [grid] σ min softmax-form NLL  = {sigma_nll_soft_grid:.6f} "
+          f"(NLL={float(nll_s_pair[s_best]):.4f})")
+
+    print("Refining via Brent's method (scipy.optimize.minimize_scalar)...")
+    cache = build_per_pano_cache(
+        sim_mat, pano_metadata, valid_pano_idx,
+        include_semipositive=args.include_semipositive, device=device,
+    )
+
+    def _nll_g(sig):
+        return scalar_nll_gaussian_residual(float(sig), cache)
+
+    def _nll_s(sig):
+        return scalar_nll_softmax(float(sig), cache)
+
+    bracket = (args.sigma_min, args.sigma_max)
+    res_g = minimize_scalar(
+        _nll_g, bounds=bracket, method="bounded",
+        options={"xatol": 1e-5, "maxiter": 200},
+    )
+    res_s = minimize_scalar(
+        _nll_s, bounds=bracket, method="bounded",
+        options={"xatol": 1e-5, "maxiter": 200},
+    )
+    sigma_nll_gauss = float(res_g.x)
+    sigma_nll_soft = float(res_s.x)
+    nll_gauss_min = float(res_g.fun)
+    nll_soft_min = float(res_s.fun)
+    print(f"  [brent] σ min Gaussian-form NLL = {sigma_nll_gauss:.6f} "
+          f"(NLL={nll_gauss_min:.4f}, evals={res_g.nfev}, "
+          f"converged={res_g.success})")
+    print(f"  [brent] σ min softmax-form NLL  = {sigma_nll_soft:.6f} "
+          f"(NLL={nll_soft_min:.4f}, evals={res_s.nfev}, "
+          f"converged={res_s.success})")
+
+    print("Writing plots and JSON summary...")
+    plot_residual_histogram(
+        residuals_pair, residuals_neg,
+        sigma_mle_pair, sigma_nll_gauss, sigma_nll_soft,
+        output_path / f"{prefix}residual_histogram.png",
+    )
+    plot_similarity_distribution(
+        sims_pair, sims_neg, sigma_nll_soft,
+        output_path / f"{prefix}similarity_distribution.png",
+    )
+    plot_nll_vs_sigma(
+        sigmas, nll_g_pair, nll_s_pair, sigma_mle_pair,
+        output_path / f"{prefix}nll_vs_sigma.png",
+    )
+    torch.save({
+        "residuals_pair": residuals_pair,
+        "residuals_negative": residuals_neg,
+        "sims_pair": sims_pair,
+        "sims_negative": sims_neg,
+    }, output_path / f"{prefix}samples.pt")
+
+    summary = {
+        "similarity_matrix_path": str(args.similarity_matrix_path),
+        "dataset_path": str(args.dataset_path),
+        "include_semipositive": args.include_semipositive,
+        "num_panoramas_total": int(sim_mat.shape[0]),
+        "num_pano_truepatch_pairs": int(len(residuals_pair)),
+        "num_negative_samples": int(len(residuals_neg)),
+        "num_excluded_constant_rows": int(rd["num_excluded_constant_rows"]),
+        "num_excluded_no_truepatch": int(rd["num_excluded_no_truepatch"]),
+        "num_panoramas_contributing": int(len(valid_pano_idx)),
+        "sigma_mle_per_pair": sigma_mle_pair,
+        "sigma_median_per_pair": sigma_median_pair,
+        "sigma_nll_gaussian_form_pair": sigma_nll_gauss,
+        "sigma_nll_softmax_form_pair": sigma_nll_soft,
+        "min_nll_gaussian_form_pair": float(nll_g_pair[g_best]),
+        "min_nll_softmax_form_pair": float(nll_s_pair[s_best]),
+        "sigma_sweep": sigmas.tolist(),
+        "nll_gaussian_form_pair_sweep": nll_g_pair.tolist(),
+        "nll_softmax_form_pair_sweep": nll_s_pair.tolist(),
+    }
+    with open(output_path / f"{prefix}sigma_calibration.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"\nDone. Outputs in {output_path} (prefix={prefix or '<none>'})")
+    print(f"  σ_MLE per-pair = {sigma_mle_pair:.4f}")
+    print(f"  σ_NLL_gaussian = {sigma_nll_gauss:.4f}")
+    print(f"  σ_NLL_softmax  = {sigma_nll_soft:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/compare_simple_v1_v3_vs_v6.py
+++ b/experimental/overhead_matching/swag/scripts/compare_simple_v1_v3_vs_v6.py
@@ -1,0 +1,102 @@
+"""One-off comparison: legacy simple_v1_hungarian_0.8 (v3 embeddings, no dustbin)
+vs new simple_v1_v6_hungarian_0.8_similarity (v6 embeddings, dustbin on).
+
+Reports recall@{1,5,10} and MRR for each city + the delta. Uses VigorDataset
+GT (positive_satellite_idxs + semipositive_satellite_idxs).
+"""
+
+import argparse
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+
+from experimental.overhead_matching.swag.data import vigor_dataset as vd
+from experimental.overhead_matching.swag.evaluation import retrieval_metrics as rm
+
+
+CITIES = [
+    ("SF_mapillary", "/data/overhead_matching/datasets/VIGOR/mapillary/SanFrancisco_mapillary"),
+    ("Boston", "/data/overhead_matching/datasets/VIGOR/Boston"),
+    ("Framingham", "/data/overhead_matching/datasets/VIGOR/mapillary/Framingham"),
+    ("Norway", "/data/overhead_matching/datasets/VIGOR/mapillary/Norway"),
+    ("Seattle", "/data/overhead_matching/datasets/VIGOR/Seattle"),
+    ("nightdrive", "/data/overhead_matching/datasets/VIGOR/nightdrive"),
+    ("MiamiBeach", "/data/overhead_matching/datasets/VIGOR/mapillary/MiamiBeach"),
+    ("Middletown", "/data/overhead_matching/datasets/VIGOR/mapillary/Middletown"),
+    ("Gap", "/data/overhead_matching/datasets/VIGOR/mapillary/Gap"),
+    ("post_hurricane_ian", "/data/overhead_matching/datasets/VIGOR/mapillary/post_hurricane_ian"),
+]
+
+
+LANDMARK_VERSIONS = {
+    "/data/overhead_matching/datasets/VIGOR/Boston": None,
+    "/data/overhead_matching/datasets/VIGOR/Seattle": "v4_202001",
+    "/data/overhead_matching/datasets/VIGOR/nightdrive": None,
+}
+
+
+def load_dataset(dpath: Path, landmark_version: str | None):
+    config = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None,
+        panorama_tensor_cache_info=None,
+        should_load_images=False,
+        should_load_landmarks=False,
+        landmark_version=landmark_version,
+    )
+    return vd.VigorDataset(dpath, config)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cities", nargs="*", default=None,
+                        help="Subset of cities to evaluate (default: all)")
+    args = parser.parse_args()
+
+    cities = CITIES
+    if args.cities:
+        cities = [(n, p) for n, p in CITIES if n in args.cities]
+
+    rows = []
+    for city_name, dpath in cities:
+        dpath = Path(dpath)
+        legacy = dpath / "similarity_matrices" / "simple_v1_hungarian_0.8.pt"
+        new = dpath / "similarity_matrices" / "simple_v1_v6_hungarian_0.8_similarity.pt"
+        if not legacy.exists() or not new.exists():
+            print(f"SKIP {city_name}: legacy={legacy.exists()} new={new.exists()}")
+            continue
+
+        print(f"\n=== {city_name} ===")
+        lver = LANDMARK_VERSIONS.get(str(dpath), None)
+        dataset = load_dataset(dpath, lver)
+        print(f"  panos={len(dataset._panorama_metadata)}, "
+              f"sats={len(dataset._satellite_metadata)}")
+
+        legacy_sim = torch.load(legacy, weights_only=False, map_location="cpu")
+        new_sim = torch.load(new, weights_only=False, map_location="cpu")
+        print(f"  legacy shape={tuple(legacy_sim.shape)}, new shape={tuple(new_sim.shape)}")
+
+        legacy_m = rm.compute_top_k_metrics(legacy_sim, dataset)
+        new_m = rm.compute_top_k_metrics(new_sim, dataset)
+        rows.append((city_name, legacy_m, new_m))
+
+    print("\n" + "=" * 120)
+    print(f"{'city':<22} | {'r@1 legacy':>10} {'r@1 v6':>8} {'Δ':>7} | "
+          f"{'r@5 legacy':>10} {'r@5 v6':>8} {'Δ':>7} | "
+          f"{'r@10 legacy':>11} {'r@10 v6':>9} {'Δ':>7} | "
+          f"{'mrr legacy':>10} {'mrr v6':>8} {'Δ':>7}")
+    print("-" * 120)
+    for city, legacy_m, new_m in rows:
+        def fmt(v): return f"{v:.4f}"
+        def delta(a, b): return f"{(b - a):+.4f}"
+        print(
+            f"{city:<22} | "
+            f"{fmt(legacy_m['recall@1']):>10} {fmt(new_m['recall@1']):>8} {delta(legacy_m['recall@1'], new_m['recall@1']):>7} | "
+            f"{fmt(legacy_m['recall@5']):>10} {fmt(new_m['recall@5']):>8} {delta(legacy_m['recall@5'], new_m['recall@5']):>7} | "
+            f"{fmt(legacy_m['recall@10']):>11} {fmt(new_m['recall@10']):>9} {delta(legacy_m['recall@10'], new_m['recall@10']):>7} | "
+            f"{fmt(legacy_m['mrr']):>10} {fmt(new_m['mrr']):>8} {delta(legacy_m['mrr'], new_m['mrr']):>7}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/evaluate_histogram_on_paths.py
+++ b/experimental/overhead_matching/swag/scripts/evaluate_histogram_on_paths.py
@@ -84,7 +84,8 @@ class HistogramFilterConfig:
 @dataclass
 class HistogramPathResult:
     """Result of running histogram filter on a single path."""
-    mean_history: torch.Tensor  # (path_len + 1, 2) lat/lon estimates
+    mean_history: torch.Tensor  # (path_len + 1, 2) lat/lon — weighted-mean estimate
+    mode_history: torch.Tensor  # (path_len + 1, 2) lat/lon — argmax-cell (MAP) estimate
     variance_history: torch.Tensor  # (path_len + 1, 2) variance in degrees squared
     final_belief: HistogramBelief
     # Convergence metrics: probability mass within radius at each step
@@ -136,6 +137,7 @@ def run_histogram_filter_on_path(
         HistogramPathResult with mean/variance history and convergence metrics
     """
     mean_history = [belief.get_mean_latlon()]
+    mode_history = [belief.get_mode_latlon()]
     variance_history = [belief.get_variance_deg_sq()]
 
     # Initialize convergence tracking
@@ -163,6 +165,7 @@ def run_histogram_filter_on_path(
         belief.apply_observation(obs_log_ll, mapping)
 
         mean_history.append(belief.get_mean_latlon())
+        mode_history.append(belief.get_mode_latlon())
         variance_history.append(belief.get_variance_deg_sq())
 
         # Track convergence after observation (before motion blurs the belief)
@@ -180,6 +183,7 @@ def run_histogram_filter_on_path(
     obs_log_ll = log_likelihood_aggregator(path_pano_ids[-1])
     belief.apply_observation(obs_log_ll, mapping)
     mean_history.append(belief.get_mean_latlon())
+    mode_history.append(belief.get_mode_latlon())
     variance_history.append(belief.get_variance_deg_sq())
 
     # Track convergence after final observation
@@ -197,29 +201,34 @@ def run_histogram_filter_on_path(
 
     return HistogramPathResult(
         mean_history=torch.stack(mean_history),
+        mode_history=torch.stack(mode_history),
         variance_history=torch.stack(variance_history),
         final_belief=belief,
         prob_mass_by_radius=prob_mass_tensors,
     )
 
 
-def get_distance_error_from_mean_history(
+def get_distance_error_from_estimate_history(
     vigor_dataset: vd.VigorDataset,
     path: list[str],
-    mean_history: torch.Tensor,
+    estimate_history: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Compute distance error between mean estimates and ground truth.
+    """Compute distance error between position estimates and ground truth.
+
+    Works for any per-step lat/lon estimate (e.g. weighted mean or argmax
+    cell / MAP).
 
     Args:
         vigor_dataset: Dataset with panorama positions
         path: List of panorama indices
-        mean_history: (path_len + 1, 2) lat/lon estimates
+        estimate_history: (path_len + 1, 2) lat/lon estimates
 
     Returns:
         error_meters: (path_len + 1,) distance error in meters
         variance_sq_m: (path_len + 1,) variance in meters squared (placeholder)
     """
-    true_latlon = vigor_dataset.get_panorama_positions(path).to(device=mean_history.device)
+    true_latlon = vigor_dataset.get_panorama_positions(path).to(
+        device=estimate_history.device)
 
     # mean_history has len(path) + 1 entries (initial + after each observation)
     # But we only have len(path) ground truth positions
@@ -234,15 +243,15 @@ def get_distance_error_from_mean_history(
     # But our mean_history has path_len + 1 entries because we track before first obs too
     # Let's match the particle filter: compare estimate at each position
 
-    # For simplicity, use the last N entries of mean_history to match path length
-    estimates = mean_history[-len(path):]
+    # For simplicity, use the last N entries to match path length
+    estimates = estimate_history[-len(path):]
 
     error_meters = []
     for i in range(len(path)):
         d = vd.EARTH_RADIUS_M * find_d_on_unit_circle(true_latlon[i], estimates[i])
         error_meters.append(d)
 
-    return torch.tensor(error_meters, device=mean_history.device)
+    return torch.tensor(error_meters, device=estimate_history.device)
 
 
 def evaluate_histogram_on_paths(
@@ -269,7 +278,8 @@ def evaluate_histogram_on_paths(
         save_intermediate_states: Whether to save belief history
         convergence_radii: List of radii in meters for convergence metrics
     """
-    all_final_error_meters = []
+    all_final_error_meters = []        # using mean estimator
+    all_final_mode_error_meters = []   # using argmax-cell (MAP / mode) estimator
     # Track convergence costs per radius
     convergence_costs_by_radius: dict[int, list[float]] = {}
     if convergence_radii:
@@ -360,25 +370,30 @@ def evaluate_histogram_on_paths(
             distance_traveled_m = es.compute_distance_traveled(vigor_dataset, path)
 
             # Compute error
-            error_meters = get_distance_error_from_mean_history(
+            error_meters = get_distance_error_from_estimate_history(
                 vigor_dataset, path, result.mean_history)
+            mode_error_meters = get_distance_error_from_estimate_history(
+                vigor_dataset, path, result.mode_history)
 
             # Variance in meters squared (convert from degrees)
             var_sq_m = result.variance_history[-len(path):].sum(dim=-1) * (web_mercator.METERS_PER_DEG_LAT ** 2)
 
             all_final_error_meters.append(error_meters[-1].item())
+            all_final_mode_error_meters.append(mode_error_meters[-1].item())
 
             # Save results
             save_path = output_path / f"{i:07d}"
             save_path.mkdir(parents=True, exist_ok=True)
 
             torch.save(error_meters, save_path / "error.pt")
+            torch.save(mode_error_meters, save_path / "mode_error.pt")
             torch.save(var_sq_m, save_path / "var.pt")
             torch.save(path, save_path / "path.pt")
             torch.save(distance_traveled_m, save_path / "distance_traveled_m.pt")
 
             if save_intermediate_states:
                 torch.save(result.mean_history.cpu(), save_path / "mean_history.pt")
+                torch.save(result.mode_history.cpu(), save_path / "mode_history.pt")
                 torch.save(result.variance_history.cpu(), save_path / "variance_history.pt")
 
             # Save convergence metrics
@@ -399,8 +414,12 @@ def evaluate_histogram_on_paths(
 
         # Summary statistics
         average_final_error = sum(all_final_error_meters) / len(all_final_error_meters)
+        average_final_mode_error = (
+            sum(all_final_mode_error_meters) / len(all_final_mode_error_meters)
+        )
         summary_stats = {
-            "average_final_error": average_final_error,
+            "average_final_error": average_final_error,            # mean estimator
+            "average_final_mode_error": average_final_mode_error,  # MAP / argmax-cell estimator
             "filter_type": "histogram",
             "grid_rows": grid_spec.num_rows,
             "grid_cols": grid_spec.num_cols,
@@ -419,7 +438,8 @@ def evaluate_histogram_on_paths(
         with open(output_path / "summary_statistics.json", "w") as f:
             f.write(json.dumps(summary_stats, indent=2))
 
-        print(f"Average final error meters: {average_final_error:.2f}")
+        print(f"Average final error meters: {average_final_error:.2f} "
+              f"(mean estimator)  vs  {average_final_mode_error:.2f} (MAP estimator)")
         if convergence_radii:
             for radius in convergence_radii:
                 mean_cost = summary_stats[f"mean_convergence_cost_{radius}m"]

--- a/experimental/overhead_matching/swag/scripts/evaluate_histogram_on_paths.py
+++ b/experimental/overhead_matching/swag/scripts/evaluate_histogram_on_paths.py
@@ -61,7 +61,7 @@ def load_model(path, device='cuda'):
 @dataclass
 class HistogramFilterConfig:
     """Configuration for histogram filter evaluation."""
-    noise_percent: float = 0.02  # Motion noise as fraction of motion magnitude
+    motion_noise_frac: float = 0.05  # Wiener noise intensity (m/√m) for filter blur
     subdivision_factor: int = 4  # Grid subdivision (4 = 160px cells at zoom 20)
     initial_std_deg: float = 0.0267  # ~2970m initial uncertainty
     initial_offset_std_deg: float = 0.0117  # ~1300m offset
@@ -174,7 +174,7 @@ def run_histogram_filter_on_path(
                 prob_mass_by_radius[radius].append(prob_mass)
 
         # Motion prediction
-        belief.apply_motion(motion_deltas[step_idx], config.noise_percent)
+        belief.apply_motion(motion_deltas[step_idx], config.motion_noise_frac)
 
     # Final observation
     obs_log_ll = log_likelihood_aggregator(path_pano_ids[-1])
@@ -540,8 +540,12 @@ if __name__ == "__main__":
                         default=0.0005, help="Panorama neighbor radius deg")
     parser.add_argument("--panorama-landmark-radius-px", type=int,
                         default=640, help="Panorama landmark radius in pixels")
-    parser.add_argument("--noise-percent", type=float, default=0.02,
-                        help="Motion noise as fraction of motion magnitude")
+    parser.add_argument("--motion-noise-frac", type=float, default=0.05,
+                        help="Wiener noise intensity (m/√m) for the filter's "
+                             "process-model blur. Per step, blur std = "
+                             "motion_noise_frac × √step_distance_m. Same "
+                             "units as --odometry-noise-frac so a calibrated "
+                             "filter sets them equal.")
     parser.add_argument("--subdivision-factor", type=int, default=4,
                         help="Grid subdivision factor (4 = 160px cells)")
     parser.add_argument("--convergence-radii", type=str, default="25,50,100",
@@ -615,7 +619,7 @@ if __name__ == "__main__":
         print(f"Resolution-normalized dataset: source_px={source_px} (footprint {source_px}px, image 640px)")
 
     config = HistogramFilterConfig(
-        noise_percent=args.noise_percent,
+        motion_noise_frac=args.motion_noise_frac,
         subdivision_factor=args.subdivision_factor,
         initial_std_deg=degrees_from_meters(2970.0),
         initial_offset_std_deg=degrees_from_meters(1300.0),
@@ -625,7 +629,7 @@ if __name__ == "__main__":
     )
 
     histogram_config_dict = {
-        "noise_percent": config.noise_percent,
+        "motion_noise_frac": config.motion_noise_frac,
         "subdivision_factor": config.subdivision_factor,
         "initial_std_deg": config.initial_std_deg,
         "initial_offset_std_deg": config.initial_offset_std_deg,

--- a/experimental/overhead_matching/swag/scripts/evaluate_learned_aggregator.py
+++ b/experimental/overhead_matching/swag/scripts/evaluate_learned_aggregator.py
@@ -1,0 +1,383 @@
+"""Evaluate a trained :class:`LearnedAggregator` on full-length paths.
+
+Counterpart to ``grid_search_convergence``: instead of sweeping constant σ
+pairs, plug a trained policy into the same trajectory rollout and report the
+same trajectory-level metrics. Also reports the policy's per-step σ / α
+distribution so we can tell whether it's doing meaningful per-step adaptation
+versus collapsing to near-constant values.
+"""
+
+from pathlib import Path
+import argparse
+import json
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import numpy as np
+import tqdm
+
+from common.gps import web_mercator
+from common.math.haversine import find_d_on_unit_circle
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+import experimental.overhead_matching.swag.evaluation.evaluate_swag as es
+from experimental.overhead_matching.swag.evaluation.convergence_metrics import (
+    compute_convergence_cost,
+    compute_probability_mass_within_radius,
+)
+from experimental.overhead_matching.swag.evaluation.odometry_noise import (
+    OdometryNoiseConfig,
+    add_noise_to_motion_deltas,
+)
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+from experimental.overhead_matching.swag.filter.histogram_belief import (
+    GridSpec,
+    HistogramBelief,
+    build_cell_to_patch_mapping,
+)
+from experimental.overhead_matching.swag.filter.learned_aggregator import (
+    LearnedAggregator,
+    SigmaPolicy,
+    StepContext,
+    HistoryEntry,
+    extract_belief_features,
+)
+from experimental.overhead_matching.swag.scripts.evaluate_histogram_on_paths import (
+    HistogramFilterConfig,
+    construct_path_eval_inputs_from_args,
+    get_dataset_bounds,
+    get_patch_positions_px,
+)
+
+
+def evaluate_path(
+    aggregator: LearnedAggregator,
+    grid_spec,
+    mapping,
+    vigor_dataset,
+    path: list[str],
+    motion_noise_frac: float,
+    convergence_radii: list[float],
+    converge_threshold: float,
+    odometry_noise: OdometryNoiseConfig | None,
+    odometry_seed: int | None,
+    device: torch.device,
+):
+    """Run the (production) hard-max filter on one path with the learned policy."""
+    belief = HistogramBelief.from_uniform(grid_spec=grid_spec, device=device)
+    motion_deltas = es.get_motion_deltas_from_path(vigor_dataset, path).to(device)
+    if odometry_noise is not None and odometry_seed is not None:
+        start_latlon = vigor_dataset.get_panorama_positions(path)[0].to(device)
+        noise_gen = torch.Generator(device="cpu").manual_seed(odometry_seed)
+        motion_deltas = add_noise_to_motion_deltas(
+            motion_deltas.cpu(), start_latlon.cpu(), odometry_noise,
+            generator=noise_gen,
+        ).to(device)
+    true_latlons = vigor_dataset.get_panorama_positions(path).to(device)
+
+    distance_traveled_m = es.compute_distance_traveled(vigor_dataset, path)
+    path_len = len(path)
+    cum_dist = torch.zeros(path_len, device=device)
+    pano_positions = true_latlons
+    for i in range(1, path_len):
+        cum_dist[i] = cum_dist[i - 1] + (
+            vd.EARTH_RADIUS_M * find_d_on_unit_circle(
+                pano_positions[i - 1], pano_positions[i]
+            )
+        )
+
+    # One prob_mass_history per radius (parallel lists).
+    prob_mass_histories: dict[float, list[float]] = {
+        r: [compute_probability_mass_within_radius(belief, true_latlons[0], r)]
+        for r in convergence_radii
+    }
+    sigma_imgs, sigma_lms, alphas = [], [], []
+    history_buffer: list[HistoryEntry] = []
+
+    def _make_step_ctx(step_idx: int) -> StepContext:
+        norm_step = float(step_idx) / max(path_len - 1, 1)
+        step_d = (
+            float((cum_dist[step_idx] - cum_dist[step_idx - 1]).item())
+            if step_idx > 0 else 0.0
+        )
+        b_entropy, b_log_var, b_top = extract_belief_features(belief)
+        return StepContext(
+            belief_entropy=b_entropy, belief_log_trace_var=b_log_var,
+            belief_top_cell_mass=b_top, belief_step_index_norm=norm_step,
+            norm_cum_distance=float(cum_dist[step_idx].item()) / 5000.0,
+            log_step_distance=float(np.log(max(step_d, 1.0))),
+            step_idx_over_path_len=norm_step,
+            history=list(history_buffer),
+        )
+
+    def _push_history(step_idx: int, log_ll: torch.Tensor) -> None:
+        b_entropy, b_log_var, b_top = extract_belief_features(belief)
+        step_d = (
+            float((cum_dist[step_idx] - cum_dist[step_idx - 1]).item())
+            if step_idx > 0 else 0.0
+        )
+        history_buffer.append(HistoryEntry(
+            belief_entropy=b_entropy,
+            belief_log_trace_var=b_log_var,
+            belief_top_cell_mass=b_top,
+            log_step_distance=float(np.log(max(step_d, 1.0))),
+            last_obs_max_log_p=float(log_ll.detach().max().item()),
+        ))
+
+    for step_idx in range(path_len - 1):
+        aggregator.set_step_context(_make_step_ctx(step_idx))
+        pano_id = path[step_idx]
+        pano_index = aggregator._pano_id_index.get_loc(pano_id)
+        img_row = aggregator.image_similarity_matrix[pano_index].to(device)
+        lm_row = aggregator.landmark_similarity_matrix[pano_index].to(device)
+        with torch.no_grad():
+            log_ll, sigma_img, sigma_lm, alpha = aggregator.fused_log_likelihood(
+                img_row, lm_row
+            )
+        sigma_imgs.append(float(sigma_img.item()))
+        sigma_lms.append(float(sigma_lm.item()))
+        alphas.append(float(alpha.item()))
+
+        # Production hard-max path (no surrogate_tau).
+        belief.apply_observation(log_ll, mapping)
+        for r in convergence_radii:
+            prob_mass_histories[r].append(
+                compute_probability_mass_within_radius(
+                    belief, true_latlons[step_idx + 1], r
+                )
+            )
+        _push_history(step_idx, log_ll)
+        belief.apply_motion(motion_deltas[step_idx], motion_noise_frac)
+
+    # Final observation
+    aggregator.set_step_context(_make_step_ctx(path_len - 1))
+    pano_id = path[-1]
+    pano_index = aggregator._pano_id_index.get_loc(pano_id)
+    img_row = aggregator.image_similarity_matrix[pano_index].to(device)
+    lm_row = aggregator.landmark_similarity_matrix[pano_index].to(device)
+    with torch.no_grad():
+        log_ll, sigma_img, sigma_lm, alpha = aggregator.fused_log_likelihood(
+            img_row, lm_row
+        )
+    sigma_imgs.append(float(sigma_img.item()))
+    sigma_lms.append(float(sigma_lm.item()))
+    alphas.append(float(alpha.item()))
+    belief.apply_observation(log_ll, mapping)
+    for r in convergence_radii:
+        prob_mass_histories[r].append(
+            compute_probability_mass_within_radius(belief, true_latlons[-1], r)
+        )
+
+    # Compute per-radius convergence cost and steps-to-converge.
+    costs: dict[float, float] = {}
+    steps_to_converge: dict[float, int | None] = {}
+    for r, hist in prob_mass_histories.items():
+        pm_tensor = torch.tensor(hist)
+        costs[r] = compute_convergence_cost(pm_tensor, distance_traveled_m)
+        above = pm_tensor >= converge_threshold
+        steps_to_converge[r] = (
+            int(above.float().argmax().item()) if above.any() else None
+        )
+
+    final_mean = belief.get_mean_latlon()
+    final_err = float(
+        vd.EARTH_RADIUS_M * find_d_on_unit_circle(true_latlons[-1], final_mean).item()
+    )
+
+    out = {
+        "final_error_m": final_err,
+        "sigma_img_mean": float(np.mean(sigma_imgs)),
+        "sigma_img_std": float(np.std(sigma_imgs)),
+        "sigma_lm_mean": float(np.mean(sigma_lms)),
+        "sigma_lm_std": float(np.std(sigma_lms)),
+        "alpha_mean": float(np.mean(alphas)),
+        "alpha_std": float(np.std(alphas)),
+        "path_len": path_len,
+    }
+    for r in convergence_radii:
+        out[f"convergence_cost_{int(r)}m"] = costs[r]
+        out[f"steps_to_converge_{int(r)}m"] = steps_to_converge[r]
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths-path", type=str, required=True)
+    parser.add_argument("--dataset-path", type=str, required=True)
+    parser.add_argument("--landmark-version", type=str, required=True)
+    parser.add_argument("--img-sim-path", type=str, required=True)
+    parser.add_argument("--lm-sim-path", type=str, required=True)
+    parser.add_argument("--policy-weights", type=str, required=True)
+    parser.add_argument("--output-path", type=str, required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument("--motion-noise-frac", type=float, default=0.05)
+    parser.add_argument("--subdivision-factor", type=int, default=4)
+    parser.add_argument("--convergence-radii", type=str, default="25,50,100",
+                        help="Comma-separated radii (m) for convergence cost.")
+    parser.add_argument("--converge-threshold", type=float, default=0.5)
+    parser.add_argument("--max-paths", type=int, default=None)
+    parser.add_argument("--max-chunk-gib", type=float, default=2.0)
+    parser.add_argument("--panorama-neighbor-radius-deg", type=float, default=0.0005)
+    parser.add_argument("--panorama-landmark-radius-px", type=int, default=640)
+    parser.add_argument("--odometry-noise-frac", type=float, default=None)
+    parser.add_argument("--odometry-noise-seed", type=int, default=7919)
+    args = parser.parse_args()
+
+    output_path = Path(args.output_path).expanduser()
+    output_path.mkdir(parents=True, exist_ok=True)
+    with open(output_path / "args.json", "w") as f:
+        json.dump(vars(args), f, indent=2)
+    device = torch.device(args.device)
+
+    print("Loading dataset / paths...")
+    vigor_dataset, _, _, paths_data = construct_path_eval_inputs_from_args(
+        dataset_path=args.dataset_path,
+        paths_path=args.paths_path,
+        panorama_neighbor_radius_deg=args.panorama_neighbor_radius_deg,
+        panorama_landmark_radius_px=args.panorama_landmark_radius_px,
+        device=device,
+        landmark_version=args.landmark_version,
+    )
+    paths = paths_data["paths"]
+    if args.max_paths is not None:
+        paths = paths[: args.max_paths]
+    print(f"  {len(paths)} paths")
+
+    print("Loading similarity matrices...")
+    img_sim = _load_similarity_matrix(Path(args.img_sim_path))
+    lm_sim = _load_similarity_matrix(Path(args.lm_sim_path))
+
+    source_px = None
+    sat_bbox_path = Path(args.dataset_path) / "satellite_bbox.json"
+    if sat_bbox_path.exists():
+        with open(sat_bbox_path) as f:
+            source_px = json.load(f).get("source_px")
+    odometry_noise = None
+    if args.odometry_noise_frac is not None:
+        odometry_noise = OdometryNoiseConfig(
+            sigma_noise_frac=args.odometry_noise_frac, seed=args.odometry_noise_seed,
+        )
+    hist_cfg = HistogramFilterConfig(
+        motion_noise_frac=args.motion_noise_frac,
+        subdivision_factor=args.subdivision_factor,
+        source_px=source_px,
+    )
+
+    print("Building grid + mapping...")
+    min_lat, max_lat, min_lon, max_lon = get_dataset_bounds(vigor_dataset)
+    footprint_px = hist_cfg.footprint_px
+    cell_size_px = footprint_px / hist_cfg.subdivision_factor
+    patch_half_size_px = footprint_px / 2.0
+    center_lat = (min_lat + max_lat) / 2
+    ref_y, ref_x = web_mercator.latlon_to_pixel_coords(
+        center_lat, min_lon, hist_cfg.zoom_level
+    )
+    buf_lat, _ = web_mercator.pixel_coords_to_latlon(
+        ref_y - patch_half_size_px, ref_x, hist_cfg.zoom_level
+    )
+    _, buf_lon = web_mercator.pixel_coords_to_latlon(
+        ref_y, ref_x + patch_half_size_px, hist_cfg.zoom_level
+    )
+    grid_spec = GridSpec.from_bounds_and_cell_size(
+        min_lat=min_lat - (buf_lat - center_lat),
+        max_lat=max_lat + (buf_lat - center_lat),
+        min_lon=min_lon - (buf_lon - min_lon),
+        max_lon=max_lon + (buf_lon - min_lon),
+        zoom_level=hist_cfg.zoom_level,
+        cell_size_px=cell_size_px,
+    )
+    patch_positions_px = get_patch_positions_px(vigor_dataset, device)
+    mapping = build_cell_to_patch_mapping(
+        grid_spec=grid_spec,
+        patch_positions_px=patch_positions_px,
+        patch_half_size_px=patch_half_size_px,
+        device=device,
+        max_chunk_bytes=int(args.max_chunk_gib * 1024 ** 3),
+    )
+
+    print(f"Loading policy from {args.policy_weights}")
+    policy = SigmaPolicy()
+    state = torch.load(args.policy_weights, map_location="cpu", weights_only=False)
+    policy.load_state_dict(state)
+    policy.standardizer.frozen = True
+    policy.eval()
+    aggregator = LearnedAggregator(
+        image_similarity_matrix=img_sim,
+        landmark_similarity_matrix=lm_sim,
+        panorama_metadata=vigor_dataset._panorama_metadata,
+        policy=policy,
+        device=device,
+    )
+
+    convergence_radii = [float(r.strip()) for r in args.convergence_radii.split(",")]
+
+    print(f"Evaluating on {len(paths)} full-length paths "
+          f"(radii={convergence_radii})...")
+    per_path = []
+    for i, path in enumerate(tqdm.tqdm(paths)):
+        result = evaluate_path(
+            aggregator=aggregator,
+            grid_spec=grid_spec,
+            mapping=mapping,
+            vigor_dataset=vigor_dataset,
+            path=path,
+            motion_noise_frac=args.motion_noise_frac,
+            convergence_radii=convergence_radii,
+            converge_threshold=args.converge_threshold,
+            odometry_noise=odometry_noise,
+            odometry_seed=args.seed * (i + 1) if odometry_noise else None,
+            device=device,
+        )
+        per_path.append(result)
+
+    errs = [r["final_error_m"] for r in per_path]
+    si_means = [r["sigma_img_mean"] for r in per_path]
+    si_stds = [r["sigma_img_std"] for r in per_path]
+    sl_means = [r["sigma_lm_mean"] for r in per_path]
+    sl_stds = [r["sigma_lm_std"] for r in per_path]
+    a_means = [r["alpha_mean"] for r in per_path]
+    a_stds = [r["alpha_std"] for r in per_path]
+
+    summary = {
+        "num_paths": len(paths),
+        "mean_final_error_m": float(np.mean(errs)),
+        "mean_sigma_img_per_path_mean": float(np.mean(si_means)),
+        "mean_sigma_img_per_path_std": float(np.mean(si_stds)),
+        "std_sigma_img_across_paths": float(np.std(si_means)),
+        "mean_sigma_lm_per_path_mean": float(np.mean(sl_means)),
+        "mean_sigma_lm_per_path_std": float(np.mean(sl_stds)),
+        "std_sigma_lm_across_paths": float(np.std(sl_means)),
+        "mean_alpha_per_path_mean": float(np.mean(a_means)),
+        "mean_alpha_per_path_std": float(np.mean(a_stds)),
+        "std_alpha_across_paths": float(np.std(a_means)),
+    }
+    for r in convergence_radii:
+        rkey = int(r)
+        costs_r = [p[f"convergence_cost_{rkey}m"] for p in per_path]
+        steps_r = [
+            p[f"steps_to_converge_{rkey}m"] for p in per_path
+            if p[f"steps_to_converge_{rkey}m"] is not None
+        ]
+        summary[f"mean_convergence_cost_{rkey}m"] = float(np.mean(costs_r))
+        summary[f"median_convergence_cost_{rkey}m"] = float(np.median(costs_r))
+        summary[f"frac_paths_converged_{rkey}m"] = len(steps_r) / max(len(paths), 1)
+        summary[f"mean_steps_to_converge_{rkey}m"] = (
+            float(np.mean(steps_r)) if steps_r else float("nan")
+        )
+    with open(output_path / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+    with open(output_path / "per_path.json", "w") as f:
+        json.dump(per_path, f, indent=2)
+
+    print("\n=== Summary ===")
+    for k, v in summary.items():
+        if isinstance(v, float):
+            print(f"  {k}: {v:.4f}")
+        else:
+            print(f"  {k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
+++ b/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
@@ -133,6 +133,12 @@ def build_raw_cost_data(args) -> cm.RawCorrespondenceData:
     print(f"  Total: {len(pano_tags_from_pano_id)} panoramas with tags")
 
     print("Precomputing raw cost matrix data...")
+    cost_matrix_memmap_path = None
+    if args.stream_cost_matrix:
+        cost_matrix_memmap_path = (
+            args.output_path.expanduser().resolve().parent
+            / (args.output_path.stem + "_cost_matrix.npy")
+        )
     return cm.precompute_raw_cost_data(
         model=model,
         text_embeddings=text_embeddings,
@@ -141,17 +147,36 @@ def build_raw_cost_data(args) -> cm.RawCorrespondenceData:
         pano_tags_from_pano_id=pano_tags_from_pano_id,
         device=device,
         allow_missing_text_embeddings=args.allow_missing_text_embeddings,
+        cost_matrix_memmap_path=cost_matrix_memmap_path,
     )
 
 
-def save_raw_cost_data(raw: cm.RawCorrespondenceData, output_path: Path) -> None:
-    """Write raw data as .npy (cost matrix) + .pt (metadata)."""
+def save_raw_cost_data(
+    raw: cm.RawCorrespondenceData,
+    output_path: Path,
+    model_path: Path,
+    text_embeddings_path: Path,
+) -> None:
+    """Write raw data as .npy (cost matrix) + .pt (metadata).
+
+    If `raw.cost_matrix` is already a memmap (stream-to-disk path), it has
+    been written in-place at the canonical location and we skip the np.save.
+
+    `model_path` and `text_embeddings_path` are recorded in the .pt for
+    provenance — they are the inputs that produced this cost matrix.
+    """
     cost_npy_path = output_path.parent / (output_path.stem + "_cost_matrix.npy")
-    print(f"Saving cost matrix ({raw.cost_matrix.shape}) to {cost_npy_path}...")
-    np.save(cost_npy_path, raw.cost_matrix)
+    if isinstance(raw.cost_matrix, np.memmap):
+        print(f"Cost matrix already streamed to {cost_npy_path} "
+              f"(shape={raw.cost_matrix.shape}); skipping np.save.")
+    else:
+        print(f"Saving cost matrix ({raw.cost_matrix.shape}) to {cost_npy_path}...")
+        np.save(cost_npy_path, raw.cost_matrix)
 
     save_dict = {
         "cost_matrix_path": str(cost_npy_path),
+        "model_path": str(Path(model_path).expanduser().resolve()),
+        "text_embeddings_path": str(Path(text_embeddings_path).expanduser().resolve()),
         "pano_id_to_lm_rows": raw.pano_id_to_lm_rows,
         "pano_lm_tags": raw.pano_lm_tags,
         "osm_lm_indices": raw.osm_lm_indices,
@@ -169,8 +194,8 @@ def load_raw_cost_data(raw_path: Path) -> cm.RawCorrespondenceData:
         cost_matrix = data["cost_matrix"]
     else:
         cost_npy = data["cost_matrix_path"]
-        print(f"  Loading cost matrix from {cost_npy}")
-        cost_matrix = np.load(cost_npy)
+        print(f"  Memory-mapping cost matrix from {cost_npy}")
+        cost_matrix = np.load(cost_npy, mmap_mode="r")
     return cm.RawCorrespondenceData(
         cost_matrix=cost_matrix,
         pano_id_to_lm_rows=data["pano_id_to_lm_rows"],
@@ -231,6 +256,12 @@ def main():
     parser.add_argument("--allow_missing_text_embeddings", action="store_true",
                         help="Silently substitute zero vectors for text values "
                              "not found in the embeddings pickle. Not recommended.")
+    parser.add_argument("--stream_cost_matrix", action="store_true",
+                        help="Stream the cost matrix directly to a memmapped "
+                             ".npy on disk during precompute, instead of "
+                             "accumulating rows in RAM and vstack'ing at the "
+                             "end. Required for cities whose cost matrix "
+                             "exceeds available RAM (e.g. NewYork at ~25 GB).")
     args = parser.parse_args()
 
     dataset_path = args.dataset_path.expanduser().resolve()
@@ -242,7 +273,7 @@ def main():
         raw = load_raw_cost_data(args.from_raw.expanduser().resolve())
     else:
         raw = build_raw_cost_data(args)
-        save_raw_cost_data(raw, output_path)
+        save_raw_cost_data(raw, output_path, args.model_path, args.text_embeddings_path)
 
     print(
         f"  {raw.cost_matrix.shape[0]} pano landmarks × "

--- a/experimental/overhead_matching/swag/scripts/grid_search_convergence.py
+++ b/experimental/overhead_matching/swag/scripts/grid_search_convergence.py
@@ -1,0 +1,417 @@
+"""Grid-search constant (σ_img, σ_lm) directly against trajectory convergence cost.
+
+This is the "oracle constant-σ" baseline that the per-step learned policy
+must beat.  It complements :mod:`calibrate_sigma` (per-pair NLL) and
+:mod:`calibrate_fusion_sigma` (joint NLL on EA fused softmax) by optimizing
+the *trajectory-level* metric the production filter actually cares about
+(see ``compute_convergence_cost`` in
+``experimental/overhead_matching/swag/evaluation/convergence_metrics.py``).
+
+For each grid point we instantiate an :class:`EntropyAdaptiveAggregator`,
+run the existing histogram filter rollout on every Seattle path, and
+accumulate per-trajectory metrics:
+
+  * Mean convergence cost at a given radius (lower is better)
+  * Mean steps-to-converge (first step where prob_mass ≥ threshold)
+  * Mean final position error (mean estimator and MAP estimator)
+
+Outputs:
+
+  * ``grid_search_results.json`` — flat list of one entry per (σ_img, σ_lm)
+  * ``grid_heatmap_<radius>.png`` — convergence-cost heatmap per radius
+
+This script intentionally does **not** save per-path tensors to disk: with a
+5×5 grid that's 25× the disk usage of one ``evaluate_histogram_on_paths`` run
+and we only need the aggregate metrics.
+"""
+
+from dataclasses import asdict
+from pathlib import Path
+import argparse
+import itertools
+import json
+
+import common.torch.load_torch_deps  # noqa: F401  (must precede torch import)
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+import tqdm
+
+from experimental.overhead_matching.swag.scripts.evaluate_histogram_on_paths import (
+    HistogramFilterConfig,
+    construct_path_eval_inputs_from_args,
+    get_dataset_bounds,
+    get_patch_positions_px,
+    run_histogram_filter_on_path,
+)
+from experimental.overhead_matching.swag.filter.histogram_belief import (
+    GridSpec,
+    HistogramBelief,
+    build_cell_to_patch_mapping,
+)
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    EntropyAdaptiveAggregator,
+    _load_similarity_matrix,
+)
+from experimental.overhead_matching.swag.evaluation.convergence_metrics import (
+    compute_convergence_cost,
+)
+from experimental.overhead_matching.swag.evaluation.odometry_noise import (
+    OdometryNoiseConfig,
+    add_noise_to_motion_deltas,
+)
+import experimental.overhead_matching.swag.evaluation.evaluate_swag as es
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from common.gps import web_mercator
+from common.math.haversine import find_d_on_unit_circle
+
+
+def parse_sigma_list(s: str) -> list[float]:
+    return [float(x.strip()) for x in s.split(",") if x.strip()]
+
+
+def steps_to_converge(prob_mass: torch.Tensor, threshold: float) -> int | None:
+    """Return the first step index where prob_mass ≥ threshold, or None.
+
+    `prob_mass` is the (path_len + 1,) tensor recorded after each observation
+    update by ``run_histogram_filter_on_path``.
+    """
+    above = prob_mass >= threshold
+    if not above.any():
+        return None
+    return int(above.float().argmax().item())
+
+
+def final_error_meters(
+    vigor_dataset: vd.VigorDataset,
+    path: list[str],
+    estimate_history: torch.Tensor,
+) -> float:
+    """Final-step distance error in meters between estimate and ground truth."""
+    true_latlon = vigor_dataset.get_panorama_positions(path).to(estimate_history.device)
+    estimates = estimate_history[-len(path):]
+    d = vd.EARTH_RADIUS_M * find_d_on_unit_circle(true_latlon[-1], estimates[-1])
+    return float(d.item())
+
+
+def evaluate_one_sigma_pair(
+    vigor_dataset,
+    paths,
+    grid_spec,
+    mapping,
+    img_sim_matrix,
+    lm_sim_matrix,
+    sigma_img: float,
+    sigma_lm: float,
+    config: HistogramFilterConfig,
+    convergence_radii: list[int],
+    converge_threshold: float,
+    seed: int,
+    device: torch.device,
+):
+    """Run the histogram filter on every path with a constant (σ_img, σ_lm)."""
+    aggregator = EntropyAdaptiveAggregator(
+        image_similarity_matrix=img_sim_matrix,
+        landmark_similarity_matrix=lm_sim_matrix,
+        panorama_metadata=vigor_dataset._panorama_metadata,
+        image_sigma=sigma_img,
+        landmark_sigma=sigma_lm,
+        device=device,
+    )
+
+    convergence_costs_by_radius: dict[int, list[float]] = {r: [] for r in convergence_radii}
+    steps_to_converge_by_radius: dict[int, list[int | None]] = {
+        r: [] for r in convergence_radii
+    }
+    final_errors = []
+    final_mode_errors = []
+
+    for i, path in enumerate(paths):
+        generator_seed = seed * (i + 1)
+
+        belief = HistogramBelief.from_uniform(grid_spec=grid_spec, device=device)
+        motion_deltas = es.get_motion_deltas_from_path(vigor_dataset, path).to(device)
+
+        if config.odometry_noise is not None:
+            start_latlon = vigor_dataset.get_panorama_positions(path)[0].to(device)
+            noise_gen = torch.Generator(device="cpu").manual_seed(
+                config.odometry_noise.seed * (i + 1)
+            )
+            motion_deltas = add_noise_to_motion_deltas(
+                motion_deltas.cpu(), start_latlon.cpu(), config.odometry_noise,
+                generator=noise_gen,
+            ).to(device)
+
+        true_latlons = vigor_dataset.get_panorama_positions(path).to(device)
+
+        result = run_histogram_filter_on_path(
+            belief=belief,
+            motion_deltas=motion_deltas,
+            path_pano_ids=path,
+            log_likelihood_aggregator=aggregator,
+            mapping=mapping,
+            config=config,
+            true_latlons=true_latlons,
+            convergence_radii=convergence_radii,
+        )
+
+        distance_traveled_m = es.compute_distance_traveled(vigor_dataset, path)
+        for radius in convergence_radii:
+            prob_mass = result.prob_mass_by_radius[radius]
+            convergence_costs_by_radius[radius].append(
+                compute_convergence_cost(prob_mass, distance_traveled_m)
+            )
+            steps_to_converge_by_radius[radius].append(
+                steps_to_converge(prob_mass, converge_threshold)
+            )
+
+        final_errors.append(final_error_meters(vigor_dataset, path, result.mean_history))
+        final_mode_errors.append(
+            final_error_meters(vigor_dataset, path, result.mode_history)
+        )
+
+    summary = {
+        "sigma_img": sigma_img,
+        "sigma_lm": sigma_lm,
+        "num_paths": len(paths),
+        "mean_final_error_m": float(np.mean(final_errors)),
+        "mean_final_mode_error_m": float(np.mean(final_mode_errors)),
+    }
+    for radius in convergence_radii:
+        costs = convergence_costs_by_radius[radius]
+        summary[f"mean_convergence_cost_{radius}m"] = float(np.mean(costs))
+        summary[f"median_convergence_cost_{radius}m"] = float(np.median(costs))
+        # steps-to-converge: report mean and fraction-converged (as a path-level
+        # binary that we can read alongside).
+        steps = steps_to_converge_by_radius[radius]
+        converged = [s for s in steps if s is not None]
+        summary[f"frac_paths_converged_{radius}m"] = (
+            len(converged) / len(steps) if steps else 0.0
+        )
+        summary[f"mean_steps_to_converge_{radius}m"] = (
+            float(np.mean(converged)) if converged else float("nan")
+        )
+    return summary
+
+
+def plot_heatmap(
+    sigmas_img: list[float],
+    sigmas_lm: list[float],
+    values: np.ndarray,
+    title: str,
+    output_path: Path,
+    annotate_min: bool = True,
+) -> None:
+    """Pcolormesh of `values` (shape: K_img × K_lm) on log-scaled σ axes."""
+    fig, ax = plt.subplots(figsize=(8.5, 6.5))
+    si = np.array(sigmas_img)
+    sl = np.array(sigmas_lm)
+    pcm = ax.pcolormesh(si, sl, values.T, shading="auto", cmap="viridis")
+    cb = plt.colorbar(pcm, ax=ax)
+    cb.set_label(title.split(" — ")[-1] if " — " in title else "value")
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlabel("σ_img")
+    ax.set_ylabel("σ_lm")
+    if annotate_min:
+        flat = int(np.argmin(values))
+        bi, bl = flat // values.shape[1], flat % values.shape[1]
+        ax.scatter(
+            [si[bi]], [sl[bl]], marker="*", color="white", edgecolor="red",
+            s=240, lw=1.5, zorder=5,
+            label=f"min ({si[bi]:.4f}, {sl[bl]:.4f}) = {values[bi, bl]:.3f}",
+        )
+        ax.legend(loc="upper right", fontsize=9)
+    ax.set_title(title)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=130)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths-path", type=str, required=True,
+                        help="JSON file produced by create_evaluation_paths.")
+    parser.add_argument("--dataset-path", type=str, required=True)
+    parser.add_argument("--landmark-version", type=str, required=True)
+    parser.add_argument("--img-sim-path", type=str, required=True)
+    parser.add_argument("--lm-sim-path", type=str, required=True)
+    parser.add_argument("--output-path", type=str, required=True)
+    parser.add_argument(
+        "--sigmas-img", type=str, default="0.05,0.10,0.13,0.19,0.25",
+        help="Comma-separated σ_img values.")
+    parser.add_argument(
+        "--sigmas-lm", type=str, default="0.13,0.20,0.26,0.40,0.53",
+        help="Comma-separated σ_lm values.")
+    parser.add_argument(
+        "--convergence-radii", type=str, default="25,50,100",
+        help="Comma-separated radii (meters) for convergence cost.")
+    parser.add_argument(
+        "--converge-threshold", type=float, default=0.5,
+        help="prob_mass threshold for steps-to-converge.")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--motion-noise-frac", type=float, default=0.05,
+                        help="Wiener filter noise (m/√m).")
+    parser.add_argument("--subdivision-factor", type=int, default=4)
+    parser.add_argument("--max-chunk-gib", type=float, default=2.0)
+    parser.add_argument("--panorama-neighbor-radius-deg", type=float, default=0.0005)
+    parser.add_argument("--panorama-landmark-radius-px", type=int, default=640)
+    parser.add_argument("--odometry-noise-frac", type=float, default=None)
+    parser.add_argument("--odometry-noise-seed", type=int, default=7919)
+    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument(
+        "--max-paths", type=int, default=None,
+        help="Subsample to the first N paths (for quick smoke tests).")
+    args = parser.parse_args()
+
+    output_path = Path(args.output_path).expanduser()
+    output_path.mkdir(parents=True, exist_ok=True)
+    with open(output_path / "args.json", "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    device = torch.device(args.device)
+    sigmas_img = parse_sigma_list(args.sigmas_img)
+    sigmas_lm = parse_sigma_list(args.sigmas_lm)
+    convergence_radii = [int(r.strip()) for r in args.convergence_radii.split(",")]
+
+    print(f"Loading dataset metadata + path set from {args.paths_path}")
+    vigor_dataset, _, _, paths_data = construct_path_eval_inputs_from_args(
+        dataset_path=args.dataset_path,
+        paths_path=args.paths_path,
+        panorama_neighbor_radius_deg=args.panorama_neighbor_radius_deg,
+        panorama_landmark_radius_px=args.panorama_landmark_radius_px,
+        device=device,
+        landmark_version=args.landmark_version,
+    )
+    paths = paths_data["paths"]
+    if args.max_paths is not None:
+        paths = paths[: args.max_paths]
+    print(f"  {len(paths)} paths, dataset factor={paths_data.get('args', {}).get('factor', 1.0)}")
+
+    print(f"Loading image similarity matrix from {args.img_sim_path}")
+    img_sim = _load_similarity_matrix(Path(args.img_sim_path))
+    print(f"  shape: {tuple(img_sim.shape)}")
+    print(f"Loading landmark similarity matrix from {args.lm_sim_path}")
+    lm_sim = _load_similarity_matrix(Path(args.lm_sim_path))
+    print(f"  shape: {tuple(lm_sim.shape)}")
+    assert img_sim.shape == lm_sim.shape, (
+        f"shape mismatch: img {tuple(img_sim.shape)} vs lm {tuple(lm_sim.shape)}")
+
+    # Read source_px from satellite_bbox.json if available (matches
+    # evaluate_histogram_on_paths' main()).
+    source_px = None
+    sat_bbox_path = Path(args.dataset_path) / "satellite_bbox.json"
+    if sat_bbox_path.exists():
+        with open(sat_bbox_path) as f:
+            sat_bbox = json.load(f)
+        source_px = sat_bbox.get("source_px")
+
+    odometry_noise_config = None
+    if args.odometry_noise_frac is not None:
+        odometry_noise_config = OdometryNoiseConfig(
+            sigma_noise_frac=args.odometry_noise_frac, seed=args.odometry_noise_seed,
+        )
+
+    config = HistogramFilterConfig(
+        motion_noise_frac=args.motion_noise_frac,
+        subdivision_factor=args.subdivision_factor,
+        source_px=source_px,
+        odometry_noise=odometry_noise_config,
+        max_chunk_gib=args.max_chunk_gib,
+    )
+
+    # Build grid + cell-to-patch mapping ONCE (expensive).
+    print("Building grid spec and cell-to-patch mapping (one-time setup)...")
+    min_lat, max_lat, min_lon, max_lon = get_dataset_bounds(vigor_dataset)
+    footprint_px = config.footprint_px
+    cell_size_px = footprint_px / config.subdivision_factor
+    patch_half_size_px = footprint_px / 2.0
+    center_lat = (min_lat + max_lat) / 2
+    ref_y, ref_x = web_mercator.latlon_to_pixel_coords(
+        center_lat, min_lon, config.zoom_level
+    )
+    buf_lat, _ = web_mercator.pixel_coords_to_latlon(
+        ref_y - patch_half_size_px, ref_x, config.zoom_level
+    )
+    _, buf_lon = web_mercator.pixel_coords_to_latlon(
+        ref_y, ref_x + patch_half_size_px, config.zoom_level
+    )
+    grid_spec = GridSpec.from_bounds_and_cell_size(
+        min_lat=min_lat - (buf_lat - center_lat),
+        max_lat=max_lat + (buf_lat - center_lat),
+        min_lon=min_lon - (buf_lon - min_lon),
+        max_lon=max_lon + (buf_lon - min_lon),
+        zoom_level=config.zoom_level,
+        cell_size_px=cell_size_px,
+    )
+    print(f"  grid {grid_spec.num_rows}x{grid_spec.num_cols}, "
+          f"cell_size_px={cell_size_px:.0f}")
+    patch_positions_px = get_patch_positions_px(vigor_dataset, device)
+    mapping = build_cell_to_patch_mapping(
+        grid_spec=grid_spec,
+        patch_positions_px=patch_positions_px,
+        patch_half_size_px=patch_half_size_px,
+        device=device,
+        max_chunk_bytes=int(config.max_chunk_gib * 1024**3),
+    )
+    print(f"  built mapping with {len(mapping.patch_indices)} overlaps")
+
+    K_img, K_lm = len(sigmas_img), len(sigmas_lm)
+    print(f"Sweeping {K_img}x{K_lm} = {K_img * K_lm} (σ_img, σ_lm) pairs over "
+          f"{len(paths)} paths each...")
+
+    results = []
+    with torch.no_grad():
+        for sigma_img, sigma_lm in tqdm.tqdm(
+            list(itertools.product(sigmas_img, sigmas_lm))
+        ):
+            summary = evaluate_one_sigma_pair(
+                vigor_dataset=vigor_dataset,
+                paths=paths,
+                grid_spec=grid_spec,
+                mapping=mapping,
+                img_sim_matrix=img_sim,
+                lm_sim_matrix=lm_sim,
+                sigma_img=sigma_img,
+                sigma_lm=sigma_lm,
+                config=config,
+                convergence_radii=convergence_radii,
+                converge_threshold=args.converge_threshold,
+                seed=args.seed,
+                device=device,
+            )
+            results.append(summary)
+
+    with open(output_path / "grid_search_results.json", "w") as f:
+        json.dump(results, f, indent=2)
+
+    # Per-radius heatmaps and best-pair summary.
+    best_per_radius = {}
+    for radius in convergence_radii:
+        costs = np.array([
+            r[f"mean_convergence_cost_{radius}m"] for r in results
+        ]).reshape(K_img, K_lm)
+        plot_heatmap(
+            sigmas_img, sigmas_lm, costs,
+            title=f"Mean convergence cost @ {radius}m — Seattle (n={len(paths)} paths)",
+            output_path=output_path / f"grid_heatmap_{radius}m.png",
+        )
+        flat = int(np.argmin(costs))
+        bi, bl = flat // K_lm, flat % K_lm
+        best_per_radius[radius] = {
+            "sigma_img": sigmas_img[bi],
+            "sigma_lm": sigmas_lm[bl],
+            "mean_convergence_cost": float(costs[bi, bl]),
+        }
+        print(f"  radius={radius}m: best (σ_img, σ_lm) = "
+              f"({sigmas_img[bi]:.4f}, {sigmas_lm[bl]:.4f}), "
+              f"mean_cost = {costs[bi, bl]:.3f}")
+
+    with open(output_path / "best_per_radius.json", "w") as f:
+        json.dump(best_per_radius, f, indent=2)
+
+    print(f"\nDone. Outputs in {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/landmark_residual_exploration.py
+++ b/experimental/overhead_matching/swag/scripts/landmark_residual_exploration.py
@@ -1,0 +1,395 @@
+"""Cross-city exploration of landmark-similarity residuals.
+
+For each of Chicago / Seattle / NewYork / post-hurricane-ian, load the v6
+Hungarian landmark similarity matrix, walk the panorama metadata to gather
+per-pair (pano, true_patch) samples + sampled negatives, and build the per-
+pair residual statistics under two parameterizations:
+
+  - raw residual:        ``r_raw  = sim_max - sim_t``
+  - normalized residual: ``r_norm = 1 - sim_t / sim_max``  (the user's
+    proposed normalization for the new fusion aggregator)
+
+Emits five figures into ``--output-path`` and prints σ_MLE / σ_median per
+city. The headline plot is ``normalized_true_residual_overlay.png`` — if
+the four cities overlap closely, the normalization is transfer-friendly and
+we can pick a single σ_lm.
+
+All-zero (or otherwise constant) landmark rows are excluded from per-pair
+sampling — they're handled by an image-only fall-through in the aggregator
+itself.
+"""
+
+from pathlib import Path
+import argparse
+import json
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+
+
+CITY_DEFAULTS: dict[str, dict] = {
+    "Chicago": {
+        "dataset_path": "/data/overhead_matching/datasets/VIGOR/Chicago",
+        "lm_sim_path": "/data/overhead_matching/datasets/VIGOR/Chicago/"
+                       "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt",
+        "landmark_version": "v4_202001",
+    },
+    "Seattle": {
+        "dataset_path": "/data/overhead_matching/datasets/VIGOR/Seattle",
+        "lm_sim_path": "/data/overhead_matching/datasets/VIGOR/Seattle/"
+                       "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt",
+        "landmark_version": "v4_202001",
+    },
+    "NewYork": {
+        "dataset_path": "/data/overhead_matching/datasets/VIGOR/NewYork",
+        "lm_sim_path": "/data/overhead_matching/datasets/VIGOR/NewYork/"
+                       "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt",
+        "landmark_version": "v4_202001",
+    },
+    "post_hurricane_ian": {
+        "dataset_path": "/data/overhead_matching/datasets/VIGOR/mapillary/post_hurricane_ian",
+        "lm_sim_path": "/data/overhead_matching/datasets/VIGOR/mapillary/"
+                       "post_hurricane_ian/similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt",
+        "landmark_version": "post_hurricane_ian_v1_220101",
+    },
+}
+
+CITY_COLORS = {
+    "Chicago": "C0",
+    "Seattle": "C1",
+    "NewYork": "C2",
+    "post_hurricane_ian": "C3",
+}
+
+
+def load_city(city: str) -> tuple[torch.Tensor, "pd.DataFrame"]:
+    """Load (lm_sim, panorama_metadata) for a city using its defaults."""
+    cfg = CITY_DEFAULTS[city]
+    print(f"  [{city}] loading lm matrix from {cfg['lm_sim_path']}")
+    lm_sim = _load_similarity_matrix(Path(cfg["lm_sim_path"]))
+    ds_cfg = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None,
+        panorama_tensor_cache_info=None,
+        should_load_images=False,
+        should_load_landmarks=False,
+        landmark_version=cfg["landmark_version"],
+    )
+    ds = vd.VigorDataset(Path(cfg["dataset_path"]), ds_cfg)
+    pano_meta = ds._panorama_metadata
+    assert lm_sim.shape[0] == len(pano_meta), (
+        f"[{city}] sim rows {lm_sim.shape[0]} != panoramas {len(pano_meta)}"
+    )
+    return lm_sim, pano_meta
+
+
+def gather_samples(
+    lm_sim: torch.Tensor,
+    pano_meta,
+    include_semipositive: bool = True,
+    num_negatives_per_pano: int = 200,
+    rng_seed: int = 0,
+) -> dict:
+    """Walk panoramas and return per-pair true / negative similarity samples.
+
+    Returns a dict with keys: row_max (per pano), num_zero_rows, num_constant_rows,
+    num_kept_rows, true_sim, true_residual_raw, true_residual_norm,
+    negative_residual_raw, negative_residual_norm.
+    """
+    rng = np.random.default_rng(rng_seed)
+    num_panos = lm_sim.shape[0]
+    num_patches = lm_sim.shape[1]
+
+    row_max_all = torch.full((num_panos,), float("nan"), dtype=torch.float64)
+    true_sim, true_r_raw, true_r_norm = [], [], []
+    neg_r_raw, neg_r_norm = [], []
+    n_zero_rows = 0
+    n_constant_rows = 0
+    n_kept_rows = 0
+    n_no_truepatch = 0
+
+    for pano_idx in range(num_panos):
+        sim_row = lm_sim[pano_idx]
+        finite_mask = torch.isfinite(sim_row)
+        if not finite_mask.any():
+            n_zero_rows += 1
+            continue
+        finite_vals = sim_row[finite_mask]
+        rmax = finite_vals.max().item()
+        rmin = finite_vals.min().item()
+        row_max_all[pano_idx] = rmax
+        if rmax == 0.0:
+            n_zero_rows += 1
+            continue
+        if rmax == rmin:
+            n_constant_rows += 1
+            continue
+
+        row = pano_meta.iloc[pano_idx]
+        true_idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            true_idxs.extend(row["semipositive_satellite_idxs"])
+        if not true_idxs:
+            n_no_truepatch += 1
+            continue
+        true_sims = sim_row[true_idxs]
+        true_finite = true_sims[torch.isfinite(true_sims)]
+        if len(true_finite) == 0:
+            n_no_truepatch += 1
+            continue
+
+        for ts in true_finite.tolist():
+            true_sim.append(ts)
+            true_r_raw.append(rmax - ts)
+            true_r_norm.append(1.0 - ts / rmax)
+
+        n_kept_rows += 1
+
+        # Sample negatives (random patches that aren't true).
+        if num_negatives_per_pano > 0:
+            true_set = set(true_idxs)
+            cand = rng.integers(0, num_patches, size=num_negatives_per_pano * 2)
+            cand = [int(c) for c in cand if int(c) not in true_set][:num_negatives_per_pano]
+            cand_t = torch.tensor(cand, dtype=torch.long)
+            neg_sims = sim_row[cand_t]
+            neg_finite = neg_sims[torch.isfinite(neg_sims)]
+            for ns in neg_finite.tolist():
+                neg_r_raw.append(rmax - ns)
+                neg_r_norm.append(1.0 - ns / rmax)
+
+    return {
+        "row_max_all": row_max_all,
+        "n_zero_rows": n_zero_rows,
+        "n_constant_rows": n_constant_rows,
+        "n_no_truepatch": n_no_truepatch,
+        "n_kept_rows": n_kept_rows,
+        "true_sim": np.asarray(true_sim, dtype=np.float64),
+        "true_r_raw": np.asarray(true_r_raw, dtype=np.float64),
+        "true_r_norm": np.asarray(true_r_norm, dtype=np.float64),
+        "neg_r_raw": np.asarray(neg_r_raw, dtype=np.float64),
+        "neg_r_norm": np.asarray(neg_r_norm, dtype=np.float64),
+    }
+
+
+def plot_row_max_distribution(per_city: dict[str, dict], out: Path) -> None:
+    """Histogram of row-max(lm_sim) across rows, one curve per city."""
+    fig, ax = plt.subplots(figsize=(8, 5.5))
+    bins = np.linspace(0.0, 5.0, 60)
+    for city, samples in per_city.items():
+        rmax = samples["row_max_all"].numpy()
+        rmax = rmax[np.isfinite(rmax)]
+        ax.hist(
+            rmax, bins=bins, histtype="step", lw=1.5,
+            color=CITY_COLORS[city],
+            label=f"{city} "
+                  f"(0-rows={samples['n_zero_rows']}, "
+                  f"const={samples['n_constant_rows']}, "
+                  f"kept={samples['n_kept_rows']})",
+        )
+    ax.set_yscale("log")
+    ax.set_xlabel("row_max(lm_sim) — landmark similarity matrix")
+    ax.set_ylabel("count (log)")
+    ax.set_title("Per-city distribution of landmark row-max\n"
+                 "(rows with row_max=0 are dropped by the new aggregator)")
+    ax.legend(fontsize=8, loc="upper right")
+    fig.tight_layout()
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+
+
+def plot_raw_true_sim_overlay(per_city: dict[str, dict], out: Path) -> None:
+    """Per-pair true similarity (raw, no normalization), one curve per city."""
+    fig, ax = plt.subplots(figsize=(8, 5.5))
+    bins = np.linspace(0.0, 4.0, 80)
+    for city, samples in per_city.items():
+        ts = samples["true_sim"]
+        ax.hist(
+            ts, bins=bins, histtype="step", lw=1.5,
+            color=CITY_COLORS[city],
+            label=f"{city} (n={len(ts)})  "
+                  f"median={np.median(ts):.3f}",
+        )
+    ax.set_yscale("log")
+    ax.set_xlabel("raw landmark similarity at true patches  sim_t")
+    ax.set_ylabel("count (log)")
+    ax.set_title("True-patch raw landmark similarity, per city\n"
+                 "(absolute scale differs across cities — motivates normalization)")
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+
+
+def plot_normalized_true_residual_overlay(per_city: dict[str, dict], out: Path) -> None:
+    """Headline plot: per-city normalized-residual density at true patches."""
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5.5))
+    bins = np.linspace(0.0, 1.0, 60)
+    for ax, scale_name in zip(axes, ["density", "log count"]):
+        for city, samples in per_city.items():
+            r = samples["true_r_norm"]
+            ax.hist(
+                r, bins=bins,
+                density=(scale_name == "density"),
+                histtype="step", lw=1.6,
+                color=CITY_COLORS[city],
+                label=f"{city} (n={len(r)})  σ_MLE={float(np.sqrt(np.mean(r**2))):.3f}  "
+                      f"med={float(np.median(r)):.3f}",
+            )
+        ax.set_xlabel(r"$r_{\rm norm} = 1 - \mathrm{sim}_t / \mathrm{sim}_{\max}$")
+        if scale_name == "log count":
+            ax.set_yscale("log")
+            ax.set_ylabel("count (log)")
+        else:
+            ax.set_ylabel("density")
+        ax.set_title(f"Normalized true-patch residual ({scale_name})")
+        ax.legend(fontsize=8, loc="upper right")
+    fig.suptitle(
+        "HEADLINE: per-city overlap of true-patch residuals AFTER /row_max normalization."
+        " Tight overlap → σ_lm transfers."
+    )
+    fig.tight_layout()
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+
+
+def plot_true_vs_negative_per_city(per_city: dict[str, dict], out: Path) -> None:
+    """2×2 grid (one per city) of true vs negative normalized residuals."""
+    fig, axes = plt.subplots(2, 2, figsize=(13, 9))
+    bins = np.linspace(0.0, 1.0, 60)
+    for ax, (city, samples) in zip(axes.flatten(), per_city.items()):
+        tr = samples["true_r_norm"]
+        nr = samples["neg_r_norm"]
+        ax.hist(tr, bins=bins, color="steelblue", alpha=0.65,
+                label=f"true (n={len(tr)})")
+        ax.hist(nr, bins=bins, histtype="step", color="darkorange", lw=1.5,
+                label=f"negative sample (n={len(nr)})")
+        ax.set_yscale("log")
+        ax.set_ylim(bottom=0.5)
+        ax.set_xlabel(r"$r_{\rm norm} = 1 - \mathrm{sim}/\mathrm{sim}_{\max}$")
+        ax.set_ylabel("count (log)")
+        ax.set_title(f"{city} — separability under /row_max normalization")
+        ax.legend(fontsize=8, loc="upper left")
+    fig.suptitle("Per-city true vs negative normalized residuals")
+    fig.tight_layout()
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+
+
+def plot_sigma_calibration(per_city: dict[str, dict], out: Path) -> tuple[float, float]:
+    """Bar chart of σ_MLE and σ_median (on r_norm) per city. Return cross-city
+    averaged σ_MLE (used as the σ_lm candidate) plus the across-city ratio
+    max/min (for the ±25% transferability check)."""
+    cities = list(per_city.keys())
+    sigma_mles, sigma_medians = [], []
+    for city in cities:
+        r = per_city[city]["true_r_norm"]
+        sigma_mles.append(float(np.sqrt(np.mean(r ** 2))))
+        sigma_medians.append(float(np.median(r)))
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    x = np.arange(len(cities))
+    w = 0.4
+    ax.bar(x - w / 2, sigma_mles, width=w, color="C0", label="σ_MLE")
+    ax.bar(x + w / 2, sigma_medians, width=w, color="C2", label="σ_median")
+    for i, (m, med) in enumerate(zip(sigma_mles, sigma_medians)):
+        ax.text(i - w / 2, m + 0.005, f"{m:.3f}", ha="center", fontsize=8)
+        ax.text(i + w / 2, med + 0.005, f"{med:.3f}", ha="center", fontsize=8)
+    ax.set_xticks(x)
+    ax.set_xticklabels(cities, rotation=15)
+    ax.set_ylabel("σ on r_norm")
+    avg_mle = float(np.mean(sigma_mles))
+    spread = float(np.max(sigma_mles) / max(np.min(sigma_mles), 1e-9))
+    ax.set_title(
+        f"σ on normalized residual r_norm = 1 − sim_t/sim_max\n"
+        f"avg σ_MLE = {avg_mle:.3f}    max/min = {spread:.2f}× "
+        f"(target < 1.25 for transferability)"
+    )
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    return avg_mle, spread
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-path", type=str, required=True)
+    parser.add_argument(
+        "--cities", type=str, default="Chicago,Seattle,NewYork,post_hurricane_ian"
+    )
+    parser.add_argument("--num-negatives-per-pano", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    output_path = Path(args.output_path).expanduser()
+    output_path.mkdir(parents=True, exist_ok=True)
+    cities = [c.strip() for c in args.cities.split(",") if c.strip()]
+
+    print(f"Exploring {len(cities)} cities: {cities}")
+    per_city: dict[str, dict] = {}
+    summary: dict[str, dict] = {}
+    for city in cities:
+        print(f"--- {city} ---")
+        lm_sim, pano_meta = load_city(city)
+        samples = gather_samples(
+            lm_sim, pano_meta,
+            num_negatives_per_pano=args.num_negatives_per_pano,
+            rng_seed=args.seed,
+        )
+        per_city[city] = samples
+        sigma_mle = float(np.sqrt(np.mean(samples["true_r_norm"] ** 2)))
+        sigma_median = float(np.median(samples["true_r_norm"]))
+        sigma_mle_raw = float(np.sqrt(np.mean(samples["true_r_raw"] ** 2)))
+        summary[city] = {
+            "n_panoramas_total": int(lm_sim.shape[0]),
+            "n_zero_or_const_rows": int(samples["n_zero_rows"] + samples["n_constant_rows"]),
+            "n_kept_rows": int(samples["n_kept_rows"]),
+            "n_truepatch_pairs": int(len(samples["true_r_norm"])),
+            "sigma_mle_norm_residual": sigma_mle,
+            "sigma_median_norm_residual": sigma_median,
+            "sigma_mle_raw_residual": sigma_mle_raw,
+        }
+        print(f"  rows total={lm_sim.shape[0]}  "
+              f"zero+const={samples['n_zero_rows'] + samples['n_constant_rows']}  "
+              f"kept={samples['n_kept_rows']}  pairs={len(samples['true_r_norm'])}")
+        print(f"  σ_MLE  (norm r) = {sigma_mle:.4f}  "
+              f"σ_med = {sigma_median:.4f}  σ_MLE (raw r) = {sigma_mle_raw:.4f}")
+
+    print("\nWriting plots and summary...")
+    plot_row_max_distribution(per_city, output_path / "row_max_distribution.png")
+    plot_raw_true_sim_overlay(per_city, output_path / "raw_true_sim_overlay.png")
+    plot_normalized_true_residual_overlay(
+        per_city, output_path / "normalized_true_residual_overlay.png"
+    )
+    plot_true_vs_negative_per_city(
+        per_city, output_path / "true_vs_negative_per_city.png"
+    )
+    avg_mle, spread = plot_sigma_calibration(
+        per_city, output_path / "sigma_calibration.png"
+    )
+
+    summary["__cross_city__"] = {
+        "avg_sigma_mle_norm_residual": avg_mle,
+        "max_over_min_spread": spread,
+        "cities": cities,
+    }
+    with open(output_path / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"\nDone. Outputs in {output_path}")
+    print(f"  Cross-city avg σ_MLE (norm) = {avg_mle:.4f}    "
+          f"max/min spread = {spread:.2f}×")
+    if spread < 1.25:
+        print("  → spread within target (<1.25×) — proceed to Phase B with this σ_lm.")
+    else:
+        print("  → spread above target; normalization may not transfer cleanly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/step_through_histogram.py
+++ b/experimental/overhead_matching/swag/scripts/step_through_histogram.py
@@ -65,7 +65,7 @@ def run_filter_with_history(
     motion_deltas: torch.Tensor,
     path_pano_ids: list[str],
     log_likelihood_aggregator: ObservationLogLikelihoodAggregator,
-    noise_percent: float,
+    motion_noise_frac: float,
 ):
     """Run filter and save belief at each step."""
     belief = initial_belief.clone()
@@ -98,7 +98,7 @@ def run_filter_with_history(
         })
 
         # Motion prediction
-        belief.apply_motion(motion_deltas[step_idx], noise_percent)
+        belief.apply_motion(motion_deltas[step_idx], motion_noise_frac)
         history.append({
             'stage': f'motion_{step_idx}',
             'log_belief': belief.get_log_belief().clone().cpu(),
@@ -133,7 +133,7 @@ def run_filter_lightweight(
     motion_deltas: torch.Tensor,
     path_pano_ids: list[str],
     log_likelihood_aggregator: ObservationLogLikelihoodAggregator,
-    noise_percent: float,
+    motion_noise_frac: float,
 ):
     """Run filter saving summaries per step and full belief at checkpoints.
 
@@ -168,7 +168,7 @@ def run_filter_lightweight(
         step_num += 1
         save_step(f'obs_{step_idx}', step_idx, path_pano_ids[step_idx], obs_log_ll, step_num)
 
-        belief.apply_motion(motion_deltas[step_idx], noise_percent)
+        belief.apply_motion(motion_deltas[step_idx], motion_noise_frac)
         step_num += 1
         save_step(f'motion_{step_idx}', step_idx + 1, path_pano_ids[step_idx + 1], None, step_num)
 
@@ -190,7 +190,7 @@ def replay_filter_to_step(
     motion_deltas: torch.Tensor,
     path_pano_ids: list[str],
     log_likelihood_aggregator: ObservationLogLikelihoodAggregator,
-    noise_percent: float,
+    motion_noise_frac: float,
     target_step: int,
     checkpoints: dict[int, torch.Tensor],
 ):
@@ -241,7 +241,7 @@ def replay_filter_to_step(
         if motion_step > target_step:
             break
         if motion_step > current_step:
-            belief.apply_motion(motion_deltas[step_idx], noise_percent)
+            belief.apply_motion(motion_deltas[step_idx], motion_noise_frac)
             current_step = motion_step
             obs_log_ll = None
             if current_step == target_step:
@@ -351,7 +351,9 @@ def main():
                         help="Path to VIGOR dataset")
     parser.add_argument("--aggregator-config", type=str, required=True,
                         help="Path to YAML config file for aggregator (see adaptive_aggregators.py)")
-    parser.add_argument("--noise-percent", type=float, default=None)
+    parser.add_argument("--motion-noise-frac", type=float, default=None,
+                        help="Wiener noise (m/√m). If unset, falls back to "
+                             "the saved eval's motion_noise_frac.")
     parser.add_argument("--simple", action="store_true",
                         help="Disable new features (pano/patch images, likelihood coloring)")
     parser.add_argument("--lightweight", action="store_true",
@@ -376,10 +378,17 @@ def main():
 
     simple_mode = args.simple
     lightweight_mode = args.lightweight
-    noise_percent = args.noise_percent if args.noise_percent is not None else eval_args.get("noise_percent", 0.02)
+    # Try the new key first, then fall back to the legacy "noise_percent" key
+    # for compatibility with previously-saved eval directories.
+    motion_noise_frac = (
+        args.motion_noise_frac
+        if args.motion_noise_frac is not None
+        else eval_args.get("motion_noise_frac",
+                           eval_args.get("noise_percent", 0.05))
+    )
     subdivision_factor = eval_args.get("subdivision_factor", 4)
 
-    print(f"Config: noise_percent={noise_percent}, subdivision={subdivision_factor}")
+    print(f"Config: motion_noise_frac={motion_noise_frac}, subdivision={subdivision_factor}")
 
     # Load path statistics
     print("Loading path statistics...")
@@ -626,14 +635,14 @@ def main():
                 grid_spec, mapping,
                 HistogramBelief.from_uniform(grid_spec, filter_device),
                 motion_deltas, path,
-                log_likelihood_aggregator, noise_percent
+                log_likelihood_aggregator, motion_noise_frac
             )
         else:
             history = run_filter_with_history(
                 grid_spec, mapping,
                 HistogramBelief.from_uniform(grid_spec, filter_device),
                 motion_deltas, path,
-                log_likelihood_aggregator, noise_percent
+                log_likelihood_aggregator, motion_noise_frac
             )
             checkpoints = {}
 
@@ -743,7 +752,7 @@ def main():
             log_belief, obs_log_ll = replay_filter_to_step(
                 grid_spec, mapping, filter_device,
                 cache['motion_deltas'], cache['path'],
-                log_likelihood_aggregator, noise_percent,
+                log_likelihood_aggregator, motion_noise_frac,
                 step_idx, cache['checkpoints'],
             )
             print(f"  Replay: {_time.time() - _t0:.2f}s")

--- a/experimental/overhead_matching/swag/scripts/train_learned_aggregator.py
+++ b/experimental/overhead_matching/swag/scripts/train_learned_aggregator.py
@@ -1,0 +1,547 @@
+"""End-to-end supervised training of the learned per-step fusion policy.
+
+Roll the differentiable histogram filter forward on Seattle paths, score the
+trajectory by the same convergence-cost formula production uses, and backprop
+through the filter all the way to the policy.
+
+The histogram filter is differentiable when ``apply_observation`` is called
+with ``surrogate_tau`` set (soft-max via segment_logsumexp instead of hard
+max). All other ops in the filter (motion shift, Gaussian blur, normalize)
+are already differentiable.
+
+Outputs (under ``--output-path``):
+
+  * ``policy_weights.pt`` — best-on-validation policy state dict.
+  * ``train_log.json`` — per-iteration losses and validation metrics.
+  * ``train_args.json`` — full CLI args for reproducibility.
+
+Use the trained policy by adding a ``LearnedAggregatorConfig`` to your
+aggregator YAML pointing at ``policy_weights.pt`` — :func:`aggregator_from_config`
+will instantiate the :class:`LearnedAggregator` automatically and the
+existing ``evaluate_histogram_on_paths`` rollout works unchanged.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+import argparse
+import json
+import math
+import random
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import numpy as np
+import tqdm
+
+from common.gps import web_mercator
+from common.gps.web_mercator import get_meters_per_pixel
+from common.math.haversine import find_d_on_unit_circle
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+import experimental.overhead_matching.swag.evaluation.evaluate_swag as es
+from experimental.overhead_matching.swag.evaluation.convergence_metrics import (
+    compute_convergence_cost,
+)
+from experimental.overhead_matching.swag.evaluation.odometry_noise import (
+    OdometryNoiseConfig,
+    add_noise_to_motion_deltas,
+)
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+from experimental.overhead_matching.swag.filter.histogram_belief import (
+    GridSpec,
+    HistogramBelief,
+    build_cell_to_patch_mapping,
+)
+from experimental.overhead_matching.swag.filter.learned_aggregator import (
+    LearnedAggregator,
+    SigmaPolicy,
+    StepContext,
+    HistoryEntry,
+    extract_belief_features,
+)
+from experimental.overhead_matching.swag.scripts.evaluate_histogram_on_paths import (
+    HistogramFilterConfig,
+    construct_path_eval_inputs_from_args,
+    get_dataset_bounds,
+    get_patch_positions_px,
+)
+
+
+# ============ Differentiable convergence reward ============
+
+
+def prob_mass_within_radius_tensor(
+    belief: HistogramBelief,
+    true_latlon: torch.Tensor,
+    radius_meters: float,
+) -> torch.Tensor:
+    """Differentiable analogue of ``compute_probability_mass_within_radius``.
+
+    Returns a 0-D tensor that retains the graph back to belief. The
+    production version calls ``.item()`` and so cannot be used in training.
+    """
+    cell_centers_px = belief.grid_spec.get_all_cell_centers_px(belief.device)
+    true_lat = (
+        true_latlon[0].item() if isinstance(true_latlon[0], torch.Tensor)
+        else float(true_latlon[0])
+    )
+    true_lon = (
+        true_latlon[1].item() if isinstance(true_latlon[1], torch.Tensor)
+        else float(true_latlon[1])
+    )
+    true_y_px, true_x_px = web_mercator.latlon_to_pixel_coords(
+        true_lat, true_lon, belief.grid_spec.zoom_level
+    )
+    true_pos_px = torch.tensor(
+        [[true_y_px, true_x_px]], device=belief.device, dtype=torch.float32
+    )
+    dist_px = torch.norm(cell_centers_px - true_pos_px, dim=1)
+    meters_per_pixel = get_meters_per_pixel(true_lat, belief.grid_spec.zoom_level)
+    dist_meters = dist_px * meters_per_pixel
+    within_mask = dist_meters <= radius_meters
+    return belief.get_belief().flatten()[within_mask].sum()
+
+
+# ============ Path-distance helpers (constant w.r.t. policy) ============
+
+
+def cumulative_distance_meters(
+    vigor_dataset: vd.VigorDataset, path: list[str], device: torch.device
+) -> torch.Tensor:
+    """(path_len,) cumulative distance traveled along the path (in meters)."""
+    pano_positions = vigor_dataset.get_panorama_positions(path).to(device)
+    cum = [torch.tensor(0.0, device=device)]
+    for i in range(len(path) - 1):
+        d = vd.EARTH_RADIUS_M * find_d_on_unit_circle(
+            pano_positions[i], pano_positions[i + 1]
+        )
+        cum.append(cum[-1] + d)
+    return torch.stack(cum)
+
+
+# ============ Rollout that keeps gradients flowing ============
+
+
+@dataclass
+class TrainConfig:
+    motion_noise_frac: float = 0.05
+    subdivision_factor: int = 4
+    surrogate_tau: float = 0.5
+    radius_m: float = 50.0
+    truncate_path_length: int | None = None
+    odometry_noise: OdometryNoiseConfig | None = None
+    max_chunk_gib: float = 2.0
+
+
+def diff_rollout_and_loss(
+    aggregator: LearnedAggregator,
+    grid_spec: GridSpec,
+    mapping,
+    vigor_dataset: vd.VigorDataset,
+    path: list[str],
+    cfg: TrainConfig,
+    device: torch.device,
+    odometry_seed: int | None = None,
+    nll_anchor: dict | None = None,
+) -> tuple[torch.Tensor, dict]:
+    """Differentiable rollout — returns (loss, diagnostics).
+
+    Loss = mean over path-segments of (1 − prob_mass[t]) · Δd[t]   in meters.
+    Optionally adds an NLL-anchor term ``λ · ((logσ_img − logσ_NLL_img)² +
+    (logσ_lm − logσ_NLL_lm)²)`` to keep the policy near the calibration
+    solution and prevent collapse early in training.
+
+    Diagnostics returned (all detached floats):
+      * ``trajectory_convergence_cost``: matches ``compute_convergence_cost``
+      * ``mean_sigma_img``, ``mean_sigma_lm``, ``mean_alpha``
+      * ``final_position_error_m`` (mean estimator)
+    """
+    if cfg.truncate_path_length is not None:
+        path = path[: cfg.truncate_path_length]
+    path_len = len(path)
+    if path_len < 3:
+        zero = torch.tensor(0.0, device=device)
+        return zero, {
+            "trajectory_convergence_cost": 0.0,
+            "mean_sigma_img": 0.0, "mean_sigma_lm": 0.0, "mean_alpha": 0.0,
+            "final_position_error_m": 0.0,
+            "path_len": path_len,
+        }
+
+    # Set up belief and motion deltas (no_grad; these are policy-independent).
+    with torch.no_grad():
+        belief = HistogramBelief.from_uniform(grid_spec=grid_spec, device=device)
+        motion_deltas = es.get_motion_deltas_from_path(vigor_dataset, path).to(device)
+        if cfg.odometry_noise is not None and odometry_seed is not None:
+            start_latlon = vigor_dataset.get_panorama_positions(path)[0].to(device)
+            noise_gen = torch.Generator(device="cpu").manual_seed(odometry_seed)
+            motion_deltas = add_noise_to_motion_deltas(
+                motion_deltas.cpu(), start_latlon.cpu(), cfg.odometry_noise,
+                generator=noise_gen,
+            ).to(device)
+        true_latlons = vigor_dataset.get_panorama_positions(path).to(device)
+        cum_dist = cumulative_distance_meters(vigor_dataset, path, device)
+    delta_d = cum_dist[1:] - cum_dist[:-1]  # (path_len - 1,)
+
+    prob_masses: list[torch.Tensor] = [
+        prob_mass_within_radius_tensor(belief, true_latlons[0], cfg.radius_m)
+    ]
+
+    sigma_imgs, sigma_lms, alphas = [], [], []
+    history_buffer: list[HistoryEntry] = []
+    pano_positions = true_latlons  # alias for clarity
+    pano_count = pano_positions.shape[0]
+
+    def _make_step_ctx(step_idx: int) -> StepContext:
+        norm_step = float(step_idx) / max(path_len - 1, 1)
+        cur_d = float(cum_dist[step_idx].item())
+        step_d = float(
+            cum_dist[step_idx].item() - cum_dist[step_idx - 1].item()
+        ) if step_idx > 0 else 0.0
+        b_entropy, b_log_var, b_top = extract_belief_features(belief)
+        return StepContext(
+            belief_entropy=b_entropy,
+            belief_log_trace_var=b_log_var,
+            belief_top_cell_mass=b_top,
+            belief_step_index_norm=norm_step,
+            norm_cum_distance=cur_d / 5000.0,  # 5km path normalization
+            log_step_distance=math.log(max(step_d, 1.0)),
+            step_idx_over_path_len=norm_step,
+            history=list(history_buffer),
+        )
+
+    def _push_history(step_idx: int, log_ll: torch.Tensor) -> None:
+        """Append the just-applied step to the history buffer."""
+        b_entropy, b_log_var, b_top = extract_belief_features(belief)
+        step_d = float(
+            cum_dist[step_idx].item() - cum_dist[step_idx - 1].item()
+        ) if step_idx > 0 else 0.0
+        history_buffer.append(HistoryEntry(
+            belief_entropy=b_entropy,
+            belief_log_trace_var=b_log_var,
+            belief_top_cell_mass=b_top,
+            log_step_distance=math.log(max(step_d, 1.0)),
+            last_obs_max_log_p=float(log_ll.detach().max().item()),
+        ))
+
+    for step_idx in range(path_len - 1):
+        aggregator.set_step_context(_make_step_ctx(step_idx))
+
+        # Compute fused log-likelihood (in graph).
+        pano_id = path[step_idx]
+        pano_index = aggregator._pano_id_index.get_loc(pano_id)
+        img_row = aggregator.image_similarity_matrix[pano_index].to(device)
+        lm_row = aggregator.landmark_similarity_matrix[pano_index].to(device)
+        log_ll, sigma_img, sigma_lm, alpha = aggregator.fused_log_likelihood(
+            img_row, lm_row
+        )
+        sigma_imgs.append(sigma_img)
+        sigma_lms.append(sigma_lm)
+        alphas.append(alpha)
+
+        belief.apply_observation(log_ll, mapping, surrogate_tau=cfg.surrogate_tau)
+        prob_masses.append(
+            prob_mass_within_radius_tensor(
+                belief, true_latlons[step_idx + 1], cfg.radius_m
+            )
+        )
+        _push_history(step_idx, log_ll)
+        # Motion update (no_grad — motion model is policy-independent).
+        with torch.no_grad():
+            belief.apply_motion(motion_deltas[step_idx], cfg.motion_noise_frac)
+
+    # Final observation step
+    aggregator.set_step_context(_make_step_ctx(path_len - 1))
+    pano_id = path[-1]
+    pano_index = aggregator._pano_id_index.get_loc(pano_id)
+    img_row = aggregator.image_similarity_matrix[pano_index].to(device)
+    lm_row = aggregator.landmark_similarity_matrix[pano_index].to(device)
+    log_ll, sigma_img, sigma_lm, alpha = aggregator.fused_log_likelihood(img_row, lm_row)
+    sigma_imgs.append(sigma_img)
+    sigma_lms.append(sigma_lm)
+    alphas.append(alpha)
+    belief.apply_observation(log_ll, mapping, surrogate_tau=cfg.surrogate_tau)
+    prob_masses.append(
+        prob_mass_within_radius_tensor(belief, true_latlons[-1], cfg.radius_m)
+    )
+
+    prob_mass_t = torch.stack(prob_masses)  # (path_len + 1,)
+    # Match compute_convergence_cost formula exactly:
+    # cost = Σ (1 - prob_mass[t+2]) · Δd[t]   for t in 0..path_len-2.
+    # Note: Δd has path_len-1 entries, prob_mass has path_len+1 entries.
+    missing = 1.0 - prob_mass_t[2:]  # (path_len - 1,)
+    seg_cost = (missing * delta_d).sum()
+    # Normalize by total distance so the loss is on the order of 1, not the
+    # several-thousand-meter trajectory cost.
+    total_distance = delta_d.sum().clamp(min=1.0)
+    loss = seg_cost / total_distance
+
+    if nll_anchor is not None and nll_anchor.get("lambda", 0.0) > 0:
+        lam = nll_anchor["lambda"]
+        log_si_target = math.log(nll_anchor["sigma_img_target"])
+        log_sl_target = math.log(nll_anchor["sigma_lm_target"])
+        si_mean_log = torch.stack([torch.log(s) for s in sigma_imgs]).mean()
+        sl_mean_log = torch.stack([torch.log(s) for s in sigma_lms]).mean()
+        loss = loss + lam * (
+            (si_mean_log - log_si_target) ** 2 + (sl_mean_log - log_sl_target) ** 2
+        )
+
+    diagnostics = {
+        "trajectory_convergence_cost": float(seg_cost.detach().item()),
+        "mean_sigma_img": float(torch.stack(sigma_imgs).mean().detach().item()),
+        "mean_sigma_lm": float(torch.stack(sigma_lms).mean().detach().item()),
+        "mean_alpha": float(torch.stack(alphas).mean().detach().item()),
+        "final_position_error_m": 0.0,  # filled by caller if asked
+        "path_len": path_len,
+        "total_distance_m": float(total_distance.detach().item()),
+    }
+    return loss, diagnostics
+
+
+# ============ Top-level training loop ============
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths-path", type=str, required=True)
+    parser.add_argument("--dataset-path", type=str, required=True)
+    parser.add_argument("--landmark-version", type=str, required=True)
+    parser.add_argument("--img-sim-path", type=str, required=True)
+    parser.add_argument("--lm-sim-path", type=str, required=True)
+    parser.add_argument("--output-path", type=str, required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--num-iters", type=int, default=200)
+    parser.add_argument("--batch-paths", type=int, default=4)
+    parser.add_argument("--val-frac", type=float, default=0.1)
+    parser.add_argument("--val-every", type=int, default=20)
+    parser.add_argument("--max-paths", type=int, default=None,
+                        help="Subsample to first N paths (for smoke runs).")
+    parser.add_argument("--truncate-path-length", type=int, default=100,
+                        help="Truncate each path to N steps for speed.")
+    parser.add_argument("--surrogate-tau", type=float, default=0.5)
+    parser.add_argument("--radius-m", type=float, default=50.0)
+    parser.add_argument("--motion-noise-frac", type=float, default=0.05)
+    parser.add_argument("--subdivision-factor", type=int, default=4)
+    parser.add_argument("--max-chunk-gib", type=float, default=2.0)
+    parser.add_argument("--panorama-neighbor-radius-deg", type=float, default=0.0005)
+    parser.add_argument("--panorama-landmark-radius-px", type=int, default=640)
+    parser.add_argument("--nll-anchor-lambda", type=float, default=0.01)
+    parser.add_argument("--nll-anchor-sigma-img", type=float, default=0.05)
+    parser.add_argument("--nll-anchor-sigma-lm", type=float, default=0.13)
+    parser.add_argument("--grad-clip-norm", type=float, default=1.0)
+    parser.add_argument("--odometry-noise-frac", type=float, default=None)
+    parser.add_argument("--odometry-noise-seed", type=int, default=7919)
+    args = parser.parse_args()
+
+    output_path = Path(args.output_path).expanduser()
+    output_path.mkdir(parents=True, exist_ok=True)
+    with open(output_path / "train_args.json", "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    random.seed(args.seed)
+    device = torch.device(args.device)
+
+    # ------ Data ------
+    print(f"Loading dataset / paths from {args.paths_path}")
+    vigor_dataset, _, _, paths_data = construct_path_eval_inputs_from_args(
+        dataset_path=args.dataset_path,
+        paths_path=args.paths_path,
+        panorama_neighbor_radius_deg=args.panorama_neighbor_radius_deg,
+        panorama_landmark_radius_px=args.panorama_landmark_radius_px,
+        device=device,
+        landmark_version=args.landmark_version,
+    )
+    paths = paths_data["paths"]
+    if args.max_paths is not None:
+        paths = paths[: args.max_paths]
+    rng = random.Random(args.seed)
+    rng.shuffle(paths)
+    n_val = max(1, int(len(paths) * args.val_frac))
+    val_paths = paths[:n_val]
+    train_paths = paths[n_val:]
+    print(f"  train: {len(train_paths)} paths, val: {len(val_paths)} paths")
+
+    print("Loading similarity matrices...")
+    img_sim = _load_similarity_matrix(Path(args.img_sim_path))
+    lm_sim = _load_similarity_matrix(Path(args.lm_sim_path))
+    assert img_sim.shape == lm_sim.shape, "img/lm similarity shape mismatch"
+
+    # ------ Filter setup (expensive, do once) ------
+    source_px = None
+    sat_bbox_path = Path(args.dataset_path) / "satellite_bbox.json"
+    if sat_bbox_path.exists():
+        with open(sat_bbox_path) as f:
+            source_px = json.load(f).get("source_px")
+
+    odometry_noise = None
+    if args.odometry_noise_frac is not None:
+        odometry_noise = OdometryNoiseConfig(
+            sigma_noise_frac=args.odometry_noise_frac, seed=args.odometry_noise_seed,
+        )
+
+    train_cfg = TrainConfig(
+        motion_noise_frac=args.motion_noise_frac,
+        subdivision_factor=args.subdivision_factor,
+        surrogate_tau=args.surrogate_tau,
+        radius_m=args.radius_m,
+        truncate_path_length=args.truncate_path_length,
+        odometry_noise=odometry_noise,
+        max_chunk_gib=args.max_chunk_gib,
+    )
+    hist_cfg = HistogramFilterConfig(
+        motion_noise_frac=args.motion_noise_frac,
+        subdivision_factor=args.subdivision_factor,
+        source_px=source_px,
+        max_chunk_gib=args.max_chunk_gib,
+    )
+
+    print("Building grid spec + cell-to-patch mapping...")
+    min_lat, max_lat, min_lon, max_lon = get_dataset_bounds(vigor_dataset)
+    footprint_px = hist_cfg.footprint_px
+    cell_size_px = footprint_px / hist_cfg.subdivision_factor
+    patch_half_size_px = footprint_px / 2.0
+    center_lat = (min_lat + max_lat) / 2
+    ref_y, ref_x = web_mercator.latlon_to_pixel_coords(
+        center_lat, min_lon, hist_cfg.zoom_level
+    )
+    buf_lat, _ = web_mercator.pixel_coords_to_latlon(
+        ref_y - patch_half_size_px, ref_x, hist_cfg.zoom_level
+    )
+    _, buf_lon = web_mercator.pixel_coords_to_latlon(
+        ref_y, ref_x + patch_half_size_px, hist_cfg.zoom_level
+    )
+    grid_spec = GridSpec.from_bounds_and_cell_size(
+        min_lat=min_lat - (buf_lat - center_lat),
+        max_lat=max_lat + (buf_lat - center_lat),
+        min_lon=min_lon - (buf_lon - min_lon),
+        max_lon=max_lon + (buf_lon - min_lon),
+        zoom_level=hist_cfg.zoom_level,
+        cell_size_px=cell_size_px,
+    )
+    patch_positions_px = get_patch_positions_px(vigor_dataset, device)
+    mapping = build_cell_to_patch_mapping(
+        grid_spec=grid_spec,
+        patch_positions_px=patch_positions_px,
+        patch_half_size_px=patch_half_size_px,
+        device=device,
+        max_chunk_bytes=int(hist_cfg.max_chunk_gib * 1024 ** 3),
+    )
+
+    # ------ Policy + aggregator ------
+    policy = SigmaPolicy().to(device)
+    aggregator = LearnedAggregator(
+        image_similarity_matrix=img_sim,
+        landmark_similarity_matrix=lm_sim,
+        panorama_metadata=vigor_dataset._panorama_metadata,
+        policy=policy,
+        device=device,
+    )
+    optim = torch.optim.Adam(policy.parameters(), lr=args.lr)
+
+    nll_anchor = {
+        "lambda": args.nll_anchor_lambda,
+        "sigma_img_target": args.nll_anchor_sigma_img,
+        "sigma_lm_target": args.nll_anchor_sigma_lm,
+    }
+
+    # ------ Training loop ------
+    log = {"iters": [], "train_loss": [], "val_loss": [],
+           "val_mean_convergence_cost": [], "val_mean_sigma_img": [],
+           "val_mean_sigma_lm": [], "val_mean_alpha": []}
+    best_val = float("inf")
+
+    for it in tqdm.tqdm(range(args.num_iters)):
+        policy.train()
+        # Update standardizer on a randomly-sampled training path's features
+        # by running a quick forward without backward.
+        batch = rng.sample(train_paths, k=min(args.batch_paths, len(train_paths)))
+        optim.zero_grad()
+        batch_loss = 0.0
+        diag_accum = []
+        for p_idx, path in enumerate(batch):
+            loss, diag = diff_rollout_and_loss(
+                aggregator=aggregator,
+                grid_spec=grid_spec,
+                mapping=mapping,
+                vigor_dataset=vigor_dataset,
+                path=path,
+                cfg=train_cfg,
+                device=device,
+                odometry_seed=args.seed * (it + 1) + p_idx,
+                nll_anchor=nll_anchor,
+            )
+            (loss / len(batch)).backward()
+            batch_loss += float(loss.detach().item())
+            diag_accum.append(diag)
+        torch.nn.utils.clip_grad_norm_(
+            policy.parameters(), max_norm=args.grad_clip_norm
+        )
+        optim.step()
+
+        # Update standardizer with features from the most recent rollout.
+        # Cheap & approximate; lets eval-time normalization track training.
+        with torch.no_grad():
+            sample_idx = aggregator._pano_id_index.get_loc(batch[0][0])
+            sample_features = aggregator._compute_features(
+                aggregator.image_similarity_matrix[sample_idx].to(device),
+                aggregator.landmark_similarity_matrix[sample_idx].to(device),
+            )
+            policy.standardizer.update(sample_features.unsqueeze(0))
+
+        log["iters"].append(it)
+        log["train_loss"].append(batch_loss / max(len(batch), 1))
+
+        if (it + 1) % args.val_every == 0 or it == args.num_iters - 1:
+            policy.eval()
+            with torch.no_grad():
+                val_losses = []
+                val_costs = []
+                v_si, v_sl, v_a = [], [], []
+                for vp in val_paths:
+                    vloss, vdiag = diff_rollout_and_loss(
+                        aggregator=aggregator,
+                        grid_spec=grid_spec,
+                        mapping=mapping,
+                        vigor_dataset=vigor_dataset,
+                        path=vp,
+                        cfg=train_cfg,
+                        device=device,
+                        odometry_seed=None,
+                        nll_anchor=None,
+                    )
+                    val_losses.append(float(vloss.detach().item()))
+                    val_costs.append(vdiag["trajectory_convergence_cost"])
+                    v_si.append(vdiag["mean_sigma_img"])
+                    v_sl.append(vdiag["mean_sigma_lm"])
+                    v_a.append(vdiag["mean_alpha"])
+            v_mean = float(np.mean(val_losses))
+            log["val_loss"].append(v_mean)
+            log["val_mean_convergence_cost"].append(float(np.mean(val_costs)))
+            log["val_mean_sigma_img"].append(float(np.mean(v_si)))
+            log["val_mean_sigma_lm"].append(float(np.mean(v_sl)))
+            log["val_mean_alpha"].append(float(np.mean(v_a)))
+            print(
+                f"  it={it+1}: train={log['train_loss'][-1]:.4f}  "
+                f"val={v_mean:.4f}  cc={np.mean(val_costs):.1f}  "
+                f"σ_img={np.mean(v_si):.3f}  σ_lm={np.mean(v_sl):.3f}  "
+                f"α={np.mean(v_a):.3f}"
+            )
+            if v_mean < best_val:
+                best_val = v_mean
+                torch.save(policy.state_dict(), output_path / "policy_weights.pt")
+
+        with open(output_path / "train_log.json", "w") as f:
+            json.dump(log, f, indent=2)
+
+    print(f"\nDone. Best val loss: {best_val:.4f}")
+    print(f"Outputs in {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Do not merge — archive

Snapshot of an exploration session. Content is preserved here for record / future reference; the production-relevant subset (what actually shipped to `/data/overhead_matching/evaluation/results/260501_v6_safa_plus_norm_lm/`) lives in a separate, much smaller PR.

This PR contains three loosely-related deliverables:

### (1) σ calibration tooling
- `scripts/calibrate_sigma.py` — single-stream half-normal MLE + NLL-min calibration on per-pair residuals (Brent + grid sweep, Gaussian-on-residuals and softmax forms).
- `scripts/calibrate_fusion_sigma.py` — joint NLL sweep over (σ_img, σ_lm) under EA fusion. Surfaces the σ-coupling trap in the EA `α = peak_sharpness ratio` formula.

### (2) Differentiable filter + learned per-step (σ_img, σ_lm, α) policy
- `filter/histogram_belief.py` — `apply_observation` gains a `surrogate_tau` kwarg: default `None` preserves production hard-max; `>0` swaps `segment_max` for `tau · segment_logsumexp(values/tau)` so backprop flows through the filter.
- `filter/learned_aggregator.py` + tests — `SigmaPolicy` MLP + `LearnedAggregator` aggregator class with optional 10-step history features.
- `scripts/grid_search_convergence.py` — Phase 0 oracle constant-σ baseline.
- `scripts/train_learned_aggregator.py` — supervised end-to-end through the differentiable filter; loss = mean trajectory convergence cost + small NLL anchor.
- `scripts/evaluate_learned_aggregator.py` — full-path eval with multi-radius convergence cost.

In practice this approach landed roughly tied with the hand-tuned EA σ=0.25/0.25 baseline on hurricane and didn't beat it across the board. Infra is preserved here for future per-step learning work.

### (3) SAFA + normalized-landmark Gaussian-on-residuals fusion (the production answer)
- `filter/adaptive_aggregators.py` adds `SafaPlusNormalizedLandmarkAggregator`: SAFA-style Gaussian on raw image residuals (σ=0.187) summed with a Gaussian on `r_norm = 1 − sim/row_max` for landmarks (σ=0.737), with image-only fall-through on all-zero / constant landmark rows.
- `filter/adaptive_aggregators_test.py` — unit tests.
- `scripts/landmark_residual_exploration.py` — derives σ_lm by checking cross-city consistency of r_norm distributions (Chicago/Seattle/NewYork/post-hurricane-ian; 1.12× max/min spread).

Production results: `/data/overhead_matching/evaluation/results/260501_v6_safa_plus_norm_lm/`. Wins c100 on every one of 10 cities vs SAFA-only baseline, wins final position error on 7/10 (decisive on the catastrophic-shift cities — hurricane, Boston, Norway, nightdrive, Framingham).

This PR is for record only; the clean PR is the one to review.