### PR TITLE
OSM PBF: expand city coverage, multi-dir search, source_px-aware bbox

### DIFF
--- a/experimental/overhead_matching/baseline/dataset/bake_mbtiles.py
+++ b/experimental/overhead_matching/baseline/dataset/bake_mbtiles.py
@@ -27,8 +27,9 @@ def planetiler_jar_path() -> Path:
 def compute_vigor_bbox(satellite_dir: Path, buffer_km: float = 1.0) -> tile_geometry.TileBBox:
     lats: list[float] = []
     lons: list[float] = []
+    sat_suffixes = {".png", ".jpg", ".jpeg"}
     for p in satellite_dir.iterdir():
-        if p.suffix != ".png":
+        if p.suffix.lower() not in sat_suffixes:
             continue
         try:
             lat, lon = tile_geometry.satellite_filename_to_center(p.name)
@@ -37,7 +38,7 @@ def compute_vigor_bbox(satellite_dir: Path, buffer_km: float = 1.0) -> tile_geom
         lats.append(lat)
         lons.append(lon)
     if not lats:
-        raise RuntimeError(f"no satellite_*.png files found under {satellite_dir}")
+        raise RuntimeError(f"no satellite_*.{{png,jpg}} files found under {satellite_dir}")
     deg_per_km_lat = 1.0 / 110.574
     # Conservative cosine using the southernmost latitude (largest deg/km).
     import math
@@ -102,7 +103,9 @@ def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--city", required=True, choices=city_pbf_map.cities())
     p.add_argument("--vigor-root", type=Path, default=Path("/data/overhead_matching/datasets/VIGOR"))
-    p.add_argument("--dumps-dir", type=Path, default=DEFAULT_DUMPS_DIR)
+    p.add_argument("--dumps-dir", type=Path, action="append", dest="dumps_dirs",
+                   help="osm.pbf search dir; repeat for multiple search paths "
+                        f"(default: {DEFAULT_DUMPS_DIR})")
     p.add_argument("--output-dir", type=Path, default=Path("/data/overhead_matching/baseline/mbtiles"))
     p.add_argument("--download-dir", type=Path,
                    default=Path("/data/overhead_matching/baseline/planetiler_sources"),
@@ -116,9 +119,10 @@ def main() -> int:
     p.add_argument("--force", action="store_true")
     args = p.parse_args()
 
-    pbf = city_pbf_map.resolve_pbf(args.city, args.dumps_dir)
+    dumps_dirs = args.dumps_dirs or [DEFAULT_DUMPS_DIR]
+    pbf = city_pbf_map.resolve_pbf(args.city, dumps_dirs)
     if not pbf.exists():
-        logger.error("PBF not found: %s", pbf)
+        logger.error("PBF not found: %s (searched %s)", pbf, [str(d) for d in dumps_dirs])
         return 1
 
     output = args.output_dir / f"{city_pbf_map.region_label(args.city)}.mbtiles"

--- a/experimental/overhead_matching/baseline/dataset/city_pbf_map.py
+++ b/experimental/overhead_matching/baseline/dataset/city_pbf_map.py
@@ -9,11 +9,23 @@ class CityPbf:
 
 
 CITY_TO_PBF: dict[str, CityPbf] = {
-    "Boston":       CityPbf("massachusetts-200101.osm.pbf", "massachusetts"),
+    # VIGOR original cities (under <vigor-root>/<City>/).
+    "Boston":       CityPbf("massachusetts-260101.osm.pbf", "massachusetts_260101_Boston"),
     "Chicago":      CityPbf("illinois-200101.osm.pbf",      "illinois"),
     "NewYork":      CityPbf("new-york-200101.osm.pbf",      "new_york"),
     "Seattle":      CityPbf("washington-200101.osm.pbf",    "washington"),
     "SanFrancisco": CityPbf("california-200101.osm.pbf",    "california"),
+    # VIGOR mapillary cities (under <vigor-root>/mapillary/<City>/). Distinct
+    # mbtiles stems per city since several share a state-level PBF but cover
+    # disjoint bboxes.
+    "Framingham":             CityPbf("massachusetts-260101.osm.pbf", "massachusetts_260101_Framingham"),
+    "Middletown":             CityPbf("connecticut-250101.osm.pbf",   "connecticut_250101_Middletown"),
+    "Gap":                    CityPbf("france-250101.osm.pbf",        "france_250101_Gap"),
+    "SanFrancisco_mapillary": CityPbf("norcal-220101.osm.pbf",        "norcal_220101_SanFrancisco_mapillary"),
+    "MiamiBeach":             CityPbf("florida-220101.osm.pbf",       "florida_220101_MiamiBeach"),
+    "post_hurricane_ian":     CityPbf("florida-220101.osm.pbf",       "florida_220101_post_hurricane_ian"),
+    "post_hurricane_ian_sw":  CityPbf("florida-220101.osm.pbf",       "florida_220101_post_hurricane_ian_sw"),
+    "Norway":                 CityPbf("norway-251201.osm.pbf",        "norway_251201_Norway"),
 }
 
 
@@ -21,10 +33,24 @@ def cities() -> list[str]:
     return list(CITY_TO_PBF.keys())
 
 
-def resolve_pbf(city: str, dumps_dir: Path) -> Path:
+def resolve_pbf(city: str, dumps_dirs: Path | list[Path]) -> Path:
+    """Return the first existing PBF path for `city` across `dumps_dirs`.
+
+    `dumps_dirs` accepts a single Path (legacy) or a list searched in order.
+    Falls back to `<first_dir>/<filename>` if none exist, so the caller's
+    error message points at a concrete path.
+    """
     if city not in CITY_TO_PBF:
         raise KeyError(f"unknown city {city!r}; known: {sorted(CITY_TO_PBF)}")
-    return dumps_dir / CITY_TO_PBF[city].pbf_filename
+    fname = CITY_TO_PBF[city].pbf_filename
+    dirs = [dumps_dirs] if isinstance(dumps_dirs, Path) else list(dumps_dirs)
+    if not dirs:
+        raise ValueError("dumps_dirs must contain at least one path")
+    for d in dirs:
+        candidate = d / fname
+        if candidate.exists():
+            return candidate
+    return dirs[0] / fname
 
 
 def region_label(city: str) -> str:

--- a/experimental/overhead_matching/baseline/dataset/city_pbf_map_test.py
+++ b/experimental/overhead_matching/baseline/dataset/city_pbf_map_test.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -8,12 +9,36 @@ class CityPbfMapTest(unittest.TestCase):
     def test_cities_covered(self):
         self.assertEqual(
             set(city_pbf_map.cities()),
-            {"Boston", "Chicago", "NewYork", "Seattle", "SanFrancisco"},
+            {
+                # VIGOR original
+                "Boston", "Chicago", "NewYork", "Seattle", "SanFrancisco",
+                # VIGOR mapillary
+                "Framingham", "Middletown", "Gap", "SanFrancisco_mapillary",
+                "MiamiBeach", "post_hurricane_ian", "post_hurricane_ian_sw", "Norway",
+            },
         )
 
-    def test_resolve_pbf(self):
+    def test_resolve_pbf_single_dir_legacy(self):
+        # Pre-existing callers pass a single Path; behavior preserved (resolves
+        # to that dir even if the file does not exist on disk).
         p = city_pbf_map.resolve_pbf("Seattle", Path("/data/overhead_matching/datasets/osm_dumps"))
         self.assertEqual(p.name, "washington-200101.osm.pbf")
+        self.assertEqual(p.parent, Path("/data/overhead_matching/datasets/osm_dumps"))
+
+    def test_resolve_pbf_searches_dirs_in_order(self):
+        with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+            d1, d2 = Path(t1), Path(t2)
+            (d2 / "norway-251201.osm.pbf").write_text("")
+            resolved = city_pbf_map.resolve_pbf("Norway", [d1, d2])
+            self.assertEqual(resolved, d2 / "norway-251201.osm.pbf")
+
+    def test_resolve_pbf_falls_back_to_first_dir_when_missing(self):
+        with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+            d1, d2 = Path(t1), Path(t2)
+            resolved = city_pbf_map.resolve_pbf("Norway", [d1, d2])
+            # Neither exists; we return the first dir so the error message
+            # points somewhere concrete.
+            self.assertEqual(resolved, d1 / "norway-251201.osm.pbf")
 
     def test_unknown_city(self):
         with self.assertRaises(KeyError):

--- a/experimental/overhead_matching/baseline/dataset/render_osm_tiles.py
+++ b/experimental/overhead_matching/baseline/dataset/render_osm_tiles.py
@@ -3,6 +3,7 @@ each existing satellite tile so vigor_dataset.py can load them by toggling
 its `satellite_subdir` config field.
 """
 import argparse
+import json
 import logging
 import os
 import sys
@@ -27,22 +28,40 @@ class RenderJob:
     output_path: Path
 
 
+def read_source_px(city_dir: Path) -> int | None:
+    """Return source_px from <city_dir>/satellite_bbox.json if present.
+
+    Resolution-normalized VIGOR splits (e.g. Norway, MiamiBeach) capture each
+    tile at `source_px` zoom-20 pixels of ground, then resize to 640. The
+    bbox the on-disk image actually covers spans `source_px` zoom-20 pixels,
+    not 640.
+    """
+    bbox_path = city_dir / "satellite_bbox.json"
+    if not bbox_path.exists():
+        return None
+    with open(bbox_path) as f:
+        meta = json.load(f)
+    return meta.get("source_px")
+
+
 def discover_jobs(
     city_dir: Path,
     output_subdir: str = "satellite_osm",
     zoom: int = 20,
-    tile_px: int = 640,
+    bbox_px: int = 640,
+    sat_subdir: str = "satellite",
+    sat_suffixes: tuple[str, ...] = (".png", ".jpg", ".jpeg"),
     force: bool = False,
 ) -> list[RenderJob]:
-    sat_dir = city_dir / "satellite"
+    sat_dir = city_dir / sat_subdir
     out_dir = city_dir / output_subdir
     out_dir.mkdir(parents=True, exist_ok=True)
 
     jobs: list[RenderJob] = []
     for p in sorted(sat_dir.iterdir()):
-        if p.suffix != ".png":
+        if p.suffix.lower() not in sat_suffixes:
             continue
-        out = out_dir / p.name
+        out = out_dir / (p.stem + ".png")
         if out.exists() and not force:
             continue
         try:
@@ -50,7 +69,7 @@ def discover_jobs(
         except ValueError:
             logger.warning("skipping %s: bad filename", p.name)
             continue
-        bbox = tile_geometry.center_zoom_to_bbox(lat, lon, zoom=zoom, tile_px=tile_px)
+        bbox = tile_geometry.center_zoom_to_bbox(lat, lon, zoom=zoom, tile_px=bbox_px)
         jobs.append(RenderJob(sat_filename=p.name, bbox=bbox, output_path=out))
     return jobs
 
@@ -79,16 +98,31 @@ def render_city(
     mbtiles_path: Path,
     output_subdir: str = "satellite_osm",
     zoom: int = 20,
-    tile_px: int = 640,
+    render_px: int = 640,
+    bbox_px: int | None = None,
     limit: int | None = None,
     force: bool = False,
 ) -> None:
     city_dir = vigor_root / city
+
+    # Resolution-normalized splits (e.g. Norway: source_px=934) capture a
+    # wider ground footprint and resize to 640. The OSM bbox must match that
+    # ground footprint, not the 640px on-disk size; the output PNG stays at
+    # render_px so vigor_dataset.py sees the same image dims as satellite/.
+    if bbox_px is None:
+        source_px = read_source_px(city_dir)
+        bbox_px = source_px if source_px is not None else render_px
+        if source_px is not None and source_px != render_px:
+            logger.info(
+                "%s: using source_px=%d for bbox (on-disk render stays %dpx)",
+                city, source_px, render_px,
+            )
+
     jobs = discover_jobs(
         city_dir,
         output_subdir=output_subdir,
         zoom=zoom,
-        tile_px=tile_px,
+        bbox_px=bbox_px,
         force=force,
     )
     logger.info("discovered %d unrendered tiles for %s", len(jobs), city)
@@ -100,7 +134,7 @@ def render_city(
 
     logger.info("rendering %d tiles -> %s", len(jobs), city_dir / output_subdir)
     style_str = style_template.render_style(mbtiles_path)
-    render_jobs(style_str, jobs, width=tile_px, height=tile_px)
+    render_jobs(style_str, jobs, width=render_px, height=render_px)
 
 
 def main() -> int:
@@ -112,7 +146,11 @@ def main() -> int:
     p.add_argument("--mbtiles-dir", type=Path, default=Path("/data/overhead_matching/baseline/mbtiles"))
     p.add_argument("--output-subdir", default="satellite_osm")
     p.add_argument("--zoom", type=int, default=20)
-    p.add_argument("--tile-px", type=int, default=640)
+    p.add_argument("--render-px", type=int, default=640,
+                   help="output PNG dimensions; should match satellite tile on-disk size")
+    p.add_argument("--bbox-px", type=int, default=None,
+                   help="zoom-20 pixel footprint of the bbox (overrides "
+                        "satellite_bbox.json:source_px; defaults to render-px when neither is set)")
     p.add_argument("--limit", type=int, default=None)
     p.add_argument("--force", action="store_true",
                    help="re-render even if output PNG already exists")
@@ -134,7 +172,8 @@ def main() -> int:
         mbtiles_path=mbtiles,
         output_subdir=args.output_subdir,
         zoom=args.zoom,
-        tile_px=args.tile_px,
+        render_px=args.render_px,
+        bbox_px=args.bbox_px,
         limit=args.limit,
         force=args.force,
     )


### PR DESCRIPTION
## Summary

Expand the city→PBF mapping from the original 5 VIGOR cities to the 13 currently used (mapillary suburbs, Norway, Fort Myers variants, etc.). Add a multi-directory PBF search path so mbtiles bake / OSM-tile rendering find PBFs across staging locations. Honor \`source_px\` from \`satellite_bbox.json\` so the rendered OSM bbox matches the on-disk satellite ground footprint for resolution-normalized cities. Accept jpg/jpeg satellite inputs (mapillary uses jpg, not png).

## Details

- **\`city_pbf_map.py\`** — \`CITY_TO_PBF\` expanded from 5 → 13 entries (adds Framingham, Middletown, Gap, SanFrancisco_mapillary, MiamiBeach, post_hurricane_ian, post_hurricane_ian_sw, Norway; updates Boston to the 2026-01-01 PBF). Cities that share a state-level PBF (e.g. Boston/Framingham → massachusetts, post_hurricane_ian/_sw/MiamiBeach → florida) get distinct \`region_label\`s so the mbtiles outputs don't collide.
- **\`city_pbf_map.py\`** — \`resolve_pbf\` now accepts a single \`Path\` (legacy) or a list of search dirs; iterates in order and returns the first existing file, else falls back to \`<first_dir>/<filename>\` so the caller's error message points somewhere concrete.
- **\`bake_mbtiles.py\`** — \`--dumps-dir\` is repeatable for the multi-dir search; bbox scan accepts \`.jpg\`/\`.jpeg\` satellites (not only \`.png\`); error message lists every directory that was searched.
- **\`render_osm_tiles.py\`** — reads \`source_px\` from \`<city>/satellite_bbox.json\` so the OSM bbox matches the on-disk satellite ground footprint for resolution-normalized cities; splits \`--tile-px\` into \`--render-px\` (PNG size) and \`--bbox-px\` (ground footprint in zoom-20 pixels); accepts jpg satellites.

## Test plan

- [x] \`bazel test //experimental/overhead_matching/baseline/dataset:city_pbf_map_test\` — passes; new tests cover legacy single-dir, multi-dir-search-in-order, and missing-file fallback.
- [x] \`bazel build //experimental/overhead_matching/baseline/dataset:bake_mbtiles //experimental/overhead_matching/baseline/dataset:render_osm_tiles\` — both build cleanly.
- [ ] Recommended: \`bake_mbtiles\` smoke-run on a city that resolves via the new multi-dir path (e.g. \`--city Norway --dumps-dir <staging> --dumps-dir <archive>\`).