### PR TITLE
Paper output tooling: LaTeX dataset stats, sigma-fit figure, paper-ready convergence table

### DIFF
--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -1026,3 +1026,17 @@ py_binary(
     "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
   ]
 )
+
+py_binary(
+  name="sigma_paper_figure",
+  srcs=["sigma_paper_figure.py"],
+  deps=[
+    requirement("torch"),
+    requirement("numpy"),
+    requirement("matplotlib"),
+    "//common/torch:load_torch_deps",
+    "//experimental/overhead_matching/swag/data:vigor_dataset",
+    "//experimental/overhead_matching/swag/filter:adaptive_aggregators",
+    ":calibrate_sigma",
+  ]
+)

--- a/experimental/overhead_matching/swag/scripts/dataset_statistics.py
+++ b/experimental/overhead_matching/swag/scripts/dataset_statistics.py
@@ -42,6 +42,46 @@ PANO_LANDMARK_DIR_MAP = {
 
 
 @dataclass
+class LatexPaperRow:
+    """Editorial metadata for one row of the paper's dataset-statistics table.
+
+    Most fields here are not derivable from on-disk data: the editorial
+    `conditions` blurb, whether the city is part of VIGOR (gets a `(VIGOR)`
+    suffix), whether it was collected by our camera rig (gets a `\\textdagger`
+    superscript). `pano_date_override` / `osm_date_override` let a row supply
+    a fixed YY-MM (or other) string when the script can't recover it from
+    data — e.g. VIGOR cities whose satellite capture_date isn't stored
+    (paper just says "2019"), or Boston Snowy / Boston Night whose landmark
+    files lack a date suffix.
+    """
+    display_name: str
+    conditions: str
+    is_vigor: bool = False
+    is_rig: bool = False
+    pano_date_override: str | None = None
+    osm_date_override: str | None = None
+
+
+# Per-dataset LaTeX paper-row metadata. Anything not listed here is emitted
+# with an empty `conditions` cell (so you can fill it in by hand). Order in
+# this dict is the order rows are printed.
+LATEX_PAPER_ROWS: dict[str, LatexPaperRow] = {
+    "Chicago":                          LatexPaperRow("Chicago",       "Metro area",       is_vigor=True, pano_date_override="2019"),
+    "Seattle":                          LatexPaperRow("Seattle",       "Metro area",       is_vigor=True, pano_date_override="2019"),
+    "NewYork":                          LatexPaperRow("New York",      "Metro area",       is_vigor=True, pano_date_override="2019"),
+    "Boston":                           LatexPaperRow("Boston Snowy",  "Actively snowing", is_rig=True,
+                                                     pano_date_override="26-01", osm_date_override="26-01"),
+    "nightdrive":                       LatexPaperRow("Boston Night",  "Recorded at night", is_rig=True,
+                                                     pano_date_override="26-02", osm_date_override="26-01"),
+    "mapillary/Framingham":             LatexPaperRow("Framingham",    "Suburban"),
+    "mapillary/Middletown":             LatexPaperRow("Middletown",    "Rainy, suburban"),
+    "mapillary/Norway":                 LatexPaperRow("Norway",        "Rural"),
+    "mapillary/SanFrancisco_mapillary": LatexPaperRow("San Francisco", "Metro area"),
+    "mapillary/post_hurricane_ian_sw":  LatexPaperRow("Fort Myers",    "Post-disaster"),
+}
+
+
+@dataclass
 class DatasetConfig:
     name: str
     path: Path
@@ -427,30 +467,154 @@ def print_stats(all_stats: list[DatasetStats]):
     print_transposed_table("EXTENDED DATASETS (* = ground-normalized satellite patches)", extended)
 
 
+def _latex_int(n: int) -> str:
+    """`12345` -> `12{,}345`. LaTeX-safe thousands separator (the `{,}` keeps
+    the comma from getting an extra side-bearing in math mode)."""
+    s = f"{n:,}"
+    return s.replace(",", "{,}")
+
+
+def _yymm(date_str: str | None) -> str:
+    """`YYYY-MM` or `YYYY-MM-DD` -> `YY-MM`; None / unparseable -> `--`."""
+    if not date_str:
+        return "--"
+    parts = date_str.split("-")
+    if len(parts) < 2:
+        return "--"
+    year = parts[0]
+    month = parts[1]
+    if len(year) != 4 or len(month) != 2:
+        return "--"
+    return f"{year[2:]}-{month}"
+
+
+def _city_label(meta: LatexPaperRow | None, raw_name: str) -> str:
+    if meta is None:
+        return raw_name
+    label = meta.display_name
+    if meta.is_vigor:
+        label += " (VIGOR)"
+    if meta.is_rig:
+        label += "\\textsuperscript{\\textdagger}"
+    return label
+
+
+def print_latex_paper_table(all_stats: list[DatasetStats]):
+    """Emit the dataset-statistics table in the paper's LaTeX format.
+
+    Stats not derivable from data (conditions, VIGOR / rig markers, the
+    "2019" pano date for VIGOR cities) come from `LATEX_PAPER_ROWS`. Cities
+    not in that dict are still emitted but with an empty `Conditions` cell
+    so the row is obvious-to-edit. Row order follows `LATEX_PAPER_ROWS`,
+    then any unrecognized datasets at the bottom.
+    """
+    stats_by_name = {s.name: s for s in all_stats}
+
+    ordered: list[tuple[DatasetStats, LatexPaperRow | None]] = []
+    for name, meta in LATEX_PAPER_ROWS.items():
+        if name in stats_by_name:
+            ordered.append((stats_by_name[name], meta))
+    seen = set(LATEX_PAPER_ROWS)
+    for s in all_stats:
+        if s.name not in seen:
+            ordered.append((s, None))
+
+    rows: list[list[str]] = []
+    for s, meta in ordered:
+        city = _city_label(meta, s.name)
+        conditions = meta.conditions if meta is not None else ""
+        panos_sat = f"{_latex_int(s.num_panoramas)} / {_latex_int(s.num_satellites)}"
+        sat_cov = f"{s.geographic_extent_km2:.1f}"
+        traj = f"{s.trajectory_km:.1f}" if s.trajectory_km is not None else "--"
+        if s.pano_landmarks is not None:
+            pano_lm = _latex_int(s.pano_landmarks.total_landmarks)
+        else:
+            pano_lm = "--"
+        osm_lm = _latex_int(s.num_landmarks_pruned)
+        landmarks = f"{pano_lm} / {osm_lm}"
+        if meta is not None and meta.pano_date_override is not None:
+            pano_date = meta.pano_date_override
+        else:
+            pano_date = _yymm(s.capture_date)
+        if meta is not None and meta.osm_date_override is not None:
+            osm_date = meta.osm_date_override
+        else:
+            osm_date = _yymm(s.osm_date)
+        dates = f"{pano_date} / {osm_date}"
+        rows.append([city, conditions, panos_sat, sat_cov, traj, landmarks, dates])
+
+    # Align columns visually in the emitted .tex source.
+    header_labels = [
+        "City",
+        "Conditions",
+        "\\#Panos / Sat.\\ Patches",
+        "\\makecell{Sat.\\ Cov.\\\\(km$^2$)}",
+        "Traj.\\ (km)",
+        "\\makecell{Landmarks\\\\(Pano / OSM)}",
+        "\\makecell{Dates (YY-MM) \\\\(Pano / OSM)}",
+    ]
+    n_cols = len(header_labels)
+    widths = [max(len(r[i]) for r in [header_labels, *rows]) for i in range(n_cols)]
+
+    def fmt_row(cells: list[str]) -> str:
+        padded = [c.ljust(widths[i]) for i, c in enumerate(cells)]
+        return " & ".join(padded) + " \\\\"
+
+    lines: list[str] = []
+    lines.append("\\begin{table*}[t]")
+    lines.append("  \\centering")
+    lines.append("  \\caption{Dataset statistics. Satellite imagery sourced from Google "
+                 "(February 2026) for all cities except the VIGOR cities and Fort Myers, "
+                 "which uses ESRI imagery from June 2022. \\textsuperscript{\\textdagger} "
+                 "indicates data collected by our camera rig.}")
+    lines.append("  \\label{tab:dataset-stats}")
+    lines.append("  \\small")
+    lines.append("  \\begin{tabular}{llrrrrc}")
+    lines.append("  \\toprule")
+    lines.append("  " + fmt_row(header_labels))
+    lines.append("  \\midrule")
+    for r in rows:
+        lines.append("  " + fmt_row(r))
+    lines.append("  \\bottomrule")
+    lines.append("  \\end{tabular}")
+    lines.append("\\end{table*}")
+
+    print("\n".join(lines))
+
+
 def main():
     parser = argparse.ArgumentParser(description="Gather statistics for VIGOR datasets")
     parser.add_argument("--dataset_base", type=str, required=True,
                         help="Base path to VIGOR datasets")
     parser.add_argument("--pano_embed_base", type=str, default=None,
                         help="Base path to panorama landmark embeddings")
+    parser.add_argument("--latex", action="store_true",
+                        help="Emit the paper-format LaTeX table (table* environment) "
+                             "and skip the ASCII summaries. Per-city conditions / VIGOR / "
+                             "rig markers come from LATEX_PAPER_ROWS.")
     args = parser.parse_args()
 
     base = Path(args.dataset_base)
     pano_embed_base = Path(args.pano_embed_base) if args.pano_embed_base else None
     configs = discover_datasets(base)
 
-    print(f"Discovered {len(configs)} datasets:")
-    for c in configs:
-        print(f"  {c.name}: {c.path}")
-    print()
+    if not args.latex:
+        print(f"Discovered {len(configs)} datasets:")
+        for c in configs:
+            print(f"  {c.name}: {c.path}")
+        print()
 
     all_stats = []
     for config in configs:
-        print(f"Processing {config.name}...", flush=True)
+        if not args.latex:
+            print(f"Processing {config.name}...", flush=True)
         stats = compute_stats(config, pano_embed_base)
         all_stats.append(stats)
 
-    print_stats(all_stats)
+    if args.latex:
+        print_latex_paper_table(all_stats)
+    else:
+        print_stats(all_stats)
 
 
 if __name__ == "__main__":

--- a/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
+++ b/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
@@ -340,20 +340,13 @@ def print_summary_table(
         col_end = col_start + n_methods - 1
         cmidrules += f"\\cmidrule(lr){{{col_start}-{col_end}}} "
 
-    lines = []
-    lines.append("\\begin{table*}[t]")
-    lines.append("\\centering")
-    lines.append("\\caption{Convergence cost (m) and final localization error (m) across environments. "
-                  "Values shown as mean $\\pm$ 95\\% CI. \\textbf{Bold} indicates the best method.}")
-    lines.append(f"\\begin{{tabular}}{{{col_spec}}}")
-    lines.append("\\toprule")
-    lines.append(header1)
-    lines.append(cmidrules)
-    lines.append(header2)
-    lines.append("\\midrule")
-
+    # Build all data rows first so we can pad each column to the widest cell,
+    # matching the paper's hand-formatted alignment style. Padding is purely
+    # cosmetic (LaTeX ignores it in rendering) but makes the .tex source diff
+    # cleanly against reviewer edits.
+    row_cells: list[list[str]] = []
     for env in ENVIRONMENTS:
-        row_parts = [DISPLAY_NAMES[env]]
+        cells = [DISPLAY_NAMES[env]]
         for _, radius in metrics:
             vals = []
             for m in method_names:
@@ -370,21 +363,38 @@ def print_summary_table(
                 vals.append(v)
 
             non_none = [(i, v) for i, v in enumerate(vals) if v is not None]
-            if non_none:
-                best_idx = min(non_none, key=lambda x: x[1][0])[0]
-            else:
-                best_idx = -1
+            best_idx = min(non_none, key=lambda x: x[1][0])[0] if non_none else -1
 
             for i, v in enumerate(vals):
                 if v is None:
-                    row_parts.append("--")
+                    cells.append("--")
                 else:
-                    row_parts.append(_fmt_val(*v, bold=(i == best_idx)))
+                    cells.append(_fmt_val(*v, bold=(i == best_idx)))
+        row_cells.append(cells)
 
-        lines.append(" & ".join(row_parts) + " \\\\")
+    n_cells = len(row_cells[0])
+    col_widths = [max(len(row[i]) for row in row_cells) for i in range(n_cells)]
 
-    lines.append("\\bottomrule")
-    lines.append("\\end{tabular}")
+    def _pad_data_row(cells: list[str]) -> str:
+        padded = [cells[i].ljust(col_widths[i]) for i in range(n_cells)]
+        return " & ".join(padded) + " \\\\"
+
+    lines = []
+    lines.append("\\begin{table*}[t]")
+    lines.append("  \\centering")
+    lines.append("  \\caption{Convergence cost (m) and final localization error (m) across environments. "
+                  "Values shown as mean $\\pm$ 95\\% CI using standard error of the mean. "
+                  "\\textbf{Bold} indicates the best method.}")
+    lines.append(f"  \\begin{{tabular}}{{{col_spec}}}")
+    lines.append("  \\toprule")
+    lines.append("  " + header1)
+    lines.append("  " + cmidrules.rstrip())
+    lines.append("  " + header2)
+    lines.append("  \\midrule")
+    for row in row_cells:
+        lines.append("  " + _pad_data_row(row))
+    lines.append("  \\bottomrule")
+    lines.append("  \\end{tabular}")
     lines.append("\\end{table*}")
 
     print("\n".join(lines))

--- a/experimental/overhead_matching/swag/scripts/sigma_paper_figure.py
+++ b/experimental/overhead_matching/swag/scripts/sigma_paper_figure.py
@@ -1,0 +1,161 @@
+"""Paper figure: normalized true-patch residual histogram vs the calibrated
+HalfNormal(σ) used by the landmark stream of SafaPlusNormalizedLandmarkAggregator.
+
+Single clean density panel (Seattle by default): the empirical distribution of
+the per-pair normalized residual ``r_norm = 1 - sim_t / row_max`` for true
+(pano, patch) pairs, overlaid with the half-normal PDF whose σ is the per-pair
+MLE ``σ = sqrt(mean(r_norm²))``.
+
+Reuses ``calibrate_sigma.compute_samples`` so the numbers match the calibration.
+"""
+
+from pathlib import Path
+import argparse
+
+import common.torch.load_torch_deps  # noqa: F401  (must precede torch import)
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+
+import experimental.overhead_matching.swag.data.vigor_dataset as vd
+from experimental.overhead_matching.swag.filter.adaptive_aggregators import (
+    _load_similarity_matrix,
+)
+from experimental.overhead_matching.swag.scripts.calibrate_sigma import (
+    compute_samples,
+)
+
+
+def _half_normal_pdf(xs: np.ndarray, sigma: float) -> np.ndarray:
+    return (2.0 / (sigma * np.sqrt(2 * np.pi))) * np.exp(-0.5 * (xs / sigma) ** 2)
+
+
+def plot_paper_figure(
+    residuals_pair: torch.Tensor,
+    sigmas: list[tuple[float, str]],
+    output_path: Path,
+    *,
+    city: str,
+) -> None:
+    """Plot the residual histogram with one or more HalfNormal(σ) overlays.
+
+    ``sigmas`` is a list of ``(σ, label)``; each is drawn in a different color
+    with a matching dashed vertical at ``r = σ``.
+    """
+    r = residuals_pair.numpy()
+    xmax = 1.0  # r_norm is bounded in [0, 1]
+    bins = np.linspace(0.0, xmax, 61)
+    xs = np.linspace(0.0, xmax, 400)
+
+    plt.rcParams.update({
+        "font.size": 13,
+        "axes.titlesize": 14,
+        "axes.labelsize": 14,
+        "legend.fontsize": 12,
+        "xtick.labelsize": 12,
+        "ytick.labelsize": 12,
+    })
+
+    fig, ax = plt.subplots(figsize=(6.0, 4.2))
+    ax.hist(
+        r, bins=bins, density=True, color="steelblue", alpha=0.7,
+        edgecolor="white", linewidth=0.3,
+        label=f"true residuals (n={len(r):,})",
+    )
+    palette = ["C3", "C2", "C1", "C4", "C5"]
+    for i, (sigma, label) in enumerate(sigmas):
+        color = palette[i % len(palette)]
+        display = label or rf"HalfNormal($\sigma$={sigma:.3f})"
+        ax.plot(xs, _half_normal_pdf(xs, sigma), color=color, lw=2.5, label=display)
+        ax.axvline(sigma, color=color, ls="--", lw=1.5, alpha=0.6)
+    ax.set_xlim(0.0, xmax)
+    ax.set_ylim(bottom=0.0)
+    ax.set_xlabel(r"normalized residual $r_{\mathrm{norm}} = 1 - \mathrm{sim}_t / \mathrm{row\,max}$")
+    ax.set_ylabel("density")
+    ax.set_title(f"{city}: true-patch residuals vs calibrated $\\sigma$")
+    ax.legend(loc="upper center", frameon=True)
+    fig.tight_layout()
+    for ext in ("png", "pdf"):
+        fig.savefig(output_path.with_suffix(f".{ext}"), dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--similarity-matrix-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle/"
+                "similarity_matrices/simple_v1_v6_hungarian_0.8_similarity.pt")
+    parser.add_argument(
+        "--dataset-path", type=str,
+        default="/data/overhead_matching/datasets/VIGOR/Seattle")
+    parser.add_argument("--city", type=str, default="Seattle")
+    parser.add_argument("--landmark-version", type=str, default="v4_202001")
+    parser.add_argument(
+        "--include-semipositive", type=lambda s: s.lower() != "false",
+        default=True)
+    parser.add_argument(
+        "--output-path", type=str,
+        default="/data/overhead_matching/evaluation/results/"
+                "260501_v6_safa_plus_norm_lm/landmark_residual_exploration/"
+                "paper_sigma_fit_seattle")
+    parser.add_argument(
+        "--sigma", type=str, action="append", default=[],
+        help=("HalfNormal σ overlay(s). Repeat to overlay multiple. Each value "
+              "is either a bare number (e.g. 0.4673) or number:label "
+              "(e.g. 0.737:previous). When omitted, uses the per-pair MLE."))
+    args = parser.parse_args()
+
+    print(f"Loading similarity matrix from {args.similarity_matrix_path}")
+    sim_mat = _load_similarity_matrix(Path(args.similarity_matrix_path))
+    print(f"  shape: {tuple(sim_mat.shape)}, dtype: {sim_mat.dtype}")
+
+    print(f"Loading dataset metadata from {args.dataset_path}")
+    dataset_config = vd.VigorDatasetConfig(
+        satellite_tensor_cache_info=None,
+        panorama_tensor_cache_info=None,
+        should_load_images=False,
+        should_load_landmarks=False,
+        landmark_version=args.landmark_version,
+    )
+    vigor_dataset = vd.VigorDataset(Path(args.dataset_path), dataset_config)
+    pano_metadata = vigor_dataset._panorama_metadata
+    assert sim_mat.shape[0] == len(pano_metadata)
+    assert sim_mat.shape[1] == len(vigor_dataset._satellite_metadata)
+
+    print("Computing normalized per-pair residuals...")
+    rd = compute_samples(
+        sim_mat, pano_metadata,
+        include_semipositive=args.include_semipositive,
+        num_negative_samples_per_pano=0,
+        exclude_constant_rows=True,
+        residual_form="normalized",
+    )
+    residuals_pair = rd["residuals_pair"]
+    r = residuals_pair.numpy()
+    sigma_mle = float(np.sqrt(np.mean(r ** 2)))
+    print(f"  pairs: {len(r):,}   σ_MLE (normalized) = {sigma_mle:.6f}   "
+          f"median = {np.median(r):.6f}")
+
+    output_path = Path(args.output_path).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.sigma:
+        sigmas: list[tuple[float, str]] = []
+        for spec in args.sigma:
+            if ":" in spec:
+                num_str, label = spec.split(":", 1)
+                sigma_val = float(num_str)
+                sigmas.append((sigma_val, rf"$\sigma$={sigma_val:.3f} ({label})"))
+            else:
+                sigma_val = float(spec)
+                sigmas.append((sigma_val, rf"$\sigma$={sigma_val:.3f}"))
+    else:
+        sigmas = [(sigma_mle, rf"HalfNormal($\sigma_{{\mathrm{{lm}}}}$={sigma_mle:.3f})")]
+
+    plot_paper_figure(residuals_pair, sigmas, output_path, city=args.city)
+    print(f"\nWrote {output_path.with_suffix('.png')} and .pdf")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three small, cohesive additions to the paper-output scripts so the paper's tables + figures are regenerable end-to-end without hand-editing.

## Changes

### 1. `dataset_statistics.py` — new `--latex` mode

Emits the paper's `tab:dataset-stats` in one shot. Reads editorial metadata (per-city Conditions blurb, VIGOR / rig markers, VIGOR pano-date override, Boston Snowy/Night date overrides) from a new \`LATEX_PAPER_ROWS\` dict; datasets discovered on disk but not in that dict emit with an empty Conditions cell so they're obvious-to-edit. Numeric fields (panos, sat patches, sat coverage km², trajectory km, pano/OSM landmarks, YY-MM dates) are derived from the same code path the ASCII summary uses, so the LaTeX numbers can't drift from the plain-text output.

Default \`dataset_statistics\` behavior (no \`--latex\`) is unchanged.

### 2. \`sigma_paper_figure.py\` — new \`--sigma=value[:label]\` overlay flag (repeatable)

Overlays one or more \`HalfNormal(σ)\` PDFs on the empirical residual histogram. Enables A/B comparisons of calibrated σ values — e.g. the σ=0.737 per-pair MLE vs the σ=0.4673 used by the canonical Ours variant of the paper.

Default behavior (no \`--sigma\`) still uses the per-pair MLE, unchanged.

Also finalizes the BUILD-registration/target: the \`py_binary\` entry was previously committed on main but pointed at an untracked source file, so \`bazel build\` of this target would fail on a fresh checkout. This PR fills that in.

### 3. \`paper_convergence_plot.py\` — paper-ready formatting in \`print_summary_table\`

Match the paper's hand-formatted style directly from the script:

- 2-space indent inside \`\\begin{table*}\`
- \`ljust\`-padded data cells so the source columns visually line up (LaTeX ignores the extra whitespace; the diff stays clean when reviewers touch individual cells)
- Caption reads \`\"…mean $\\pm$ 95\\% CI using standard error of the mean.…\"\` — explicit about how the interval is built (\`1.96 * SEM\`, normal approximation).

All figure rendering behavior is unchanged; only the LaTeX table's whitespace + caption change.

## Test plan

- [x] \`bazel build //experimental/overhead_matching/swag/scripts:{paper_convergence_plot,sigma_paper_figure,dataset_statistics}\` — all three build clean.
- [x] Re-rendered the canonical paper figure + LaTeX table from the four-method eval set with the new script — matches the on-disk \`table.tex\` at \`.../260522_full_rerun_no_hinge/figures/cosmos_no_hinge_sigma0.46/\` bit-for-bit.
- [x] \`dataset_statistics.py --latex\` produces the paper's \`tab:dataset-stats\` rows verbatim; the ASCII summary output is unchanged.
- [x] \`sigma_paper_figure.py --sigma=0.737:MLE --sigma=0.4673:canonical\` overlays both PDFs and prints per-σ vertical lines; no \`--sigma\` still uses the MLE.