### PR TITLE
Aggregator: assert similarity matrix rows match panorama_metadata

### DIFF
--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -113,6 +113,31 @@ def _load_similarity_matrix(path: Path) -> torch.Tensor:
     return data
 
 
+def _assert_matrix_aligned(
+    matrix: torch.Tensor,
+    panorama_metadata: pd.DataFrame,
+    matrix_path: Path,
+) -> None:
+    """Verify a similarity matrix has one row per current panorama.
+
+    Aggregators index matrix rows positionally via the metadata's pano_id list.
+    If the dataset was trimmed after the matrix was generated, indexing silently
+    returns rows for the wrong panoramas (no IndexError when matrix has *more*
+    rows than metadata) — the filter then converges confidently to the wrong
+    cell. Catch that here with a path-aware message so the stale file is
+    identifiable at a glance.
+    """
+    n_pano = len(panorama_metadata)
+    n_rows = matrix.shape[0]
+    if n_rows != n_pano:
+        raise ValueError(
+            f"Similarity matrix at {matrix_path} has {n_rows} rows but the "
+            f"dataset's panorama_metadata has {n_pano} entries. The matrix is "
+            f"misaligned with the current panorama set (likely stale relative "
+            f"to a dataset trim). Regenerate it from the current panoramas."
+        )
+
+
 # ============ Aggregator Classes ============
 
 
@@ -172,6 +197,11 @@ class SingleSimilarityMatrixAggregator(ObservationLogLikelihoodAggregator):
         device: torch.device,
     ) -> "SingleSimilarityMatrixAggregator":
         similarity_matrix = _load_similarity_matrix(config.similarity_matrix_path)
+        _assert_matrix_aligned(
+            similarity_matrix,
+            vigor_dataset._panorama_metadata,
+            config.similarity_matrix_path,
+        )
         return cls(
             similarity_matrix, vigor_dataset._panorama_metadata, config.sigma, device
         )
@@ -234,6 +264,14 @@ class ImageLandmarkPrivilegedInformationFusion(ObservationLogLikelihoodAggregato
     ) -> "ImageLandmarkPrivilegedInformationFusion":
         image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
         landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
+        _assert_matrix_aligned(
+            image_sim, vigor_dataset._panorama_metadata, config.image_similarity_matrix_path
+        )
+        _assert_matrix_aligned(
+            landmark_sim,
+            vigor_dataset._panorama_metadata,
+            config.landmark_similarity_matrix_path,
+        )
         return cls(
             image_sim,
             landmark_sim,
@@ -316,6 +354,14 @@ class EntropyAdaptiveAggregator(ObservationLogLikelihoodAggregator):
     ) -> "EntropyAdaptiveAggregator":
         image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
         landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
+        _assert_matrix_aligned(
+            image_sim, vigor_dataset._panorama_metadata, config.image_similarity_matrix_path
+        )
+        _assert_matrix_aligned(
+            landmark_sim,
+            vigor_dataset._panorama_metadata,
+            config.landmark_similarity_matrix_path,
+        )
         return cls(
             image_sim,
             landmark_sim,
@@ -417,6 +463,14 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
     ) -> "SafaPlusNormalizedLandmarkAggregator":
         image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
         landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
+        _assert_matrix_aligned(
+            image_sim, vigor_dataset._panorama_metadata, config.image_similarity_matrix_path
+        )
+        _assert_matrix_aligned(
+            landmark_sim,
+            vigor_dataset._panorama_metadata,
+            config.landmark_similarity_matrix_path,
+        )
         return cls(
             image_similarity_matrix=image_sim,
             landmark_similarity_matrix=landmark_sim,

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -116,25 +116,35 @@ def _load_similarity_matrix(path: Path) -> torch.Tensor:
 def _assert_matrix_aligned(
     matrix: torch.Tensor,
     panorama_metadata: pd.DataFrame,
+    satellite_metadata: pd.DataFrame,
     matrix_path: Path,
 ) -> None:
-    """Verify a similarity matrix has one row per current panorama.
+    """Verify a similarity matrix's shape matches the current dataset.
 
-    Aggregators index matrix rows positionally via the metadata's pano_id list.
-    If the dataset was trimmed after the matrix was generated, indexing silently
-    returns rows for the wrong panoramas (no IndexError when matrix has *more*
-    rows than metadata) — the filter then converges confidently to the wrong
-    cell. Catch that here with a path-aware message so the stale file is
-    identifiable at a glance.
+    Rows are indexed positionally via the panorama_metadata pano_id list and
+    columns via the satellite_metadata satellite-patch index (e.g. through
+    ``positive_satellite_idxs`` and the cell-to-patch mapping). If either
+    dimension was trimmed after the matrix was generated, indexing silently
+    returns valid-looking values for the wrong query — the filter still
+    converges, but to the wrong cell. Bigger-than-current always silently
+    succeeds (no IndexError), so we have to compare lengths explicitly.
     """
     n_pano = len(panorama_metadata)
-    n_rows = matrix.shape[0]
+    n_sat = len(satellite_metadata)
+    n_rows, n_cols = matrix.shape[0], matrix.shape[1]
     if n_rows != n_pano:
         raise ValueError(
             f"Similarity matrix at {matrix_path} has {n_rows} rows but the "
             f"dataset's panorama_metadata has {n_pano} entries. The matrix is "
             f"misaligned with the current panorama set (likely stale relative "
             f"to a dataset trim). Regenerate it from the current panoramas."
+        )
+    if n_cols != n_sat:
+        raise ValueError(
+            f"Similarity matrix at {matrix_path} has {n_cols} columns but the "
+            f"dataset's satellite_metadata has {n_sat} entries. The matrix is "
+            f"misaligned with the current satellite set (likely stale relative "
+            f"to a satellite trim). Regenerate it from the current satellites."
         )
 
 
@@ -200,6 +210,7 @@ class SingleSimilarityMatrixAggregator(ObservationLogLikelihoodAggregator):
         _assert_matrix_aligned(
             similarity_matrix,
             vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
             config.similarity_matrix_path,
         )
         return cls(
@@ -265,11 +276,15 @@ class ImageLandmarkPrivilegedInformationFusion(ObservationLogLikelihoodAggregato
         image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
         landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
         _assert_matrix_aligned(
-            image_sim, vigor_dataset._panorama_metadata, config.image_similarity_matrix_path
+            image_sim,
+            vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
+            config.image_similarity_matrix_path,
         )
         _assert_matrix_aligned(
             landmark_sim,
             vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
             config.landmark_similarity_matrix_path,
         )
         return cls(
@@ -355,11 +370,15 @@ class EntropyAdaptiveAggregator(ObservationLogLikelihoodAggregator):
         image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
         landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
         _assert_matrix_aligned(
-            image_sim, vigor_dataset._panorama_metadata, config.image_similarity_matrix_path
+            image_sim,
+            vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
+            config.image_similarity_matrix_path,
         )
         _assert_matrix_aligned(
             landmark_sim,
             vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
             config.landmark_similarity_matrix_path,
         )
         return cls(
@@ -464,11 +483,15 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
         image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
         landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
         _assert_matrix_aligned(
-            image_sim, vigor_dataset._panorama_metadata, config.image_similarity_matrix_path
+            image_sim,
+            vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
+            config.image_similarity_matrix_path,
         )
         _assert_matrix_aligned(
             landmark_sim,
             vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
             config.landmark_similarity_matrix_path,
         )
         return cls(


### PR DESCRIPTION
## Summary

- Add `_assert_matrix_aligned()` in `adaptive_aggregators.py` and wire it into all four aggregators' `from_config` methods (six matrix-load sites total).
- Compares `matrix.shape[0]` to `len(panorama_metadata)` **and** `matrix.shape[1]` to `len(satellite_metadata)`, raising a `ValueError` naming the offending matrix path so a stale file is identifiable at a glance.

## Why

The adaptive aggregators index similarity-matrix rows positionally via the dataset's `panorama_metadata["pano_id"]` list (e.g. `SingleSimilarityMatrixAggregator.__call__`):

```python
pano_index = self._pano_id_index.get_loc(pano_id)
similarity = self.similarity_matrix[pano_index]
```

Columns are indexed positionally too — via `positive_satellite_idxs` in `panorama_metadata` (used in `ImageLandmarkPrivilegedInformationFusion`) and via the cell-to-patch mapping built downstream. So either dimension can be silently misaligned if a trim happens after the matrix is generated:

- Matrix dim ≥ metadata length → indexing is in-bounds, returns valid-looking values for the wrong query (no IndexError to fall out on).
- Matrix dim < metadata length → would have raised IndexError, but trims today only ever shrink, so this case doesn't happen.

The filter still converges (the row/column it pulls is well-formed), but it converges to the wrong cell.

Concretely we observed the row side of this in the wild on:
- **Boston**: 1709-row matrix vs 1674 current panoramas (35 trimmed Apr 3, matrix not regenerated)
- **nightdrive**: 1401-row matrix vs 1378 panoramas

This very likely explains the saturated CC100 ≈ 3000 m on those two datasets in recent v6 SAFA evals — the filter "converged" to wrong-pano peaks and never recovered.

No on-disk matrix today has a column-count mismatch, but the hazard is symmetric with the row side and the check is the same shape, so it goes in here.

## Test plan

- [x] `bazel test //experimental/overhead_matching/swag/filter:adaptive_aggregators_test` — passes
- [x] Manual: re-run `evaluate_histogram_on_paths` against Boston (whose `safa_dinov3_wag_chicago.pt` is the stale 1709-row matrix). Before this change the eval ran ~30 min and produced average final error ≈ 1115 m; now it raises in ~5 s with:
  ```
  ValueError: Similarity matrix at .../safa_dinov3_wag_chicago.pt has 1709 rows
  but the dataset's panorama_metadata has 1674 entries. The matrix is misaligned
  with the current panorama set (likely stale relative to a dataset trim).
  Regenerate it from the current panoramas.
  ```

## Follow-ups (not in this PR)

- Regenerate the stale matrices in `Boston/similarity_matrices/` (`safa_dinov3_wag_chicago.pt`, `correspondence_v5_*.pt`, `learned_tag_weight_chicago*.pt`) and the same set under `nightdrive/`. Two `simple_v1*` matrices in each dir are already at the correct row count.
- Stronger version: store the panorama_id and satellite_id lists (or their hashes) alongside the matrix so alignment is verified by content, not just length.