### PR TITLE
Local-LLM correspondence timing benchmark (Gemma 3 27B)

### DIFF
--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -893,6 +893,28 @@ py_binary(
   ]
 )
 
+py_library(
+  name="correspondence_scaling_common",
+  srcs=["correspondence_scaling_common.py"],
+  visibility=["//experimental/overhead_matching/swag:__subpackages__"],
+  deps=[
+    ":landmark_pairing_cli_lib",
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/model:additional_panorama_extractors",
+  ]
+)
+
+py_binary(
+  name="benchmark_correspondence_scaling_ollama",
+  srcs=["benchmark_correspondence_scaling_ollama.py"],
+  deps=[
+    requirement("ollama"),
+    ":correspondence_scaling_common",
+    "//common/ollama:pyollama",
+  ]
+)
+
 py_binary(
   name="convert_gemini_landmark_pairing_responses_to_viewer_json",
   srcs=["convert_gemini_landmark_pairing_responses_to_viewer_json.py"],

--- a/experimental/overhead_matching/swag/scripts/benchmark_correspondence_scaling_ollama.py
+++ b/experimental/overhead_matching/swag/scripts/benchmark_correspondence_scaling_ollama.py
@@ -1,0 +1,195 @@
+"""Sweep gemma3:27b (via ollama) over growing OSM-candidate context fills.
+
+Measures prefill/decode throughput and the max usable context on the local GPU for
+the whole-stockpile landmark-correspondence task, then extrapolates the calls and
+wall-clock to match a whole city (Chicago by default).
+
+Usage:
+    bazel run //experimental/overhead_matching/swag/scripts:benchmark_correspondence_scaling_ollama -- \
+        --output_dir /tmp/corr_scaling/gemma3_27b \
+        --candidate_fills 100,1000,5000,10000,20000 \
+        --pano_batch 10 --thinking both
+
+The Gemma 3 family is not a native reasoning model, so "thinking on" is best-effort:
+we try ollama's think=True and fall back to a chain-of-thought system instruction
+(free-text output, JSON parsed from the tail), flagged as emulated in the report.
+"""
+
+import argparse
+import functools
+import math
+import time
+from pathlib import Path
+
+from common.ollama.pyollama import Ollama
+
+print = functools.partial(print, flush=True)  # noqa: A001 - stream progress to redirected logs
+from experimental.overhead_matching.swag.scripts import correspondence_scaling_common as common
+
+
+def _next_pow2(n: int) -> int:
+    return 1 << max(0, math.ceil(math.log2(max(1, n))))
+
+
+def _choose_num_ctx(prompt_tokens_est: int, output_headroom: int, max_num_ctx: int) -> int:
+    return min(max_num_ctx, max(4096, _next_pow2(prompt_tokens_est + output_headroom)))
+
+
+def _run_one(client, model, system, user, num_ctx, think, use_schema):
+    """One chat call. Returns (response_obj, error_str_or_None)."""
+    kwargs = dict(
+        model=model,
+        messages=[{"role": "system", "content": system},
+                  {"role": "user", "content": user}],
+        options={"num_ctx": num_ctx, "temperature": 0.0},
+    )
+    if use_schema:
+        kwargs["format"] = common.MATCH_SCHEMA
+    if think is not None:
+        kwargs["think"] = think
+    try:
+        return client.chat(**kwargs), None
+    except Exception as e:  # noqa: BLE001 - want to record OOM/unsupported-think as data
+        return None, f"{type(e).__name__}: {e}"
+
+
+def _ns_to_s(ns) -> float:
+    return (ns or 0) / 1e9
+
+
+def _sweep_thinking_mode(client, model, thinking, fills, pano_batch, queries, stockpile,
+                         gpu_safe_num_ctx, output_headroom, tokens_per_cand):
+    """Run the candidate-fill sweep for one thinking mode. Returns list[SweepPoint]."""
+    points = []
+    emulated = False
+    for fill in fills:
+        candidates = stockpile[:fill]
+        query_landmarks = queries[:pano_batch]
+        user = common.build_match_prompt(query_landmarks, candidates)
+        system = common.MATCH_SYSTEM_PROMPT
+
+        think_arg = None
+        use_schema = True
+        if thinking == "on":
+            think_arg = True  # first attempt: native thinking
+
+        prompt_est = int(tokens_per_cand * (fill + pano_batch)) + 2000
+        needed_ctx = prompt_est + output_headroom
+        # Don't even submit a prompt that would need a KV cache too big for the GPU --
+        # record it as the max-usable-context ceiling and stop growing the fill.
+        if needed_ctx > gpu_safe_num_ctx:
+            note = f"needs num_ctx~{needed_ctx} > gpu_safe ceiling {gpu_safe_num_ctx}"
+            print(f"  [b{pano_batch} {thinking}] fill={fill}: STOP ({note})")
+            points.append(common.SweepPoint(
+                model=model, thinking=thinking, thinking_emulated=emulated,
+                n_candidates=fill, n_queries=pano_batch, prompt_tokens=0, output_tokens=0,
+                prefill_s=0.0, decode_s=0.0, total_latency_s=0.0,
+                parsed_ok=False, schema_ok=False, ok=False, note=note))
+            break
+        num_ctx = _choose_num_ctx(prompt_est, output_headroom, gpu_safe_num_ctx)
+        t0 = time.perf_counter()
+        resp, err = _run_one(client, model, system, user, num_ctx, think_arg, use_schema)
+
+        # gemma3 doesn't support native thinking -> emulate with CoT, free-text output.
+        if err is not None and thinking == "on" and "think" in err.lower():
+            emulated = True
+            system = common.MATCH_SYSTEM_PROMPT + common.MATCH_THINKING_SUFFIX
+            t0 = time.perf_counter()
+            resp, err = _run_one(client, model, system, user, num_ctx,
+                                 think=None, use_schema=False)
+
+        if err is not None:
+            print(f"  [b{pano_batch} {thinking}] fill={fill}: STOP ({err})")
+            points.append(common.SweepPoint(
+                model=model, thinking=thinking, thinking_emulated=emulated,
+                n_candidates=fill, n_queries=pano_batch, prompt_tokens=0, output_tokens=0,
+                prefill_s=0.0, decode_s=0.0, total_latency_s=0.0,
+                parsed_ok=False, schema_ok=False, ok=False, note=err))
+            break  # larger fills will only fail harder
+
+        wall = time.perf_counter() - t0
+        content = resp.message.content or ""
+        prompt_tokens = resp.prompt_eval_count or 0
+        output_tokens = resp.eval_count or 0
+        prefill_s = _ns_to_s(resp.prompt_eval_duration)
+        decode_s = _ns_to_s(resp.eval_duration)
+        total = prefill_s + decode_s if (prefill_s + decode_s) > 0 else wall
+        parsed_ok, schema_ok = common.validate_json(common.extract_json_blob(content))
+
+        points.append(common.SweepPoint(
+            model=model, thinking=thinking, thinking_emulated=emulated,
+            n_candidates=fill, n_queries=pano_batch,
+            prompt_tokens=prompt_tokens, output_tokens=output_tokens,
+            prefill_s=prefill_s, decode_s=decode_s, total_latency_s=total,
+            parsed_ok=parsed_ok, schema_ok=schema_ok, ok=True,
+            note=f"num_ctx={num_ctx}"))
+        p = points[-1]
+        print(f"  [b{pano_batch} {thinking}] fill={fill}: {prompt_tokens} ptok, {output_tokens} otok, "
+              f"prefill {p.prefill_tok_s:,.0f} tok/s, decode {p.decode_tok_s:,.0f} tok/s, "
+              f"latency {total:.1f}s, json_ok={schema_ok}")
+    return points
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", default="gemma3:27b")
+    ap.add_argument("--city", default=common.DEFAULT_CITY)
+    ap.add_argument("--thinking", choices=["on", "off", "both"], default="both")
+    ap.add_argument("--candidate_fills", default="100,500,1000,2000,4000",
+                    help="Comma-separated OSM-candidate counts to pack into context")
+    ap.add_argument("--pano_batches", default="1,10,40",
+                    help="Comma-separated pano-query batch sizes to sweep (queries per call)")
+    ap.add_argument("--gpu_safe_num_ctx", type=int, default=65536,
+                    help="Largest num_ctx to submit; fills needing more are recorded as the ceiling")
+    ap.add_argument("--output_headroom", type=int, default=4096,
+                    help="Tokens reserved for the model's output in num_ctx sizing")
+    ap.add_argument("--call_timeout_s", type=float, default=900.0,
+                    help="Per-request HTTP timeout; a slower call is recorded as the ceiling")
+    ap.add_argument("--output_dir", type=Path, required=True)
+    args = ap.parse_args()
+
+    fills = [int(x) for x in args.candidate_fills.split(",") if x.strip()]
+    pano_batches = [int(x) for x in args.pano_batches.split(",") if x.strip()]
+    modes = ["off", "on"] if args.thinking == "both" else [args.thinking]
+
+    print(f"Loading OSM stockpile and pano queries for {args.city}...")
+    stockpile = common.load_osm_stockpile(city=args.city)
+    queries = common.load_pano_query_landmarks(city=args.city)
+    print(f"  stockpile: {len(stockpile):,} OSM landmarks | query pool: {len(queries):,} pano landmarks")
+    fills = [f for f in fills if f <= len(stockpile)] or [len(stockpile)]
+
+    all_points = []
+    with Ollama(args.model) as server:
+        client = server.client
+        # Bound each request so a pathological large-context prefill is recorded as the
+        # ceiling instead of hanging the whole sweep.
+        client._client.timeout = args.call_timeout_s
+        # Warm-up + tokens-per-candidate estimate (excluded from results).
+        warm_user = common.build_match_prompt(queries[:pano_batches[0]], stockpile[:50])
+        warm, err = _run_one(client, args.model, common.MATCH_SYSTEM_PROMPT, warm_user,
+                             num_ctx=8192, think=None, use_schema=True)
+        if err is not None:
+            raise RuntimeError(f"Warm-up call failed: {err}")
+        tokens_per_cand = max(5.0, (warm.prompt_eval_count or 2500) / 50.0)
+        print(f"Warm-up: ~{tokens_per_cand:.1f} prompt tokens per candidate landmark")
+
+        for mode in modes:
+            for pano_batch in pano_batches:
+                print(f"\n=== thinking={mode}, pano_batch={pano_batch} ===")
+                all_points += _sweep_thinking_mode(
+                    client, args.model, mode, fills, pano_batch, queries, stockpile,
+                    args.gpu_safe_num_ctx, args.output_headroom, tokens_per_cand)
+
+    out_path = args.output_dir / "sweep_points.jsonl"
+    common.dump_sweep_points(all_points, out_path)
+    print(f"\nWrote {len(all_points)} sweep points to {out_path}")
+
+    num_query_landmarks = len(queries)
+    reports = common.extrapolate(all_points, stockpile_size=len(stockpile),
+                                 num_query_landmarks=num_query_landmarks)
+    common.print_report(reports, stockpile_size=len(stockpile),
+                        num_query_landmarks=num_query_landmarks)
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/correspondence_scaling_README.md
+++ b/experimental/overhead_matching/swag/scripts/correspondence_scaling_README.md
@@ -1,0 +1,64 @@
+# Local-LLM correspondence timing benchmark
+
+Measures how long a local LLM would take to replace the learned correspondence model:
+prompted to match a panorama's landmarks directly against a city's full OpenStreetMap
+landmark set. This backs the timing comparison in the paper (Gemma 3 27B: ~5.4 min /
+panorama without thinking, ~7.6 min with chain-of-thought, vs the 3.7 s learned step).
+
+## What it does
+
+The correspondence model cheaply scores each panorama landmark against the whole city
+stockpile. An LLM must instead read candidate OSM landmarks into a finite context window,
+so covering the full stockpile (Chicago: 28,582 unique tag bundles) requires streaming the
+candidates through in chunks. The benchmark measures single-stream per-call latency
+(prefill + decode) on the local GPU at a range of context fills and query-batch sizes, then
+extrapolates to per-landmark / per-panorama / full-city cost.
+
+- `correspondence_scaling_common.py` — library: loads the Chicago OSM stockpile (VIGOR
+  `v4_202001` landmarks) and panorama query landmarks (pano_v2 `panov2_tuned_prompt`),
+  builds the match prompt, validates JSON output, and extrapolates per-call timings to a
+  whole city.
+- `benchmark_correspondence_scaling_ollama.py` — runnable benchmark for `gemma3:27b` via
+  ollama.
+
+## Setup (one-time, not CI-reproducible — needs a local GPU + ollama)
+
+1. Install ollama (https://ollama.com) and ensure the `ollama` binary is on PATH. The
+   `gemma3:27b` weights (~17 GB) are pulled automatically on first run.
+2. The VIGOR dataset and pano_v2 embeddings must be present under
+   `/data/overhead_matching/datasets/` (see `data/README.md`).
+
+## Run
+
+```bash
+bazel run //experimental/overhead_matching/swag/scripts:benchmark_correspondence_scaling_ollama -- \
+  --candidate_fills 500 --pano_batches 1,2,3,5 --thinking off \
+  --gpu_safe_num_ctx 65536 --output_headroom 8192 \
+  --output_dir /tmp/corr_scaling/gemma3_off
+
+# thinking on (chain-of-thought; gemma3 has no native thinking mode):
+#   --thinking on
+```
+
+## Output
+
+- stdout: one line per measured call (prompt/output tokens, prefill & decode tok/s, latency)
+  plus an extrapolation report (operating-point curve, chosen point, per-pano-landmark time,
+  full-city totals).
+- `<output_dir>/sweep_points.jsonl`: machine-readable per-point record — the traceable
+  source of the reported numbers.
+
+## Reference results
+
+The sweep results behind the paper figures are stored at
+`/data/overhead_matching/evaluation/timing/`:
+- `gemma3_27b_thinking_off_per_panorama.jsonl` — ~5.4 min / panorama
+- `gemma3_27b_thinking_on_cot_per_panorama.jsonl` — ~7.6 min / panorama
+
+## Notes
+
+- "single-stream" = one request at a time (the latency a robot processing observations
+  sequentially would see), no concurrent request batching.
+- Gemma 3 has no native thinking mode (ollama reports `completion`+`vision` only), so
+  `--thinking on` emulates it with a chain-of-thought instruction; that output is free text,
+  so schema-valid JSON is not enforced in that mode.

--- a/experimental/overhead_matching/swag/scripts/correspondence_scaling_common.py
+++ b/experimental/overhead_matching/swag/scripts/correspondence_scaling_common.py
@@ -1,0 +1,338 @@
+"""Shared helpers for the local-LLM correspondence scaling benchmark.
+
+The question this benchmark answers: *if we replaced the learned correspondence
+model with a local LLM, how long would it take?* The correspondence model cheaply
+scores, for each panorama (street-level) landmark, which OSM landmarks in the entire
+city stockpile it could correspond to. An LLM instead has to read candidate OSM
+landmarks into a finite context window, so covering the whole stockpile needs many
+large-context calls per query.
+
+This module provides:
+  - data loading for one city (Chicago by default): the full OSM landmark stockpile
+    and a pool of realistic panorama query landmarks,
+  - a prompt builder framed for the *whole-stockpile search* task,
+  - JSON validation for free-text model outputs,
+  - a SweepPoint record + JSONL dump, and
+  - an extrapolation/report that turns measured per-call latency and max usable
+    context into a total call count and wall-clock for the full city.
+
+It is imported by the benchmark binary (benchmark_correspondence_scaling_ollama).
+"""
+
+import dataclasses
+import json
+import math
+from pathlib import Path
+
+import common.torch.load_torch_deps  # noqa: F401  (must precede torch-importing modules)
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.model.additional_panorama_extractors import load_v2_pickle
+from experimental.overhead_matching.swag.scripts.landmark_pairing_cli import (
+    extract_tags_from_pano_data, format_tags)
+
+
+DEFAULT_VIGOR_BASE = Path("/data/overhead_matching/datasets/VIGOR/")
+DEFAULT_PANO_BASE = Path(
+    "/data/overhead_matching/datasets/semantic_landmark_embeddings/panov2_tuned_prompt")
+DEFAULT_CITY = "Chicago"
+DEFAULT_LANDMARK_VERSION = "v4_202001"
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def load_osm_stockpile(city: str = DEFAULT_CITY,
+                       vigor_base: Path = DEFAULT_VIGOR_BASE,
+                       landmark_version: str = DEFAULT_LANDMARK_VERSION) -> list[str]:
+    """Return the deduplicated OSM landmark stockpile for a city as tag strings.
+
+    Each string is ``key=value; key=value`` (same formatting used in the real
+    pairing prompts). Deduplication is by pruned tag set, matching
+    ``landmark_pairing_cli.osm_landmarks_from_pano_id``.
+    """
+    config = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None,
+        panorama_tensor_cache_info=None,
+        should_load_images=False,
+        should_load_landmarks=True,
+        landmark_version=landmark_version,
+    )
+    dataset = vd.VigorDataset(dataset_path=Path(vigor_base) / city, config=config)
+    props = dataset._landmark_metadata["pruned_props"].values
+    unique_props = sorted(set(props), key=lambda fs: sorted(fs))
+    return [format_tags(sorted(p)) for p in unique_props if len(p) > 0]
+
+
+def load_pano_query_landmarks(city: str = DEFAULT_CITY,
+                              pano_base: Path = DEFAULT_PANO_BASE) -> list[str]:
+    """Return a flat pool of panorama (street-level) landmark tag strings for a city.
+
+    Reads only ``<pano_base>/<city>/embeddings/embeddings.pkl`` directly (rather than
+    every city) and applies the same keep-list tag pruning as the pairing CLI.
+    """
+    pickle_path = Path(pano_base) / city / "embeddings" / "embeddings.pkl"
+    data = load_v2_pickle(pickle_path)
+    if data is None or "panoramas" not in data:
+        raise FileNotFoundError(f"No v2.0 panorama pickle at {pickle_path}")
+    queries: list[str] = []
+    for pano_id, pano_data in data["panoramas"].items():
+        landmarks = extract_tags_from_pano_data(pano_id.split(",")[0], pano_data)
+        if not landmarks:
+            continue
+        for lm in landmarks:
+            queries.append(format_tags(lm["tags"]))
+    return queries
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction (whole-stockpile search framing)
+# ---------------------------------------------------------------------------
+
+MATCH_SYSTEM_PROMPT = """You are a landmark matching expert. You are given two lists of \
+OpenStreetMap-style tag bundles in key=value notation.
+
+"Query landmarks" were extracted from street-level imagery. "Candidate landmarks" come \
+from an OpenStreetMap map database. For each query landmark, identify which candidate \
+landmarks (by id) could plausibly be the same physical object. A query may match zero, \
+one, or several candidates. Only report matches you are confident about."""
+
+MATCH_THINKING_SUFFIX = (
+    "\n\nThink step by step about each query before answering, then give the final answer.")
+
+MATCH_SCHEMA = {
+    "type": "object",
+    "required": ["matches"],
+    "properties": {
+        "matches": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["query_id", "candidate_ids"],
+                "properties": {
+                    "query_id": {"type": "integer"},
+                    "candidate_ids": {"type": "array", "items": {"type": "integer"}},
+                },
+            },
+        }
+    },
+}
+
+
+def itemized(items) -> str:
+    return "\n".join(f" {i}. {v}" for i, v in enumerate(items))
+
+
+def build_match_prompt(query_landmarks: list[str],
+                       candidate_landmarks: list[str]) -> str:
+    """Build the user prompt for one whole-stockpile-search call."""
+    return (f"Query landmarks (seen from street level):\n{itemized(query_landmarks)}\n\n"
+            f"Candidate map landmarks (OpenStreetMap database):\n{itemized(candidate_landmarks)}")
+
+
+# ---------------------------------------------------------------------------
+# Output validation
+# ---------------------------------------------------------------------------
+
+def extract_json_blob(text: str) -> str:
+    """Best-effort: the substring from the first '{' to the last '}'.
+
+    Lets the validators tolerate models (or emulated chain-of-thought) that wrap the
+    JSON object in surrounding prose.
+    """
+    start = text.find("{")
+    end = text.rfind("}")
+    return text[start:end + 1] if 0 <= start < end else text
+
+
+def validate_json(text: str) -> tuple[bool, bool]:
+    """Return (parsed_ok, schema_ok) for a model's free-text output.
+
+    parsed_ok: text parses as JSON. schema_ok: it has a ``matches`` list whose items
+    carry an int ``query_id`` and an int-list ``candidate_ids``.
+    """
+    try:
+        obj = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return False, False
+    matches = obj.get("matches") if isinstance(obj, dict) else None
+    if not isinstance(matches, list):
+        return True, False
+    for m in matches:
+        if not isinstance(m, dict):
+            return True, False
+        if not isinstance(m.get("query_id"), int):
+            return True, False
+        cids = m.get("candidate_ids")
+        if not isinstance(cids, list) or not all(isinstance(c, int) for c in cids):
+            return True, False
+    return True, True
+
+
+# ---------------------------------------------------------------------------
+# Sweep records
+# ---------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class SweepPoint:
+    model: str
+    thinking: str            # "on" | "off"
+    thinking_emulated: bool  # True if "thinking on" was approximated (e.g. gemma3 CoT)
+    n_candidates: int        # OSM candidates packed into context
+    n_queries: int           # pano query landmarks per call (the batch size)
+    prompt_tokens: int
+    output_tokens: int
+    prefill_s: float
+    decode_s: float
+    total_latency_s: float
+    parsed_ok: bool
+    schema_ok: bool
+    ok: bool                 # call completed without OOM / fatal error
+    note: str = ""
+
+    @property
+    def prefill_tok_s(self) -> float:
+        return self.prompt_tokens / self.prefill_s if self.prefill_s > 0 else 0.0
+
+    @property
+    def decode_tok_s(self) -> float:
+        return self.output_tokens / self.decode_s if self.decode_s > 0 else 0.0
+
+
+def dump_sweep_points(points: list[SweepPoint], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        for p in points:
+            row = dataclasses.asdict(p)
+            row["prefill_tok_s"] = p.prefill_tok_s
+            row["decode_tok_s"] = p.decode_tok_s
+            f.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Extrapolation to a full city
+# ---------------------------------------------------------------------------
+
+def _batched_wall_s(point: SweepPoint, stockpile_size: int, num_query_landmarks: int) -> float:
+    ctx_chunks = math.ceil(stockpile_size / point.n_candidates)
+    query_batches = math.ceil(num_query_landmarks / point.n_queries)
+    return ctx_chunks * query_batches * point.total_latency_s
+
+
+def extrapolate(points: list[SweepPoint],
+                stockpile_size: int,
+                num_query_landmarks: int) -> list[dict]:
+    """Project measured per-call cost to matching a whole city's stockpile.
+
+    Groups points by (model, thinking). To give the LLM its best shot, "best-case
+    batched" picks the *wall-clock-minimizing* operating point across the sweep (not
+    simply the largest context): packing more candidates per call cuts the number of
+    context-chunks but raises per-call latency (more prefill, and the model emits more
+    claimed matches), so the optimum is usually an interior point. For the chosen
+    point we report:
+
+      best_case_batched : ceil(stockpile/lpc) * ceil(queries/pano_batch) calls
+      one_at_a_time     : ceil(stockpile/lpc) * queries calls (pano_batch -> 1)
+
+    one_at_a_time reuses the chosen point's per-call latency, so it is an *optimistic*
+    lower bound for that strategy and still strictly worse than batched. Each group
+    also carries the full per-operating-point curve.
+    """
+    groups: dict[tuple[str, str], list[SweepPoint]] = {}
+    for p in points:
+        if p.ok and p.n_candidates > 0:
+            groups.setdefault((p.model, p.thinking), []).append(p)
+
+    reports = []
+    for (model, thinking), pts in sorted(groups.items()):
+        curve = []
+        for p in sorted(pts, key=lambda p: p.n_candidates):
+            wall = _batched_wall_s(p, stockpile_size, num_query_landmarks)
+            curve.append({
+                "n_candidates": p.n_candidates,
+                "latency_s": p.total_latency_s,
+                "output_tokens": p.output_tokens,
+                "prompt_tokens": p.prompt_tokens,
+                "batched_wall_clock_s": wall,
+                "batched_wall_clock_days": wall / 86400.0,
+            })
+
+        best = min(pts, key=lambda p: _batched_wall_s(p, stockpile_size, num_query_landmarks))
+        lpc = best.n_candidates
+        pano_batch = best.n_queries
+        latency = best.total_latency_s
+        ctx_chunks = math.ceil(stockpile_size / lpc)
+        batched_calls = ctx_chunks * math.ceil(num_query_landmarks / pano_batch)
+        one_at_a_time_calls = ctx_chunks * num_query_landmarks
+        reports.append({
+            "model": model,
+            "thinking": thinking,
+            "thinking_emulated": best.thinking_emulated,
+            "landmarks_per_ctx": lpc,
+            "pano_batch": pano_batch,
+            "latency_at_chosen_ctx_s": latency,
+            "prompt_tokens_at_chosen_ctx": best.prompt_tokens,
+            "output_tokens_at_chosen_ctx": best.output_tokens,
+            "prefill_tok_s": best.prefill_tok_s,
+            "decode_tok_s": best.decode_tok_s,
+            "ctx_chunks_for_stockpile": ctx_chunks,
+            "operating_points": curve,
+            "best_case_batched": {
+                "calls": batched_calls,
+                "wall_clock_s": batched_calls * latency,
+                "wall_clock_days": batched_calls * latency / 86400.0,
+                # Cost to compare ONE pano query landmark against the whole stockpile,
+                # amortized over the pano_batch queries that share each context-chunk:
+                #   ctx_chunks * latency / pano_batch
+                "seconds_per_query_landmark": ctx_chunks * latency / pano_batch,
+            },
+            "one_at_a_time": {
+                "calls": one_at_a_time_calls,
+                "wall_clock_s": one_at_a_time_calls * latency,
+                "wall_clock_days": one_at_a_time_calls * latency / 86400.0,
+            },
+        })
+    return reports
+
+
+def _fmt_duration(seconds: float) -> str:
+    if seconds < 90:
+        return f"{seconds:.1f}s"
+    if seconds < 5400:
+        return f"{seconds / 60:.1f}min"
+    if seconds < 2 * 86400:
+        return f"{seconds / 3600:.1f}h"
+    return f"{seconds / 86400:.1f}d"
+
+
+def print_report(reports: list[dict], stockpile_size: int, num_query_landmarks: int) -> None:
+    print("\n" + "=" * 100)
+    print(f"CORRESPONDENCE SCALING EXTRAPOLATION  "
+          f"(stockpile={stockpile_size:,} OSM landmarks, "
+          f"queries={num_query_landmarks:,} pano landmarks)")
+    print("=" * 100)
+    for r in reports:
+        emu = " (emulated)" if r["thinking_emulated"] and r["thinking"] == "on" else ""
+        print(f"\n{r['model']}  |  thinking={r['thinking']}{emu}")
+        print(f"  operating points (candidates/ctx -> latency, out_tok, full-city days):")
+        for c in r["operating_points"]:
+            marker = "  *" if c["n_candidates"] == r["landmarks_per_ctx"] else "   "
+            print(f"   {marker} {c['n_candidates']:>6,} -> {_fmt_duration(c['latency_s']):>7}/call, "
+                  f"{c['output_tokens']:>6,} out_tok, {c['batched_wall_clock_days']:>8,.1f} days")
+        print(f"  chosen (min wall)   : {r['landmarks_per_ctx']:,} candidates/ctx "
+              f"(~{r['prompt_tokens_at_chosen_ctx']:,} prompt tok, "
+              f"{r['output_tokens_at_chosen_ctx']:,} out tok), pano_batch={r['pano_batch']}")
+        print(f"  throughput          : prefill {r['prefill_tok_s']:,.0f} tok/s, "
+              f"decode {r['decode_tok_s']:,.0f} tok/s, "
+              f"latency/call {_fmt_duration(r['latency_at_chosen_ctx_s'])}")
+        print(f"  stockpile coverage  : {r['ctx_chunks_for_stockpile']} context-chunks per query-batch")
+        b = r["best_case_batched"]
+        o = r["one_at_a_time"]
+        print(f"  PER PANO LANDMARK   : {_fmt_duration(b['seconds_per_query_landmark'])} "
+              f"to compare 1 landmark against the whole stockpile "
+              f"({r['ctx_chunks_for_stockpile']} chunks / pano_batch {r['pano_batch']})")
+        print(f"  BEST-CASE BATCHED   : {b['calls']:,} calls  ->  "
+              f"{_fmt_duration(b['wall_clock_s'])}  ({b['wall_clock_days']:,.1f} days)")
+        print(f"  one-at-a-time       : {o['calls']:,} calls  ->  "
+              f"{_fmt_duration(o['wall_clock_s'])}  ({o['wall_clock_days']:,.1f} days)")
+    print("\n" + "=" * 100)


### PR DESCRIPTION
## What

Adds a benchmark measuring the cost of **replacing the learned correspondence model with a local LLM** that matches a panorama's landmarks directly against a city's full OSM landmark set. This backs the timing comparison in the paper.

The correspondence model cheaply scores each panorama landmark against the whole city stockpile; an LLM must instead read candidate OSM landmarks into a finite context window. So we stream the 28,582 unique Chicago landmark tag bundles through the model in chunks and time **single-stream** prefill+decode latency on the local GPU (RTX 5090), then extrapolate to per-landmark / per-panorama / full-city cost.

## Result (backs the paper)

| config | per panorama |
|---|---|
| Gemma 3 27B, no thinking | ~5.4 min |
| Gemma 3 27B, chain-of-thought | ~7.6 min |
| learned correspondence step | 3.7 s |

→ roughly two orders of magnitude slower.

## Files

- `correspondence_scaling_common.py` — loads the Chicago OSM stockpile (VIGOR `v4_202001`) + panorama query landmarks (pano_v2 `panov2_tuned_prompt`), builds the match prompt, validates JSON output, and extrapolates per-call timings to a whole city.
- `benchmark_correspondence_scaling_ollama.py` — runnable sweep for `gemma3:27b` via ollama (candidate-fill × query-batch × thinking on/off).
- `correspondence_scaling_README.md` — setup + reproduction commands.

## Reproduction / notes

- Requires a local GPU + ollama (`gemma3:27b` pulled on first run, ~17 GB) and the VIGOR/pano_v2 data under `/data/overhead_matching/datasets/` — not CI-reproducible. Commands are in the README.
- Reference sweep results behind the figures live at `/data/overhead_matching/evaluation/timing/` (`gemma3_27b_thinking_off_per_panorama.jsonl`, `gemma3_27b_thinking_on_cot_per_panorama.jsonl`).
- Gemma 3 has no native thinking mode (ollama reports `completion`+`vision`), so `--thinking on` emulates it via chain-of-thought prompting.