### PR TITLE
[archive] Piecewise/LR landmark observation model (unused)

### DIFF
--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators.py
@@ -86,12 +86,65 @@ class SafaPlusNormalizedLandmarkAggregatorConfig(
             raise ValueError(f"landmark_sigma must be positive, got {self.landmark_sigma}")
 
 
+class SafaPlusPiecewiseLandmarkAggregatorConfig(
+    msgspec.Struct, **MSGSPEC_STRUCT_OPTS
+):
+    """Config for ``SafaPlusPiecewiseLandmarkAggregator`` (prototype).
+
+    Same image stream as ``SafaPlusNormalizedLandmarkAggregator`` (SAFA
+    Gaussian-on-residuals at ``image_sigma``). The landmark stream replaces the
+    single half-normal Gaussian on the normalized residual
+    ``r = 1 - sim / row_max`` with a calibrated, piecewise-constant
+    *log-likelihood-ratio* lookup over ``r in [0, 1]``:
+
+      ``log_p_lm[j] = landmark_lr_scale * g(r_j)``
+
+    where ``g`` is the per-bin value ``log p(r|true) - log p(r|negative)``
+    estimated from a calibration matrix. This is the principled per-patch
+    factor for the histogram filter under conditional independence of patches
+    given the true location; ``0`` means "uninformative", so the natural
+    fall-through for missing / constant landmark rows is ``log_p_lm == 0``
+    (image-only) — consistent with the lookup baseline.
+
+    The lookup uses uniformly-wide bins (the discrete ``r == 0`` argmax-hit and
+    ``r == 1`` miss events simply land in the first / last bin — both
+    populations have their atoms at the same location, so the bin ratio
+    recovers them without special-casing). It is matrix-agnostic: a bimodal
+    Hungarian residual and a unimodal dense residual are both fit by the same
+    table.
+
+    ``landmark_lr_scale`` is an optional temperature multiplier; ``1.0`` is the
+    calibrated value. Calibration is produced by
+    ``calibrate_landmark_piecewise.py`` and frozen across cities (calibrated
+    once on a reference city), matching the single-``sigma_lm`` methodology of
+    the Gaussian variant.
+    """
+
+    image_similarity_matrix_path: Path
+    landmark_similarity_matrix_path: Path
+    image_sigma: float
+    landmark_log_lr_edges: list[float]
+    landmark_log_lr_values: list[float]
+    landmark_lr_scale: float = 1.0
+
+    def __post_init__(self):
+        if not (self.image_sigma > 0):
+            raise ValueError(f"image_sigma must be positive, got {self.image_sigma}")
+        if len(self.landmark_log_lr_edges) != len(self.landmark_log_lr_values) + 1:
+            raise ValueError(
+                "landmark_log_lr_edges must have one more entry than "
+                f"landmark_log_lr_values (got {len(self.landmark_log_lr_edges)} "
+                f"edges vs {len(self.landmark_log_lr_values)} bins)"
+            )
+
+
 # Union type for polymorphic deserialization.
 AggregatorConfig = (
     SingleSimilarityMatrixAggregatorConfig
     | ImageLandmarkPrivilegedInformationFusionConfig
     | EntropyAdaptiveAggregatorConfig
     | SafaPlusNormalizedLandmarkAggregatorConfig
+    | SafaPlusPiecewiseLandmarkAggregatorConfig
 )
 
 
@@ -548,6 +601,132 @@ class SafaPlusNormalizedLandmarkAggregator(ObservationLogLikelihoodAggregator):
         )
 
 
+class SafaPlusPiecewiseLandmarkAggregator(ObservationLogLikelihoodAggregator):
+    """SAFA image stream + piecewise likelihood-ratio landmark stream.
+
+    Prototype variant of ``SafaPlusNormalizedLandmarkAggregator``. The image
+    stream is identical. The landmark stream maps the per-row normalized
+    residual ``r = 1 - sim / row_max`` through a frozen, calibrated
+    piecewise-constant log-likelihood-ratio lookup instead of a half-normal
+    Gaussian:
+
+      ``log_p_lm[j] = landmark_lr_scale * values[bin(r_j)]``
+
+    where ``values`` are per-bin ``log p(r|true)/p(r|neg)``. ``0`` is
+    uninformative; missing / constant / all-zero landmark rows fall through to
+    image-only (``log_p_lm == 0``), matching the lookup baseline. The discrete
+    ``r == 0`` (argmax hit) and ``r == 1`` (miss) events land in the first /
+    last bin with no special-casing.
+
+    See ``SafaPlusPiecewiseLandmarkAggregatorConfig`` for the motivation (the
+    Hungarian landmark residual is strongly bimodal — a half-normal is the
+    wrong family and discards the highly-discriminative argmax-hit event while
+    over-penalizing the common miss event).
+    """
+
+    def __init__(
+        self,
+        image_similarity_matrix: torch.Tensor,
+        landmark_similarity_matrix: torch.Tensor,
+        panorama_metadata: pd.DataFrame,
+        image_sigma: float,
+        landmark_log_lr_edges: list[float],
+        landmark_log_lr_values: list[float],
+        device: torch.device,
+        landmark_lr_scale: float = 1.0,
+    ):
+        self.image_similarity_matrix = image_similarity_matrix
+        self.landmark_similarity_matrix = landmark_similarity_matrix
+        self.image_sigma = float(image_sigma)
+        self.landmark_lr_scale = float(landmark_lr_scale)
+        self.device = device
+        # Lookup tensors live on the compute device.
+        self._edges = torch.tensor(
+            landmark_log_lr_edges, dtype=torch.float32, device=device
+        )
+        self._values = torch.tensor(
+            landmark_log_lr_values, dtype=torch.float32, device=device
+        )
+        self._pano_id_index = pd.Index(panorama_metadata["pano_id"])
+
+    def _landmark_log_lr(self, r_norm: torch.Tensor) -> torch.Tensor:
+        """Map normalized residuals to landmark log-LR via the frozen lookup.
+
+        ``r_norm`` may contain non-finite entries (no landmark info); callers
+        mask those to 0 afterwards. ``right=True`` so a value equal to an edge
+        maps to the bin on its left; r==0 -> bin 0, r==1 -> last bin.
+        """
+        n_bins = self._values.numel()
+        idx = torch.bucketize(r_norm, self._edges, right=True) - 1
+        idx = idx.clamp(0, n_bins - 1)
+        return self._values[idx] * self.landmark_lr_scale
+
+    def __call__(self, pano_id: str) -> torch.Tensor:
+        pano_index = self._pano_id_index.get_loc(pano_id)
+
+        img_sim = self.image_similarity_matrix[pano_index].to(self.device)
+        lm_sim = self.landmark_similarity_matrix[pano_index].to(self.device)
+
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim, self.image_sigma
+        )
+        _raise_if_nonfinite(log_p_img, pano_id, "log_p_img", cls_name=type(self).__name__)
+
+        # Landmark stream. NaN means "no landmark info for this cell" (same
+        # sparse-with-holes contract as the normalized-residual variant): fall
+        # back to image-only at those positions, and image-only for whole rows
+        # that are all-zero / constant / NaN.
+        lm_finite_mask = torch.isfinite(lm_sim)
+        if not lm_finite_mask.any():
+            return log_p_img
+        lm_finite = lm_sim[lm_finite_mask]
+        sim_max_lm = lm_finite.max()
+        sim_min_lm = lm_finite.min()
+        if (sim_max_lm <= 0) or (sim_max_lm == sim_min_lm):
+            return log_p_img
+
+        r_norm = 1.0 - lm_sim / sim_max_lm
+        log_p_lm = self._landmark_log_lr(r_norm)
+        # Image-only (log_p_lm == 0) where the landmark entry is non-finite.
+        log_p_lm = torch.where(lm_finite_mask, log_p_lm, torch.zeros_like(log_p_lm))
+
+        log_p = log_p_img + log_p_lm
+        _raise_if_nonfinite(log_p, pano_id, "log_p_img + log_p_lm", cls_name=type(self).__name__)
+        return log_p
+
+    @classmethod
+    def from_config(
+        cls,
+        config: SafaPlusPiecewiseLandmarkAggregatorConfig,
+        vigor_dataset: vd.VigorDataset,
+        device: torch.device,
+    ) -> "SafaPlusPiecewiseLandmarkAggregator":
+        image_sim = _load_similarity_matrix(config.image_similarity_matrix_path)
+        landmark_sim = _load_similarity_matrix(config.landmark_similarity_matrix_path)
+        _assert_matrix_aligned(
+            image_sim,
+            vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
+            config.image_similarity_matrix_path,
+        )
+        _assert_matrix_aligned(
+            landmark_sim,
+            vigor_dataset._panorama_metadata,
+            vigor_dataset._satellite_metadata,
+            config.landmark_similarity_matrix_path,
+        )
+        return cls(
+            image_similarity_matrix=image_sim,
+            landmark_similarity_matrix=landmark_sim,
+            panorama_metadata=vigor_dataset._panorama_metadata,
+            image_sigma=config.image_sigma,
+            landmark_log_lr_edges=config.landmark_log_lr_edges,
+            landmark_log_lr_values=config.landmark_log_lr_values,
+            landmark_lr_scale=config.landmark_lr_scale,
+            device=device,
+        )
+
+
 def aggregator_from_config(
     config: AggregatorConfig,
     vigor_dataset: vd.VigorDataset,
@@ -572,6 +751,10 @@ def aggregator_from_config(
         return EntropyAdaptiveAggregator.from_config(config, vigor_dataset, device)
     elif isinstance(config, SafaPlusNormalizedLandmarkAggregatorConfig):
         return SafaPlusNormalizedLandmarkAggregator.from_config(
+            config, vigor_dataset, device
+        )
+    elif isinstance(config, SafaPlusPiecewiseLandmarkAggregatorConfig):
+        return SafaPlusPiecewiseLandmarkAggregator.from_config(
             config, vigor_dataset, device
         )
     else:

--- a/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
+++ b/experimental/overhead_matching/swag/filter/adaptive_aggregators_test.py
@@ -8,6 +8,8 @@ import pandas as pd
 from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
     SafaPlusNormalizedLandmarkAggregator,
     SafaPlusNormalizedLandmarkAggregatorConfig,
+    SafaPlusPiecewiseLandmarkAggregator,
+    SafaPlusPiecewiseLandmarkAggregatorConfig,
     SingleSimilarityMatrixAggregator,
 )
 from experimental.overhead_matching.swag.filter.particle_filter import (
@@ -228,6 +230,91 @@ class TestSafaPlusNormalizedLandmarkAggregator(unittest.TestCase):
                 landmark_similarity_matrix_path="/tmp/lm.pt",
                 image_sigma=0.5,
                 landmark_sigma=-0.1,
+            )
+
+
+class TestSafaPlusPiecewiseLandmarkAggregator(unittest.TestCase):
+    """Landmark stream maps r_norm = 1 - sim/row_max through a frozen
+    piecewise-constant log-LR lookup (uniform bins) times lr_scale; image-only
+    fall-through on missing / constant rows. r==0 lands in the first bin,
+    r==1 in the last bin."""
+
+    # 4 uniform bins over [0,1]: [0,.25),[.25,.5),[.5,.75),[.75,1]
+    EDGES = [0.0, 0.25, 0.5, 0.75, 1.0]
+    VALUES = [4.0, 2.0, 0.0, -1.0]
+
+    def _make(self, img_sim, lm_sim, image_sigma=0.187, lr_scale=1.0):
+        meta = _make_metadata(img_sim.shape[0])
+        return SafaPlusPiecewiseLandmarkAggregator(
+            image_similarity_matrix=img_sim,
+            landmark_similarity_matrix=lm_sim,
+            panorama_metadata=meta,
+            image_sigma=image_sigma,
+            landmark_log_lr_edges=self.EDGES,
+            landmark_log_lr_values=self.VALUES,
+            landmark_lr_scale=lr_scale,
+            device=torch.device("cpu"),
+        )
+
+    def test_bin_mapping_including_endpoints(self):
+        # row_max = 1.0 at idx 0. r_norm = 1 - sim.
+        #   idx0 sim=1.0 -> r=0.0  -> bin 0 (4.0)   [argmax-hit, first bin]
+        #   idx1 sim=0.0 -> r=1.0  -> bin 3 (-1.0)  [miss, last bin]
+        #   idx2 sim=0.9 -> r=0.1  -> bin 0 (4.0)
+        #   idx3 sim=0.4 -> r=0.6  -> bin 2 (0.0)
+        #   idx4 sim=0.2 -> r=0.8  -> bin 3 (-1.0)
+        img_sim = torch.zeros(1, 5)
+        lm_sim = torch.tensor([[1.0, 0.0, 0.9, 0.4, 0.2]])
+        agg = self._make(img_sim, lm_sim)
+        out = agg("p0")
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        log_p_lm = out - log_p_img
+        expected = torch.tensor([4.0, -1.0, 4.0, 0.0, -1.0])
+        self.assertTrue(torch.allclose(log_p_lm, expected, atol=1e-5),
+                        f"got {log_p_lm.tolist()}")
+
+    def test_lr_scale_multiplies_landmark_stream(self):
+        img_sim = torch.zeros(1, 5)
+        lm_sim = torch.tensor([[1.0, 0.0, 0.9, 0.4, 0.2]])
+        out1 = self._make(img_sim, lm_sim, lr_scale=1.0)("p0")
+        out2 = self._make(img_sim, lm_sim, lr_scale=2.0)("p0")
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        self.assertTrue(torch.allclose(
+            (out2 - log_p_img), 2.0 * (out1 - log_p_img), atol=1e-5))
+
+    def test_all_zero_row_falls_through_to_image_only(self):
+        img_sim = torch.randn(2, 20) * 0.3 + 0.4
+        lm_sim = torch.zeros(2, 20)
+        lm_sim[1] = torch.rand(20)
+        agg = self._make(img_sim, lm_sim)
+        expected = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        self.assertTrue(torch.allclose(agg("p0"), expected, atol=1e-6))
+
+    def test_nan_landmark_entry_is_image_only_at_that_position(self):
+        img_sim = torch.randn(1, 5) * 0.3 + 0.4
+        lm_sim = torch.tensor([[1.0, float("nan"), 0.9, 0.4, 0.2]])
+        agg = self._make(img_sim, lm_sim)
+        out = agg("p0")
+        log_p_img = wag_observation_log_likelihood_from_similarity_matrix(
+            img_sim[0], 0.187
+        )
+        self.assertTrue(torch.allclose(out[1], log_p_img[1], atol=1e-6))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_config_validates_edges_length(self):
+        with self.assertRaises(ValueError):
+            SafaPlusPiecewiseLandmarkAggregatorConfig(
+                image_similarity_matrix_path="/tmp/img.pt",
+                landmark_similarity_matrix_path="/tmp/lm.pt",
+                image_sigma=0.187,
+                landmark_log_lr_edges=[0.0, 0.5, 1.0],     # 2 bins
+                landmark_log_lr_values=[1.0, 0.0, -1.0],   # 3 values: mismatch
             )
 
 

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -1026,3 +1026,85 @@ py_binary(
     "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
   ]
 )
+
+py_binary(
+  name="sigma_paper_figure",
+  srcs=["sigma_paper_figure.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+    ":calibrate_sigma",
+  ]
+)
+
+py_binary(
+  name="residual_likelihood_analysis",
+  srcs=["residual_likelihood_analysis.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+    ":calibrate_sigma",
+  ]
+)
+
+py_binary(
+  name="calibrate_landmark_zoi",
+  srcs=["calibrate_landmark_zoi.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+    ":calibrate_sigma",
+  ]
+)
+
+py_binary(
+  name="calibrate_landmark_piecewise",
+  srcs=["calibrate_landmark_piecewise.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+  ]
+)
+
+py_binary(
+  name="plot_piecewise_calibration",
+  srcs=["plot_piecewise_calibration.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+    ":calibrate_landmark_piecewise",
+  ]
+)
+
+py_binary(
+  name="inspect_landmark_misses",
+  srcs=["inspect_landmark_misses.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    requirement("Pillow"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+  ]
+)
+

--- a/experimental/overhead_matching/swag/scripts/calibrate_landmark_piecewise.py
+++ b/experimental/overhead_matching/swag/scripts/calibrate_landmark_piecewise.py
@@ -1,0 +1,264 @@
+"""Calibrate the piecewise log-LR landmark observation model from ALL matrix
+entries (no Monte-Carlo negative sampling) and report discrimination D.
+
+The landmark stream of ``SafaPlusPiecewiseLandmarkAggregator`` maps the
+normalized residual ``r = 1 - sim/row_max`` through a piecewise-constant lookup
+``g(r) = log p(r|true) - log p(r|negative)`` over uniform bins on [0, 1].
+
+Negatives are *every* (pano, patch) residual in the matrix (true patches
+subtracted out exactly), so ``p(r|negative)`` is exact rather than a sampled
+estimate. The discrete r==0 (argmax hit) and r==1 (miss) events fall in the
+first / last bin — no special-casing.
+
+Discrimination  D = E_true[g] - E_neg[g]  measures the mean belief-update gap
+the lookup gives true vs negative patches (bigger = better; it equals the
+empirical ceiling when g is the binned empirical LR).
+
+Reports, for every eval city: D_self (the city's own lookup) and D_transfer
+(the frozen reference-city lookup applied to that city) — the latter is what a
+single frozen calibration actually achieves. Writes the reference city's
+calibration JSON for ``SafaPlusPiecewiseLandmarkAggregatorConfig``.
+"""
+
+from pathlib import Path
+import argparse
+import json
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import numpy as np
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+
+# city -> (dataset_path, landmark_version). Matrix path is derived as
+# <dataset>/similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt.
+CITY_INFO = {
+    "Seattle": ("/data/overhead_matching/datasets/VIGOR/Seattle", "v4_202001"),
+    "NewYork": ("/data/overhead_matching/datasets/VIGOR/NewYork", "v4_202001"),
+    "Boston": ("/data/overhead_matching/datasets/VIGOR/Boston", "boston"),
+    "Framingham": ("/data/overhead_matching/datasets/VIGOR/mapillary/Framingham", "Framingham_v1_260101"),
+    "Middletown": ("/data/overhead_matching/datasets/VIGOR/mapillary/Middletown", "Middletown_v1_250101"),
+    "Norway": ("/data/overhead_matching/datasets/VIGOR/mapillary/Norway", "Norway_v1_251201"),
+    "nightdrive": ("/data/overhead_matching/datasets/VIGOR/nightdrive", "boston"),
+    "post_hurricane_ian_sw": ("/data/overhead_matching/datasets/VIGOR/mapillary/post_hurricane_ian_sw", "post_hurricane_ian_sw_v1_220101"),
+    "SanFrancisco_mapillary": ("/data/overhead_matching/datasets/VIGOR/mapillary/SanFrancisco_mapillary", "SanFrancisco_mapillary_v1_220101"),
+}
+MATRIX_REL = "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt"
+
+
+def _bin_idx(r: torch.Tensor, edges: torch.Tensor) -> torch.Tensor:
+    """Bin residuals into 0..n_bins-1 using explicit edges (handles overflow)."""
+    inner = edges[1:-1].contiguous()
+    return torch.clamp(torch.bucketize(r, inner, right=False), 0, edges.numel() - 2)
+
+
+def _residual(M, rmax, residual_form):
+    """r = rowmax - sim  (raw, image stream)  or  1 - sim/rowmax  (normalized)."""
+    if residual_form == "raw":
+        return rmax[:, None] - M
+    safe = torch.where(rmax > 0, rmax, torch.ones_like(rmax))
+    return 1.0 - M / safe[:, None]
+
+
+def compute(dataset_path, landmark_version, matrix_path, edges,
+            include_semipositive, device, residual_form="normalized",
+            chunk_rows=1024):
+    """Return (true_hist, neg_hist) bin counts over all valid rows.
+
+    ``edges`` is a 1-D tensor of n_bins+1 bin edges. ``residual_form`` selects
+    ``raw`` (rowmax-sim, the image stream) or ``normalized`` (1-sim/rowmax, the
+    landmark stream). A row is excluded if it has no finite entries, is constant,
+    or (normalized only) row_max <= 0 — matching the image-only fall-through.
+    neg_hist = all-finite-entry hist minus true-pair hist.
+    """
+    sim = _load_similarity_matrix(Path(matrix_path))
+    cfg = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None, panorama_tensor_cache_info=None,
+        should_load_images=False, should_load_landmarks=False,
+        landmark_version=landmark_version)
+    ds = vd.VigorDataset(Path(dataset_path), cfg)
+    meta = ds._panorama_metadata
+    assert sim.shape[0] == len(meta), (sim.shape, len(meta))
+    n_rows = sim.shape[0]
+    edges = torch.as_tensor(edges, dtype=torch.float64)
+    n_bins = edges.numel() - 1
+    edges_d = edges.to(device)
+
+    row_max = torch.empty(n_rows, dtype=torch.float64)
+    valid = torch.empty(n_rows, dtype=torch.bool)
+    all_hist = torch.zeros(n_bins, dtype=torch.float64)
+
+    for r0 in range(0, n_rows, chunk_rows):
+        r1 = min(r0 + chunk_rows, n_rows)
+        M = sim[r0:r1].to(device).double()
+        finite = torch.isfinite(M)
+        Mf_hi = torch.where(finite, M, torch.full_like(M, float("-inf")))
+        Mf_lo = torch.where(finite, M, torch.full_like(M, float("inf")))
+        rmax = Mf_hi.max(dim=1).values
+        rmin = Mf_lo.min(dim=1).values
+        v = torch.isfinite(rmax) & (rmax != rmin)
+        if residual_form != "raw":
+            v = v & (rmax > 0)
+        row_max[r0:r1] = rmax.cpu()
+        valid[r0:r1] = v.cpu()
+        r = _residual(M, rmax, residual_form)
+        sel = finite & v[:, None]
+        if sel.any():
+            idx = _bin_idx(r[sel], edges_d)
+            all_hist += torch.bincount(idx.cpu(), minlength=n_bins).double()
+
+    # true pairs
+    true_rows, true_cols = [], []
+    for i in range(n_rows):
+        row = meta.iloc[i]
+        idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            idxs += list(row["semipositive_satellite_idxs"])
+        for c in idxs:
+            true_rows.append(i)
+            true_cols.append(int(c))
+    tr = torch.tensor(true_rows)
+    tc = torch.tensor(true_cols)
+    tsim = sim[tr, tc].double()
+    keep = valid[tr] & torch.isfinite(tsim)
+    tr, tc, tsim = tr[keep], tc[keep], tsim[keep]
+    t_rmax = row_max[tr]
+    t_r = (t_rmax - tsim) if residual_form == "raw" else (1.0 - tsim / t_rmax)
+    true_hist = torch.bincount(_bin_idx(t_r, edges), minlength=n_bins).double()
+
+    neg_hist = torch.clamp(all_hist - true_hist, min=0.0)
+    return true_hist, neg_hist
+
+
+def reference_raw_upper(dataset_path, landmark_version, matrix_path,
+                        include_semipositive, device, q=0.995, chunk_rows=1024):
+    """Upper raw-residual bin edge = q-quantile of the reference city's TRUE
+    (rowmax - sim) residuals, so bins resolve where true mass lives."""
+    sim = _load_similarity_matrix(Path(matrix_path))
+    cfg = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None, panorama_tensor_cache_info=None,
+        should_load_images=False, should_load_landmarks=False,
+        landmark_version=landmark_version)
+    ds = vd.VigorDataset(Path(dataset_path), cfg)
+    meta = ds._panorama_metadata
+    n_rows = sim.shape[0]
+    row_max = torch.empty(n_rows, dtype=torch.float64)
+    valid = torch.empty(n_rows, dtype=torch.bool)
+    for r0 in range(0, n_rows, chunk_rows):
+        r1 = min(r0 + chunk_rows, n_rows)
+        M = sim[r0:r1].to(device).double()
+        finite = torch.isfinite(M)
+        rmax = torch.where(finite, M, torch.full_like(M, float("-inf"))).max(dim=1).values
+        rmin = torch.where(finite, M, torch.full_like(M, float("inf"))).min(dim=1).values
+        row_max[r0:r1] = rmax.cpu()
+        valid[r0:r1] = (torch.isfinite(rmax) & (rmax != rmin)).cpu()
+    true_rows, true_cols = [], []
+    for i in range(n_rows):
+        row = meta.iloc[i]
+        idxs = list(row["positive_satellite_idxs"])
+        if include_semipositive:
+            idxs += list(row["semipositive_satellite_idxs"])
+        for c in idxs:
+            true_rows.append(i)
+            true_cols.append(int(c))
+    tr = torch.tensor(true_rows)
+    tc = torch.tensor(true_cols)
+    tsim = sim[tr, tc].double()
+    keep = valid[tr] & torch.isfinite(tsim)
+    t_r = row_max[tr][keep] - tsim[keep]
+    return float(torch.quantile(t_r, q))
+
+
+def build_lookup(true_hist, neg_hist, n_bins, clip):
+    nt, nn = float(true_hist.sum()), float(neg_hist.sum())
+    pt = (true_hist + 1.0) / (nt + n_bins)
+    pn = (neg_hist + 1.0) / (nn + n_bins)
+    values = torch.clamp(torch.log(pt) - torch.log(pn), -clip, clip)
+    return values.numpy()
+
+
+def discrimination(values, true_hist, neg_hist):
+    ft = (true_hist / true_hist.sum()).numpy()
+    fn = (neg_hist / neg_hist.sum()).numpy()
+    return float(np.sum((ft - fn) * values))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n-bins", type=int, default=20)
+    p.add_argument("--clip", type=float, default=6.0)
+    p.add_argument("--reference-city", default="Seattle")
+    p.add_argument("--include-semipositive", type=lambda s: s.lower() != "false", default=True)
+    p.add_argument("--image-sigma", type=float, default=0.1809)
+    p.add_argument("--matrix-rel", default=MATRIX_REL,
+                   help="similarity matrix path relative to each dataset dir "
+                        "(e.g. similarity_matrices/wag_no_hinge.pt)")
+    p.add_argument("--residual-form", choices=["normalized", "raw"],
+                   default="normalized",
+                   help="raw = rowmax-sim (image stream); "
+                        "normalized = 1-sim/rowmax (landmark stream)")
+    p.add_argument("--raw-upper", type=float, default=None,
+                   help="raw mode upper bin edge; default = 0.995 quantile of "
+                        "reference-city true residuals")
+    p.add_argument("--output-path", required=True, help="reference calibration JSON")
+    args = p.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if args.residual_form == "raw":
+        rdpath, rlv = CITY_INFO[args.reference_city]
+        upper = args.raw_upper if args.raw_upper is not None else reference_raw_upper(
+            rdpath, rlv, Path(rdpath) / args.matrix_rel,
+            args.include_semipositive, device)
+        print(f"raw residual: upper bin edge = {upper:.4f} "
+              f"({'given' if args.raw_upper is not None else '0.995 quantile of ' + args.reference_city + ' true'})")
+        edges = list(np.linspace(0.0, upper, args.n_bins + 1))
+    else:
+        edges = list(np.linspace(0.0, 1.0, args.n_bins + 1))
+    edges_t = torch.as_tensor(edges, dtype=torch.float64)
+
+    hists, lookups = {}, {}
+    for city, (dpath, lv) in CITY_INFO.items():
+        mpath = Path(dpath) / args.matrix_rel
+        print(f"[{city}] {mpath}")
+        th, nh = compute(dpath, lv, mpath, edges_t,
+                         args.include_semipositive, device, args.residual_form)
+        hists[city] = (th, nh)
+        lookups[city] = build_lookup(th, nh, args.n_bins, args.clip)
+
+    ref = args.reference_city
+    ref_lookup = lookups[ref]
+
+    print(f"\nReference = {ref} ({args.n_bins} uniform bins, all-entry negatives)\n")
+    print(f"{'city':24s}{'D_self':>9s}{'D_transfer':>12s}{'n_true':>9s}")
+    print("-" * 54)
+    rows = {}
+    for city in CITY_INFO:
+        th, nh = hists[city]
+        d_self = discrimination(lookups[city], th, nh)
+        d_trans = discrimination(ref_lookup, th, nh)
+        rows[city] = {"D_self": d_self, "D_transfer": d_trans,
+                      "n_true": int(th.sum()), "n_neg": int(nh.sum())}
+        print(f"{city:24s}{d_self:9.3f}{d_trans:12.3f}{int(th.sum()):9d}")
+
+    out = {
+        "n_bins": args.n_bins, "clip": args.clip, "reference_city": ref,
+        "image_sigma": args.image_sigma, "matrix_rel": args.matrix_rel,
+        "residual_form": args.residual_form,
+        "calibration": {
+            "landmark_log_lr_edges": [float(e) for e in edges],
+            "landmark_log_lr_values": [float(v) for v in ref_lookup],
+        },
+        "reference_lookup_values": [float(v) for v in ref_lookup],
+        "per_city_D": rows,
+    }
+    outp = Path(args.output_path).expanduser()
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    json.dump(out, open(outp, "w"), indent=2)
+    print(f"\nWrote {outp}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/calibrate_landmark_zoi.py
+++ b/experimental/overhead_matching/swag/scripts/calibrate_landmark_zoi.py
@@ -1,0 +1,187 @@
+"""Calibrate the zero/one-inflated likelihood-ratio landmark observation model.
+
+The landmark stream of ``SafaPlusZeroOneInflatedLandmarkAggregator`` maps the
+per-row normalized residual ``r = 1 - sim/row_max`` through a frozen log-LR
+lookup:  log p(r|true) - log p(r|negative).  We estimate p(r|true) and
+p(r|negative) from a calibration similarity matrix (true (pano,patch) pairs vs
+randomly sampled negative patches), decomposing each population into
+
+  * the discrete event r == 0  (true patch is the row argmax),
+  * the discrete event r == 1  (landmark missed the patch),
+  * a binned continuous interior over (0, 1).
+
+Output JSON contains the calibration fields consumed directly by
+``SafaPlusZeroOneInflatedLandmarkAggregatorConfig`` plus diagnostics
+(per-regime masses, discrimination score). Calibrate once on a reference city
+and freeze across cities (matching the single-sigma_lm methodology).
+"""
+
+from pathlib import Path
+import argparse
+import json
+
+import common.torch.load_torch_deps  # noqa: F401  (must precede torch import)
+import torch
+import numpy as np
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+from experimental.overhead_matching.swag.scripts.calibrate_sigma import (
+    compute_samples,
+)
+
+EPS = 1e-6
+
+
+def build_calibration(
+    r_true: np.ndarray,
+    r_neg: np.ndarray,
+    n_interior_bins: int,
+    log_lr_clip: float,
+):
+    """Build zero/one-inflated log-LR calibration from true/negative residuals.
+
+    Returns (calibration_dict, diagnostics_dict). Smoothing: a Laplace
+    pseudo-count is added to every regime/bin of both populations so empty
+    cells give finite, bounded log-LRs; values are clipped to +/- log_lr_clip.
+    """
+    edges = np.linspace(0.0, 1.0, n_interior_bins + 1)
+
+    def _counts(r):
+        at0 = int(np.sum(r <= EPS))
+        at1 = int(np.sum(r >= 1.0 - EPS))
+        interior = r[(r > EPS) & (r < 1.0 - EPS)]
+        hist, _ = np.histogram(interior, bins=edges)
+        return at0, at1, hist
+
+    t0, t1, t_hist = _counts(r_true)
+    n0, n1, n_hist = _counts(r_neg)
+
+    # One smoothing cell per regime (2 endpoints + n_interior_bins).
+    n_cells = 2 + n_interior_bins
+    nt, nn = len(r_true), len(r_neg)
+
+    def _logp(count, total):
+        return np.log((count + 1.0) / (total + n_cells))
+
+    # Endpoint events: compare probability mass directly.
+    lr_zero = float(np.clip(_logp(t0, nt) - _logp(n0, nn), -log_lr_clip, log_lr_clip))
+    lr_one = float(np.clip(_logp(t1, nt) - _logp(n1, nn), -log_lr_clip, log_lr_clip))
+
+    # Interior: compare *densities* (per-bin mass / bin width) so the lookup is
+    # a proper density ratio; bin width is constant here but keep it explicit.
+    widths = np.diff(edges)
+    lr_interior = []
+    for k in range(n_interior_bins):
+        lp_t = _logp(int(t_hist[k]), nt) - np.log(widths[k])
+        lp_n = _logp(int(n_hist[k]), nn) - np.log(widths[k])
+        lr_interior.append(float(np.clip(lp_t - lp_n, -log_lr_clip, log_lr_clip)))
+
+    calibration = {
+        "landmark_log_lr_zero": lr_zero,
+        "landmark_log_lr_one": lr_one,
+        "landmark_interior_edges": [float(e) for e in edges],
+        "landmark_interior_log_lr": lr_interior,
+    }
+    diagnostics = {
+        "n_true": int(nt),
+        "n_negative": int(nn),
+        "true_mass_zero": t0 / nt,
+        "true_mass_one": t1 / nt,
+        "true_mass_interior": 1.0 - (t0 + t1) / nt,
+        "neg_mass_zero": n0 / nn,
+        "neg_mass_one": n1 / nn,
+        "neg_mass_interior": 1.0 - (n0 + n1) / nn,
+        "n_interior_bins": n_interior_bins,
+        "log_lr_clip": log_lr_clip,
+    }
+    return calibration, diagnostics
+
+
+def _discrimination(calibration, r_true, r_neg):
+    """D = E_true[log LR] - E_neg[log LR]: mean belief-update gap (bigger=better)."""
+    edges = np.asarray(calibration["landmark_interior_edges"])
+    inner_lr = np.asarray(calibration["landmark_interior_log_lr"])
+
+    def log_lr(r):
+        idx = np.clip(np.searchsorted(edges, r, side="right") - 1, 0, len(inner_lr) - 1)
+        out = inner_lr[idx]
+        out = np.where(r <= EPS, calibration["landmark_log_lr_zero"], out)
+        out = np.where(r >= 1.0 - EPS, calibration["landmark_log_lr_one"], out)
+        return out
+
+    return float(log_lr(r_true).mean() - log_lr(r_neg).mean())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--similarity-matrix-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle/"
+                "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt")
+    parser.add_argument(
+        "--dataset-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle")
+    parser.add_argument("--landmark-version", type=str, default="v4_202001")
+    parser.add_argument("--num-negative-samples-per-pano", type=int, default=200)
+    parser.add_argument("--negative-sample-seed", type=int, default=0)
+    parser.add_argument("--n-interior-bins", type=int, default=20)
+    parser.add_argument("--log-lr-clip", type=float, default=6.0)
+    parser.add_argument(
+        "--include-semipositive", type=lambda s: s.lower() != "false", default=True)
+    parser.add_argument("--output-path", type=str, required=True)
+    args = parser.parse_args()
+
+    sim_mat = _load_similarity_matrix(Path(args.similarity_matrix_path))
+    nan_frac = float(torch.isnan(sim_mat).float().mean())
+    print(f"matrix {tuple(sim_mat.shape)} dtype={sim_mat.dtype} nan_frac={nan_frac:.4f}")
+
+    dataset_config = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None, panorama_tensor_cache_info=None,
+        should_load_images=False, should_load_landmarks=False,
+        landmark_version=args.landmark_version)
+    dataset = vd.VigorDataset(Path(args.dataset_path), dataset_config)
+    pano_metadata = dataset._panorama_metadata
+
+    rd = compute_samples(
+        sim_mat, pano_metadata,
+        include_semipositive=args.include_semipositive,
+        num_negative_samples_per_pano=args.num_negative_samples_per_pano,
+        rng_seed=args.negative_sample_seed,
+        exclude_constant_rows=True, residual_form="normalized")
+    r_true = rd["residuals_pair"].numpy()
+    r_neg = rd["residuals_negative"].numpy()
+
+    calibration, diagnostics = build_calibration(
+        r_true, r_neg, args.n_interior_bins, args.log_lr_clip)
+    sigma_mle = float(np.sqrt(np.mean(r_true ** 2)))
+    D = _discrimination(calibration, r_true, r_neg)
+
+    print("\nregime masses (true / negative):")
+    print(f"  r==0 : {diagnostics['true_mass_zero']:.4f} / {diagnostics['neg_mass_zero']:.4f}"
+          f"   -> log_lr_zero = {calibration['landmark_log_lr_zero']:+.3f}")
+    print(f"  r==1 : {diagnostics['true_mass_one']:.4f} / {diagnostics['neg_mass_one']:.4f}"
+          f"   -> log_lr_one  = {calibration['landmark_log_lr_one']:+.3f}")
+    print(f"  interior: {diagnostics['true_mass_interior']:.4f} / "
+          f"{diagnostics['neg_mass_interior']:.4f}")
+    print(f"\nsigma_mle (gaussian baseline) = {sigma_mle:.4f}")
+    print(f"discrimination D (this calibration) = {D:.3f}")
+
+    out = {
+        "similarity_matrix_path": str(args.similarity_matrix_path),
+        "dataset_path": str(args.dataset_path),
+        "calibration": calibration,
+        "diagnostics": {**diagnostics, "sigma_mle_gaussian": sigma_mle,
+                        "discrimination_D": D},
+    }
+    output_path = Path(args.output_path).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(out, f, indent=2)
+    print(f"\nWrote calibration to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/plot_piecewise_calibration.py
+++ b/experimental/overhead_matching/swag/scripts/plot_piecewise_calibration.py
@@ -1,0 +1,170 @@
+"""Plot the calibrated piecewise landmark log-LR lookup over the true / negative
+normalized-residual densities it was fit to.
+
+Single-city mode (``--city``): one figure, top panel = per-bin densities of
+r = 1 - sim/row_max for true (pano,patch) pairs vs all-entry negatives, bottom
+panel = the piecewise-constant log-LR g(r) = log p(r|true) - log p(r|neg).
+
+All-cities mode (``--all-cities``): a grid with one column per city. Each
+column overlays, in the bottom panel, the city's OWN calibrated log-LR
+(``D_self``) against the FROZEN reference-city lookup that the filter actually
+applies (``D_transfer``). The gap between those two curves -- weighted by where
+the city's *negative* mass sits -- is what makes a frozen lookup over- or
+under-confident on that city.
+
+Also prints a per-city "negative leakage" diagnostic: ``E_neg[g_ref]`` (the mean
+applied log-LR handed to negative/wrong patches) and the fraction of negative
+mass sitting in bins where the applied lookup is positive (evidence *for* a
+wrong patch). High values predict filter divergence at ``landmark_lr_scale=1``.
+"""
+from pathlib import Path
+import argparse
+import json
+
+import common.torch.load_torch_deps  # noqa: F401
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+
+from experimental.overhead_matching.swag.scripts.calibrate_landmark_piecewise import (
+    compute, build_lookup, discrimination, CITY_INFO, MATRIX_REL,
+)
+
+
+def _densities(th, nh, widths):
+    dt = (th / th.sum()) / widths
+    dn = (nh / nh.sum()) / widths
+    return dt, dn
+
+
+def _leakage(values_applied, neg_hist):
+    """Diagnostics for how much the applied lookup boosts negative patches."""
+    fn = (neg_hist / neg_hist.sum()).numpy()
+    e_neg = float(np.sum(fn * values_applied))            # mean applied log-LR to negatives
+    pos_mass = float(np.sum(fn[values_applied > 0]))      # neg mass where lookup says "true"
+    return e_neg, pos_mass
+
+
+def _plot_city(ax1, ax2, city, edges, widths, n_bins, ref_values, ref_city, device,
+               matrix_rel=MATRIX_REL, residual_form="normalized"):
+    dpath, lv = CITY_INFO[city]
+    mpath = Path(dpath) / matrix_rel
+    th, nh = compute(dpath, lv, str(mpath), edges, True, device, residual_form)
+    own_values = build_lookup(th, nh, n_bins, clip=6.0)
+    d_self = discrimination(own_values, th, nh)
+    d_trans = discrimination(ref_values, th, nh)
+    dt, dn = _densities(th.numpy(), nh.numpy(), widths)
+
+    ax1.step(edges, np.concatenate([[dt[0]], dt]), where="pre", color="steelblue",
+             lw=2, label=f"true (n={int(th.sum()):,})")
+    ax1.step(edges, np.concatenate([[dn[0]], dn]), where="pre", color="darkorange",
+             lw=2, label=f"negative (n={int(nh.sum()):,})")
+    ax1.set_yscale("log")
+    ax1.set_title(f"{city}", fontweight="bold")
+    ax1.legend(loc="lower center", fontsize=8)
+    ax1.grid(alpha=0.25)
+
+    ax2.step(edges, np.concatenate([[own_values[0]], own_values]), where="pre",
+             color="C0", lw=2.0, label=f"own  (D={d_self:.2f})")
+    ax2.step(edges, np.concatenate([[ref_values[0]], ref_values]), where="pre",
+             color="C3", lw=2.2, ls="--", label=f"{ref_city} applied (D={d_trans:.2f})")
+    ax2.axhline(0, color="k", lw=0.9, ls=":")
+    ax2.set_xlim(edges[0], edges[-1])
+    ax2.legend(loc="upper right", fontsize=8)
+    ax2.grid(alpha=0.25)
+
+    e_neg, pos_mass = _leakage(ref_values, nh)
+    tf = (th / th.sum()).numpy()
+    lo = int(round(0.1 * n_bins))   # bins with r < 0.1
+    hi = n_bins - lo                # bins with r > 0.9
+    return {
+        "city": city, "D_self": d_self, "D_transfer": d_trans,
+        "n_true": int(th.sum()), "n_neg": int(nh.sum()),
+        "E_neg_applied": e_neg, "neg_mass_in_positive_g": pos_mass,
+        "true_mass_lo_r": float(tf[:lo].sum()),   # true patches the lookup rewards (g>0)
+        "true_mass_hi_r": float(tf[hi:].sum()),   # true patches in the miss/penalized region
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--city", default="Seattle")
+    p.add_argument("--all-cities", action="store_true",
+                   help="render a grid over every city in CITY_INFO")
+    p.add_argument("--calibration", default="/tmp/zoi_proto/piecewise_calibration_seattle.json")
+    p.add_argument("--output-path", default="/tmp/zoi_proto/piecewise_calibration_seattle_plot")
+    p.add_argument("--matrix-rel", default=None,
+                   help="override matrix path rel to dataset dir; "
+                        "defaults to the calibration JSON's matrix_rel")
+    args = p.parse_args()
+
+    cal = json.load(open(args.calibration))
+    edges = np.asarray(cal["calibration"]["landmark_log_lr_edges"])
+    ref_values = np.asarray(cal["calibration"]["landmark_log_lr_values"])
+    ref_city = cal.get("reference_city", "Seattle")
+    n_bins = len(ref_values)
+    widths = np.diff(edges)
+    matrix_rel = args.matrix_rel or cal.get("matrix_rel", MATRIX_REL)
+    residual_form = cal.get("residual_form", "normalized")
+    xlabel = (r"$r = \mathrm{row\,max} - \mathrm{sim}$" if residual_form == "raw"
+              else r"$r_{\mathrm{norm}} = 1 - \mathrm{sim}/\mathrm{row\,max}$")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    plt.rcParams.update({"font.size": 11})
+
+    if not args.all_cities:
+        # single-city behaviour (backwards compatible)
+        fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(7.5, 6.4), sharex=True)
+        diag = _plot_city(ax1, ax2, args.city, edges, widths, n_bins,
+                          ref_values, ref_city, device, matrix_rel, residual_form)
+        ax1.set_ylabel("density")
+        ax2.set_xlabel(xlabel)
+        ax2.set_ylabel(r"$\log\,p(r|\mathrm{true}) - \log\,p(r|\mathrm{neg})$")
+        fig.tight_layout()
+        out = Path(args.output_path)
+        for ext in ("png", "pdf"):
+            fig.savefig(out.with_suffix(f".{ext}"), dpi=190, bbox_inches="tight")
+        plt.close(fig)
+        print(json.dumps(diag, indent=2))
+        print(f"Wrote {out.with_suffix('.png')}")
+        return
+
+    cities = list(CITY_INFO)
+    ncol = len(cities)
+    fig, axes = plt.subplots(2, ncol, figsize=(3.0 * ncol, 6.6), sharex=True,
+                             squeeze=False)
+    diags = []
+    for j, city in enumerate(cities):
+        diags.append(_plot_city(axes[0][j], axes[1][j], city, edges, widths,
+                                n_bins, ref_values, ref_city, device, matrix_rel,
+                                residual_form))
+        if j == 0:
+            axes[0][j].set_ylabel("density (log)")
+            axes[1][j].set_ylabel(r"$\log$-LR  $g(r)$")
+        axes[1][j].set_xlabel(xlabel, fontsize=9)
+    fig.suptitle(
+        f"Per-city landmark residual densities (top) and log-LR (bottom): "
+        f"own vs frozen {ref_city} lookup applied by the filter",
+        fontsize=13, y=1.005)
+    fig.tight_layout()
+    out = Path(args.output_path)
+    for ext in ("png", "pdf"):
+        fig.savefig(out.with_suffix(f".{ext}"), dpi=170, bbox_inches="tight")
+    plt.close(fig)
+
+    print(f"\n{'city':24s}{'D_self':>8s}{'D_trans':>9s}"
+          f"{'true%@r<.1':>11s}{'true%@r>.9':>11s}{'n_true':>8s}")
+    print("-" * 71)
+    for d in sorted(diags, key=lambda r: r["true_mass_hi_r"], reverse=True):
+        print(f"{d['city']:24s}{d['D_self']:8.3f}{d['D_transfer']:9.3f}"
+              f"{100*d['true_mass_lo_r']:10.1f}%{100*d['true_mass_hi_r']:10.1f}%"
+              f"{d['n_true']:8d}")
+    print("\ntrue%@r<.1 = true patches in the rewarded (g>0, up to +4) region.")
+    print("true%@r>.9 = true patches in the penalized miss bin (g<0).")
+    print("Low true%@r<.1 + high true%@r>.9 = lookup mostly penalizes the true "
+          "patch and rewards spurious low-r negatives => divergence at scale=1.")
+    print(f"Wrote {out.with_suffix('.png')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/overhead_matching/swag/scripts/residual_likelihood_analysis.py
+++ b/experimental/overhead_matching/swag/scripts/residual_likelihood_analysis.py
@@ -1,0 +1,196 @@
+"""Diagnose the landmark normalized-residual distribution as an OBSERVATION
+LIKELIHOOD, comparing true vs negative pairs.
+
+For the filter, what matters is not how well a density fits the true residuals
+in isolation, but the *likelihood ratio* L(r) = p(r|true)/p(r|neg): that is the
+factor by which a patch's belief is multiplied. We therefore:
+
+  1. Decompose both populations into the discrete endpoint masses
+     (r==0  := true patch IS the row argmax; r==1 := patch totally missed)
+     and the continuous interior (0,1).
+  2. Plot true vs negative densities and the empirical log-likelihood-ratio.
+  3. Score candidate observation models by their discriminative separation
+     D = E_true[log L] - E_neg[log L]  (mean log-LR gap; bigger = better).
+
+Candidates scored:
+  - HalfNormal(sigma_mle)         (the current landmark model)
+  - Beta(a,b) method-of-moments   (natural [0,1] support, can be U-shaped)
+  - empirical binned LR           (non-parametric ceiling for r as a statistic)
+  - zero/one-inflated empirical   (point masses at 0/1 + uniform interior)
+"""
+
+from pathlib import Path
+import argparse
+
+import common.torch.load_torch_deps  # noqa: F401  (must precede torch import)
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+from experimental.overhead_matching.swag.scripts.calibrate_sigma import (
+    compute_samples,
+)
+
+EPS = 1e-9
+
+
+def _masses(r: np.ndarray):
+    """Fraction at exactly 0, exactly 1, and the interior values."""
+    at0 = float(np.mean(r <= EPS))
+    at1 = float(np.mean(r >= 1.0 - EPS))
+    interior = r[(r > EPS) & (r < 1.0 - EPS)]
+    return at0, at1, interior
+
+
+def _halfnormal_logpdf(r, sigma):
+    return (np.log(2.0) - 0.5 * np.log(2 * np.pi) - np.log(sigma)
+            - 0.5 * (r / sigma) ** 2)
+
+
+def _beta_mom(x):
+    """Method-of-moments Beta(a,b) fit on x in (0,1)."""
+    m, v = x.mean(), x.var()
+    common = m * (1 - m) / v - 1.0
+    return m * common, (1 - m) * common
+
+
+def _empirical_log_lr(r_true, r_neg, edges):
+    """Binned log p(r|true)/p(r|neg) with Laplace smoothing, evaluated per bin."""
+    ht, _ = np.histogram(r_true, bins=edges)
+    hn, _ = np.histogram(r_neg, bins=edges)
+    pt = (ht + 1.0) / (ht.sum() + len(ht))
+    pn = (hn + 1.0) / (hn.sum() + len(hn))
+    widths = np.diff(edges)
+    dt, dn = pt / widths, pn / widths
+    return np.log(dt) - np.log(dn), dt, dn
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--similarity-matrix-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle/"
+                "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt")
+    parser.add_argument(
+        "--dataset-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle")
+    parser.add_argument("--city", type=str, default="Seattle")
+    parser.add_argument("--landmark-version", type=str, default="v4_202001")
+    parser.add_argument("--num-negative-samples-per-pano", type=int, default=200)
+    parser.add_argument(
+        "--output-path", type=str,
+        default="/data/overhead_matching/evaluation/results/"
+                "260501_v6_safa_plus_norm_lm/landmark_residual_exploration/"
+                "residual_likelihood_analysis")
+    args = parser.parse_args()
+
+    sim_mat = _load_similarity_matrix(Path(args.similarity_matrix_path))
+    print(f"matrix {tuple(sim_mat.shape)}")
+    dataset_config = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None, panorama_tensor_cache_info=None,
+        should_load_images=False, should_load_landmarks=False,
+        landmark_version=args.landmark_version)
+    dataset = vd.VigorDataset(Path(args.dataset_path), dataset_config)
+    pano_metadata = dataset._panorama_metadata
+
+    rd = compute_samples(
+        sim_mat, pano_metadata, include_semipositive=True,
+        num_negative_samples_per_pano=args.num_negative_samples_per_pano,
+        exclude_constant_rows=True, residual_form="normalized")
+    r_true = rd["residuals_pair"].numpy()
+    r_neg = rd["residuals_negative"].numpy()
+
+    t0, t1, t_int = _masses(r_true)
+    n0, n1, n_int = _masses(r_neg)
+    sigma_mle = float(np.sqrt(np.mean(r_true ** 2)))
+
+    print(f"\nn_true={len(r_true):,}  n_neg={len(r_neg):,}")
+    print(f"{'':12s}{'r==0':>10s}{'r==1':>10s}{'interior':>10s}")
+    print(f"{'true':12s}{t0:10.3f}{t1:10.3f}{1-t0-t1:10.3f}")
+    print(f"{'negative':12s}{n0:10.3f}{n1:10.3f}{1-n0-n1:10.3f}")
+    print(f"\nsigma_mle (HalfNormal) = {sigma_mle:.4f}")
+    if len(t_int) > 50:
+        a, b = _beta_mom(t_int)
+        print(f"Beta interior MoM (true): a={a:.3f} b={b:.3f}  (U-shape iff a,b<1)")
+
+    # Discrimination score D = E_true[log L] - E_neg[log L] for each model.
+    def score(log_l_fn):
+        return float(log_l_fn(r_true).mean() - log_l_fn(r_neg).mean())
+
+    hn_D = score(lambda r: _halfnormal_logpdf(np.clip(r, EPS, None), sigma_mle))
+
+    edges = np.concatenate([[0.0, EPS],
+                            np.linspace(EPS, 1 - EPS, 40),
+                            [1 - EPS, 1.0]])
+    edges = np.unique(edges)
+    log_lr, dt, dn = _empirical_log_lr(r_true, r_neg, edges)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+
+    def emp_log_l(r):
+        idx = np.clip(np.searchsorted(edges, r, side="right") - 1,
+                      0, len(log_lr) - 1)
+        return log_lr[idx]
+    emp_D = score(emp_log_l)
+
+    print(f"\nDiscrimination  D = E_true[log L] - E_neg[log L]  (bigger better)")
+    print(f"  HalfNormal(sigma={sigma_mle:.3f}) : {hn_D:8.3f}")
+    print(f"  empirical binned LR           : {emp_D:8.3f}   <- ceiling for r")
+
+    # ---- figure ----
+    plt.rcParams.update({"font.size": 12})
+    fig, axes = plt.subplots(1, 3, figsize=(16, 4.4))
+
+    # Panel 1: densities, interior only (endpoint masses annotated)
+    ax = axes[0]
+    ib = np.linspace(0, 1, 41)
+    ax.hist(t_int, bins=ib, density=True, color="steelblue", alpha=0.7,
+            label=f"true interior")
+    ax.hist(n_int, bins=ib, density=True, histtype="step", color="darkorange",
+            lw=2, label="negative interior")
+    xs = np.linspace(EPS, 1 - EPS, 300)
+    ax.plot(xs, np.exp(_halfnormal_logpdf(xs, sigma_mle)), "C3", lw=2,
+            label=f"HalfNormal(σ={sigma_mle:.2f})")
+    ax.set_title("interior densities (0<r<1)")
+    ax.set_xlabel(r"$r_{\rm norm}$"); ax.set_ylabel("density")
+    ax.legend(fontsize=9)
+
+    # Panel 2: endpoint masses, true vs negative
+    ax = axes[1]
+    x = np.arange(3); w = 0.38
+    ax.bar(x - w/2, [t0, 1 - t0 - t1, t1], w, color="steelblue", label="true")
+    ax.bar(x + w/2, [n0, 1 - n0 - n1, n1], w, color="darkorange", label="negative")
+    ax.set_xticks(x); ax.set_xticklabels(["r=0\n(argmax hit)", "0<r<1", "r=1\n(missed)"])
+    ax.set_ylabel("probability mass")
+    ax.set_title("where the mass is: true vs negative")
+    ax.legend()
+
+    # Panel 3: empirical log likelihood ratio vs HalfNormal log-likelihood shape
+    ax = axes[2]
+    ax.plot(centers, log_lr, color="purple", lw=2, marker=".",
+            label="empirical log p(r|true)/p(r|neg)")
+    hn_shape = _halfnormal_logpdf(np.clip(centers, EPS, None), sigma_mle)
+    ax.plot(centers, hn_shape - hn_shape.mean() + log_lr.mean(), "C3", lw=2,
+            ls="--", label="HalfNormal log-lik (shape, shifted)")
+    ax.axhline(0, color="k", lw=0.8, ls=":")
+    ax.set_title("observation log-likelihood-ratio")
+    ax.set_xlabel(r"$r_{\rm norm}$"); ax.set_ylabel("log LR")
+    ax.legend(fontsize=9)
+
+    fig.suptitle(
+        f"{args.city} landmark residual as observation likelihood   "
+        f"(D_halfnormal={hn_D:.2f}  vs  D_empirical={emp_D:.2f})")
+    fig.tight_layout()
+    out = Path(args.output_path).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    for ext in ("png", "pdf"):
+        fig.savefig(out.with_suffix(f".{ext}"), dpi=170, bbox_inches="tight")
+    plt.close(fig)
+    print(f"\nWrote {out.with_suffix('.png')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Archival PR — **intended to be closed unmerged**, not reviewed/merged.

Preserves the piecewise likelihood-ratio landmark observation stream explored as an alternative to the half-normal landmark model. Performed better in some settings and worse in others

- `SafaPlusPiecewiseLandmarkAggregator` (+ config/dispatch/tests) in `filter/adaptive_aggregators.py`
- `scripts/calibrate_landmark_piecewise.py`, `scripts/plot_piecewise_calibration.py`
- ZOI precursor `scripts/calibrate_landmark_zoi.py` and `scripts/residual_likelihood_analysis.py`
