### PR TITLE
Aggregator: opt-in raw-residual mode for SafaPlusNormalizedLandmark fusion

### DIFF
--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -94,12 +94,14 @@ def _replace_nan_with_zero(tensor: torch.Tensor) -> torch.Tensor:
     return tensor
 
 
-def _raise_if_nonfinite(tensor: torch.Tensor, pano_id: str, name: str) -> None:
+def _raise_if_nonfinite(
+    tensor: torch.Tensor, pano_id: str, name: str, cls_name: str
+) -> None:
     nonfinite = ~torch.isfinite(tensor)
     if nonfinite.any():
         first_idx = int(torch.nonzero(nonfinite, as_tuple=False)[0].item())
         raise RuntimeError(
-            f"SafaPlusNormalizedLandmarkAggregator: non-finite value in {name} "
+            f"{cls_name}: non-finite value in {name} "
             f"for pano_id={pano_id!r} at index {first_idx} "
             f"(value={tensor.flatten()[first_idx].item()})."
         )
@@ -206,7 +208,8 @@ class SingleSimilarityMatrixAggregator(ObservationLogLikelihoodAggregator):
         log_ll = wag_observation_log_likelihood_from_similarity_matrix(
             similarity, self.sigma
         )
-        return _replace_nan_with_zero(log_ll).to(self.device)
+        _raise_if_nonfinite(log_ll, pano_id, "log_ll", cls_name=type(self).__name__)
+        return log_ll.to(self.device)
 
     @classmethod
     def from_config(
@@ -455,7 +458,7 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
         log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
             img_sim, self.image_sigma
         )
-        _raise_if_nonfinite(log_p_img, pano_id, "log_p_img")
+        _raise_if_nonfinite(log_p_img, pano_id, "log_p_img", cls_name=type(self).__name__)
 
         # Landmark-side: per-row /max normalization, then Gaussian-on-r_norm.
         # Fall through to image-only when the landmark row is uninformative.
@@ -490,7 +493,7 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
         log_p_lm = torch.where(lm_finite_mask, log_p_lm, torch.zeros_like(log_p_lm))
 
         log_p = log_p_img + log_p_lm
-        _raise_if_nonfinite(log_p, pano_id, "log_p_img + log_p_lm")
+        _raise_if_nonfinite(log_p, pano_id, "log_p_img + log_p_lm", cls_name=type(self).__name__)
         return log_p
 
     @classmethod

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -61,6 +61,16 @@ class SafaPlusNormalizedLandmarkAggregatorConfig(
     matrix), where the per-row /max normalization is unnecessary.
     Note ``landmark_sigma`` then lives on the raw-cosine scale rather
     than the [0,1] normalized scale.
+
+    The two modes also differ in their NaN contract on the landmark
+    matrix:
+
+    * Normalized-residual (default): NaN entries are legitimate "no
+      landmark info for this cell" signals; the aggregator falls back
+      to image-only at those positions.
+    * Raw-residual: ``landmark_similarity_matrix`` is expected dense.
+      Any NaN/inf entry indicates a bug (stale matrix, broken export,
+      etc.) and raises eagerly.
     """
 
     image_similarity_matrix_path: Path
@@ -460,27 +470,38 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
         )
         _raise_if_nonfinite(log_p_img, pano_id, "log_p_img", cls_name=type(self).__name__)
 
-        # Landmark-side: per-row /max normalization, then Gaussian-on-r_norm.
-        # Fall through to image-only when the landmark row is uninformative.
-        lm_finite_mask = torch.isfinite(lm_sim)
-        if not lm_finite_mask.any():
-            return log_p_img
-        lm_finite = lm_sim[lm_finite_mask]
-        sim_max_lm = lm_finite.max()
-        sim_min_lm = lm_finite.min()
-        if (sim_max_lm <= 0) or (sim_max_lm == sim_min_lm):
-            # All-zero or constant row → landmark is uninformative.
-            return log_p_img
-
+        # Landmark stream — branch on residual form. The two branches have
+        # *different* NaN contracts:
+        #
+        #   * raw-residual: lm_sim is expected dense (a second SAFA-form
+        #     matrix on the same scale as the image stream, e.g. an OSM-tile
+        #     baseline). NaN/inf indicates a bug — stale matrix, broken
+        #     export, etc. — and is raised eagerly.
+        #
+        #   * normalized-residual (#626): lm_sim is sparse-with-holes; NaN
+        #     means "no landmark info for this cell" and we fall back to
+        #     image-only at those positions.
         if self.landmark_use_raw_residual:
-            # Same SAFA-form residual as the image stream. NaNs can poison
-            # `.max()` inside the helper, so substitute the finite minimum at
-            # those positions; they're zeroed out by the mask below.
-            lm_sim_safe = torch.where(lm_finite_mask, lm_sim, sim_min_lm)
+            _raise_if_nonfinite(lm_sim, pano_id, "lm_sim", cls_name=type(self).__name__)
+            sim_max_lm = lm_sim.max()
+            sim_min_lm = lm_sim.min()
+            if sim_max_lm == sim_min_lm:
+                # Constant row → uniform log_p_lm (no spatial information).
+                # Skip the landmark contribution entirely.
+                return log_p_img
             log_p_lm = wag_observation_log_likelihood_from_similarity_matrix(
-                lm_sim_safe, self.landmark_sigma
+                lm_sim, self.landmark_sigma
             )
         else:
+            lm_finite_mask = torch.isfinite(lm_sim)
+            if not lm_finite_mask.any():
+                return log_p_img
+            lm_finite = lm_sim[lm_finite_mask]
+            sim_max_lm = lm_finite.max()
+            sim_min_lm = lm_finite.min()
+            if (sim_max_lm <= 0) or (sim_max_lm == sim_min_lm):
+                # All-zero or constant row → landmark is uninformative.
+                return log_p_img
             norm_sim = lm_sim / sim_max_lm
             r_norm = 1.0 - norm_sim
             sigma_lm = self.landmark_sigma
@@ -488,9 +509,8 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
                 torch.sqrt(torch.tensor(2 * torch.pi, device=lm_sim.device))
             ) - torch.log(torch.tensor(sigma_lm, device=lm_sim.device))
             log_p_lm = log_norm_const - 0.5 * torch.square(r_norm / sigma_lm)
-
-        # Mask out non-finite landmark entries (image-only at those indices).
-        log_p_lm = torch.where(lm_finite_mask, log_p_lm, torch.zeros_like(log_p_lm))
+            # Mask non-finite landmark entries → image-only at those positions.
+            log_p_lm = torch.where(lm_finite_mask, log_p_lm, torch.zeros_like(log_p_lm))
 
         log_p = log_p_img + log_p_lm
         _raise_if_nonfinite(log_p, pano_id, "log_p_img + log_p_lm", cls_name=type(self).__name__)

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -53,12 +53,21 @@ class SafaPlusNormalizedLandmarkAggregatorConfig(
     Gaussian-on-residuals to ``r_norm = 1 − sim_t / row_max`` at
     ``landmark_sigma``. All-zero / constant landmark rows fall through
     to image-only.
+
+    When ``landmark_use_raw_residual`` is True, the landmark stream uses
+    the same SAFA-form raw residual ``row_max − sim_t`` as the image
+    stream. Use this when the second matrix is a similarity matrix on
+    the same scale as the image stream (e.g. an OSM-tile-baseline SAFA
+    matrix), where the per-row /max normalization is unnecessary.
+    Note ``landmark_sigma`` then lives on the raw-cosine scale rather
+    than the [0,1] normalized scale.
     """
 
     image_similarity_matrix_path: Path
     landmark_similarity_matrix_path: Path
     image_sigma: float
     landmark_sigma: float
+    landmark_use_raw_residual: bool = False
 
     def __post_init__(self):
         if not (self.image_sigma > 0):
@@ -426,11 +435,13 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
         image_sigma: float,
         landmark_sigma: float,
         device: torch.device,
+        landmark_use_raw_residual: bool = False,
     ):
         self.image_similarity_matrix = image_similarity_matrix
         self.landmark_similarity_matrix = landmark_similarity_matrix
         self.image_sigma = float(image_sigma)
         self.landmark_sigma = float(landmark_sigma)
+        self.landmark_use_raw_residual = bool(landmark_use_raw_residual)
         self.device = device
         self._pano_id_index = pd.Index(panorama_metadata["pano_id"])
 
@@ -458,13 +469,22 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
             # All-zero or constant row → landmark is uninformative.
             return log_p_img
 
-        norm_sim = lm_sim / sim_max_lm
-        r_norm = 1.0 - norm_sim
-        sigma_lm = self.landmark_sigma
-        log_norm_const = -torch.log(
-            torch.sqrt(torch.tensor(2 * torch.pi, device=lm_sim.device))
-        ) - torch.log(torch.tensor(sigma_lm, device=lm_sim.device))
-        log_p_lm = log_norm_const - 0.5 * torch.square(r_norm / sigma_lm)
+        if self.landmark_use_raw_residual:
+            # Same SAFA-form residual as the image stream. NaNs can poison
+            # `.max()` inside the helper, so substitute the finite minimum at
+            # those positions; they're zeroed out by the mask below.
+            lm_sim_safe = torch.where(lm_finite_mask, lm_sim, sim_min_lm)
+            log_p_lm = wag_observation_log_likelihood_from_similarity_matrix(
+                lm_sim_safe, self.landmark_sigma
+            )
+        else:
+            norm_sim = lm_sim / sim_max_lm
+            r_norm = 1.0 - norm_sim
+            sigma_lm = self.landmark_sigma
+            log_norm_const = -torch.log(
+                torch.sqrt(torch.tensor(2 * torch.pi, device=lm_sim.device))
+            ) - torch.log(torch.tensor(sigma_lm, device=lm_sim.device))
+            log_p_lm = log_norm_const - 0.5 * torch.square(r_norm / sigma_lm)
 
         # Mask out non-finite landmark entries (image-only at those indices).
         log_p_lm = torch.where(lm_finite_mask, log_p_lm, torch.zeros_like(log_p_lm))
@@ -500,6 +520,7 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
             panorama_metadata=vigor_dataset._panorama_metadata,
             image_sigma=config.image_sigma,
             landmark_sigma=config.landmark_sigma,
+            landmark_use_raw_residual=config.landmark_use_raw_residual,
             device=device,
         )
 

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
@@ -23,7 +23,8 @@ class TestSafaPlusNormalizedLandmarkAggregator(unittest.TestCase):
     SAFA Gaussian-on-residuals (image) + Gaussian-on-r_norm (landmark),
     with image-only fall-through on all-zero / constant landmark rows."""
 
-    def _make(self, img_sim, lm_sim, image_sigma=0.187, landmark_sigma=0.72):
+    def _make(self, img_sim, lm_sim, image_sigma=0.187, landmark_sigma=0.72,
+              landmark_use_raw_residual=False):
         meta = _make_metadata(img_sim.shape[0])
         return SafaPlusNormalizedLandmarkAggregator(
             image_similarity_matrix=img_sim,
@@ -31,6 +32,7 @@ class TestSafaPlusNormalizedLandmarkAggregator(unittest.TestCase):
             panorama_metadata=meta,
             image_sigma=image_sigma,
             landmark_sigma=landmark_sigma,
+            landmark_use_raw_residual=landmark_use_raw_residual,
             device=torch.device("cpu"),
         )
 
@@ -100,6 +102,44 @@ class TestSafaPlusNormalizedLandmarkAggregator(unittest.TestCase):
                 (log_p_lm[j] - ref).item(), expected_drop, places=4,
                 msg=f"residual at idx {j} should be −0.5·(r/σ)^2",
             )
+
+    def test_raw_residual_mode_equals_sum_of_safa_streams(self):
+        """With landmark_use_raw_residual=True both streams use the SAFA
+        helper, so the output must equal the elementwise sum of two
+        wag_observation_log_likelihood_from_similarity_matrix calls."""
+        torch.manual_seed(0)
+        img_sim = torch.randn(1, 12) * 0.3 + 0.4
+        lm_sim = torch.randn(1, 12) * 0.3 + 0.4
+        sigma_img, sigma_lm = 0.2, 0.25
+        agg = self._make(img_sim, lm_sim, image_sigma=sigma_img,
+                         landmark_sigma=sigma_lm,
+                         landmark_use_raw_residual=True)
+        out = agg("p0")
+
+        expected = (
+            wag_observation_log_likelihood_from_similarity_matrix(img_sim[0], sigma_img)
+            + wag_observation_log_likelihood_from_similarity_matrix(lm_sim[0], sigma_lm)
+        )
+        self.assertTrue(torch.allclose(out, expected, atol=1e-6))
+
+    def test_raw_residual_mode_zeroes_nan_landmark_entries(self):
+        """NaN landmark entries must contribute 0 to the fused log-likelihood
+        (image-only at those indices) without poisoning the helper's .max()."""
+        img_sim = torch.zeros(1, 5)
+        lm_sim = torch.tensor([[0.1, float("nan"), 0.7, 0.3, float("nan")]])
+        sigma_img, sigma_lm = 0.187, 0.2
+        agg = self._make(img_sim, lm_sim, image_sigma=sigma_img,
+                         landmark_sigma=sigma_lm,
+                         landmark_use_raw_residual=True)
+        out = agg("p0")
+
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], sigma_img
+        )
+        # At NaN positions: out should equal image-only.
+        self.assertTrue(torch.allclose(out[1], log_p_img[1], atol=1e-6))
+        self.assertTrue(torch.allclose(out[4], log_p_img[4], atol=1e-6))
+        self.assertTrue(torch.isfinite(out).all())
 
     def test_raises_on_nan_image_sim(self):
         """Non-finite image similarity must raise rather than silently zero."""

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
@@ -8,6 +8,7 @@ import pandas as pd
 from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
     SafaPlusNormalizedLandmarkAggregator,
     SafaPlusNormalizedLandmarkAggregatorConfig,
+    SingleSimilarityMatrixAggregator,
 )
 from experimental.overhead_matching.swag.filter.particle_filter import (
     wag_observation_log_likelihood_from_similarity_matrix,
@@ -16,6 +17,50 @@ from experimental.overhead_matching.swag.filter.particle_filter import (
 
 def _make_metadata(n: int = 4) -> pd.DataFrame:
     return pd.DataFrame({"pano_id": [f"p{i}" for i in range(n)]})
+
+
+class TestSingleSimilarityMatrixAggregator(unittest.TestCase):
+    """Contract: passes the similarity row through the SAFA helper and
+    raises on any non-finite output (NaN, ±inf) rather than silently
+    zeroing it. The aggregator's inputs are expected to be dense
+    similarity matrices; NaN inputs indicate a bug or stale matrix and
+    should not be swallowed."""
+
+    def _make(self, sim, sigma=0.187):
+        return SingleSimilarityMatrixAggregator(
+            similarity_matrix=sim,
+            panorama_metadata=_make_metadata(sim.shape[0]),
+            sigma=sigma,
+            device=torch.device("cpu"),
+        )
+
+    def test_finite_input_matches_safa_helper(self):
+        torch.manual_seed(0)
+        sim = torch.randn(2, 8) * 0.3 + 0.4
+        sigma = 0.2
+        agg = self._make(sim, sigma=sigma)
+        out = agg("p1")
+        expected = wag_observation_log_likelihood_from_similarity_matrix(
+            sim[1], sigma
+        )
+        self.assertTrue(torch.allclose(out, expected, atol=1e-6))
+
+    def test_raises_on_nan_input(self):
+        """NaN in the similarity row poisons the helper's .max() and yields
+        an all-NaN log-likelihood; that must raise rather than be silently
+        zeroed."""
+        sim = torch.zeros(1, 5)
+        sim[0, 2] = float("nan")
+        agg = self._make(sim)
+        with self.assertRaises(RuntimeError):
+            agg("p0")
+
+    def test_raises_on_inf_input(self):
+        sim = torch.zeros(1, 5)
+        sim[0, 2] = float("inf")
+        agg = self._make(sim)
+        with self.assertRaises(RuntimeError):
+            agg("p0")
 
 
 class TestSafaPlusNormalizedLandmarkAggregator(unittest.TestCase):

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
@@ -167,15 +167,34 @@ class TestSafaPlusNormalizedLandmarkAggregator(unittest.TestCase):
         )
         self.assertTrue(torch.allclose(out, expected, atol=1e-6))
 
-    def test_raw_residual_mode_zeroes_nan_landmark_entries(self):
-        """NaN landmark entries must contribute 0 to the fused log-likelihood
-        (image-only at those indices) without poisoning the helper's .max()."""
+    def test_raw_residual_mode_raises_on_nan_landmark(self):
+        """In raw-residual mode the landmark matrix is expected dense
+        (same scale as the image stream). NaN/inf entries indicate a bug
+        and must raise rather than silently fall back to image-only."""
         img_sim = torch.zeros(1, 5)
         lm_sim = torch.tensor([[0.1, float("nan"), 0.7, 0.3, float("nan")]])
-        sigma_img, sigma_lm = 0.187, 0.2
+        agg = self._make(img_sim, lm_sim, landmark_use_raw_residual=True)
+        with self.assertRaises(RuntimeError):
+            agg("p0")
+
+    def test_raw_residual_mode_raises_on_inf_landmark(self):
+        img_sim = torch.zeros(1, 5)
+        lm_sim = torch.tensor([[0.1, 0.3, float("inf"), 0.5, 0.2]])
+        agg = self._make(img_sim, lm_sim, landmark_use_raw_residual=True)
+        with self.assertRaises(RuntimeError):
+            agg("p0")
+
+    def test_normalized_residual_mode_falls_back_to_image_only_on_nan(self):
+        """Asymmetric contract: with landmark_use_raw_residual=False the
+        normalized branch keeps #626's "NaN = no landmark info, image-only
+        fallback" semantics."""
+        torch.manual_seed(0)
+        img_sim = torch.randn(1, 6) * 0.3 + 0.4
+        lm_sim = torch.tensor([[0.1, float("nan"), 0.7, 0.3, float("nan"), 0.5]])
+        sigma_img, sigma_lm = 0.187, 0.72
         agg = self._make(img_sim, lm_sim, image_sigma=sigma_img,
                          landmark_sigma=sigma_lm,
-                         landmark_use_raw_residual=True)
+                         landmark_use_raw_residual=False)
         out = agg("p0")
 
         log_p_img = wag_observation_log_likelihood_from_similarity_matrix(


### PR DESCRIPTION
## Summary

Add an opt-in \`landmark_use_raw_residual\` flag on \`SafaPlusNormalizedLandmarkAggregatorConfig\` (default \`False\`, preserves #626 behavior bit-exact). When \`True\`, the landmark stream uses the SAFA-form raw residual (\`row_max − sim_t\`, same helper as the image stream) instead of the per-row /max-normalized residual — appropriate when the second matrix is itself a SAFA-form similarity matrix (e.g. the OSM-tile baseline) on the same raw-cosine scale as the image stream.

NaN handling preserved by substituting the finite row-min into the helper before masking those positions to image-only output, so the helper's \`.max()\` isn't poisoned.

## Why

#626 introduced \`SafaPlusNormalizedLandmarkAggregator\` with a single landmark-stream shape: \`r_norm = 1 − sim_t/row_max\`, Gaussian on \`r_norm\`. That's the correct inverse transform when the landmark matrix is on a different scale than the image matrix (the original normalized-correspondence case).

The WAG+OSM evaluation in the paper figure uses an OSM-tile-baseline SAFA matrix as the second stream — same raw-cosine scale as the image stream. Applying /max-normalization to it suppresses the informative content and we see degraded performance. The new flag matches the residual shape to the data: effective output becomes \`wag_helper(img) + wag_helper(lm)\`.

This is what makes the WAG+OSM eval in the paper figure meaningfully distinct from #626's \"ours\" approach.

## Test plan

- [x] \`bazel test //experimental/overhead_matching/swag/filter:adaptive_aggregators_test\` — passes; two new tests:
  - \`test_raw_residual_mode_equals_sum_of_safa_streams\` verifies the math reduces to \`wag_helper(img) + wag_helper(lm)\` when all finite.
  - \`test_raw_residual_mode_zeroes_nan_landmark_entries\` verifies NaN positions fall back to image-only and output stays finite.
- [x] All #626 existing tests still pass (default flag \`False\` → bit-exact prior behavior).