### PR TITLE
Correspondence tooling fixes

### DIFF
--- a/experimental/overhead_matching/swag/analysis/correspondence_explorer.py
+++ b/experimental/overhead_matching/swag/analysis/correspondence_explorer.py
@@ -262,6 +262,15 @@ HTML_TEMPLATE = '''
                 document.getElementById('pano-search').style.borderColor = '#ccc';
             } else {
                 document.getElementById('pano-search').style.borderColor = '#c00';
+                fetch(`/api/pano_lookup/${query}`).then(r => r.json()).then(info => {
+                    if (!info.in_dataset) {
+                        alert(`Pano ${query}: not in this dataset`);
+                    } else if (info.n_landmarks === 0) {
+                        alert(`Pano ${query}: in the dataset but has 0 Gemini landmarks — ` +
+                              `no correspondence rows exist, so the landmark stream is ` +
+                              `uniform at this step (observation likelihood = image stream only).`);
+                    }
+                });
             }
         }
 
@@ -771,6 +780,18 @@ def get_panoramas():
             'n_landmarks': n_lm,
         })
     return jsonify(result)
+
+
+@app.route('/api/pano_lookup/<pano_id>')
+def pano_lookup(pano_id):
+    """Explain why a searched pano is or isn't browsable (for cross-tool hops
+    from step_through_histogram, which lists every pano incl. landmark-less)."""
+    return jsonify({
+        'in_dataset': pano_id in PANO_ID_TO_VIGOR_IDX,
+        'n_landmarks': len(RAW_DATA.pano_id_to_lm_rows.get(pano_id, [])),
+        'in_explorer': pano_id in PANO_ID_TO_VIGOR_IDX
+                       and bool(RAW_DATA.pano_id_to_lm_rows.get(pano_id)),
+    })
 
 
 @app.route('/api/panorama/<pano_id>')

--- a/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
+++ b/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
@@ -195,7 +195,15 @@ def load_raw_cost_data(raw_path: Path) -> cm.RawCorrespondenceData:
     if "cost_matrix" in data:
         cost_matrix = data["cost_matrix"]
     else:
-        cost_npy = data["cost_matrix_path"]
+        # The recorded path is absolute and goes stale if the dataset moves;
+        # fall back to the .npy saved next to the .pt (the write-side layout).
+        cost_npy = Path(data["cost_matrix_path"])
+        if not cost_npy.exists():
+            sibling = raw_path.parent / (raw_path.stem + "_cost_matrix.npy")
+            if sibling.exists():
+                print(f"  Recorded cost-matrix path is stale ({cost_npy}); "
+                      f"using sibling {sibling}")
+                cost_npy = sibling
         print(f"  Memory-mapping cost matrix from {cost_npy}")
         cost_matrix = np.load(cost_npy, mmap_mode="r")
     return cm.RawCorrespondenceData(

--- a/experimental/overhead_matching/swag/scripts/export_similarity_matrix.py
+++ b/experimental/overhead_matching/swag/scripts/export_similarity_matrix.py
@@ -88,6 +88,32 @@ def load_models_from_training_output(base_path: Path, device='cuda', checkpoint=
     return pano_model, sat_model, checkpoint
 
 
+def override_tag_text_embeddings(models, pickle_path: Path) -> int:
+    """Repoint tag-bundle extractors at `pickle_path` and force a reload.
+
+    Both extractor classes lazy-load their tag-value embedding table from a
+    path attribute at first forward, so swapping the attribute before export
+    is sufficient. Returns the number of extractors updated.
+    """
+    from experimental.overhead_matching.swag.model import tag_bundle_extractor as tbe
+    pickle_path = Path(pickle_path).expanduser().resolve()
+    if not pickle_path.exists():
+        raise FileNotFoundError(f"override embeddings pickle not found: {pickle_path}")
+    count = 0
+    for model in models:
+        for module in model.modules():
+            if isinstance(module, tbe.OSMTagBundleExtractor):
+                module._embedding_path = pickle_path
+            elif isinstance(module, tbe.PanoramaTagBundleExtractor):
+                module._text_embedding_path = pickle_path
+            else:
+                continue
+            module._text_embeddings = None
+            module._files_loaded = False
+            count += 1
+    return count
+
+
 def get_git_info():
     try:
         commit = subprocess.check_output(
@@ -133,12 +159,23 @@ def main():
     parser.add_argument("--disable_safa_cache", action="store_true",
                         help="Force live SAFA computation (load images, ignore tensor cache). "
                              "Needed for cities that weren't pre-cached during training.")
+    parser.add_argument("--tag_text_embeddings_override", type=Path, default=None,
+                        help="Repoint every TagBundleExtractor in the loaded models at this "
+                             "tag-value text-embeddings pickle before export. Use when exporting "
+                             "a city whose tag values postdate the pickle recorded in the model "
+                             "config (the override must be a superset of it).")
     args = parser.parse_args()
 
     model_path = Path(args.model_path)
     pano_model, sat_model, checkpoint_idx = load_models_from_training_output(
         model_path, device=args.device, checkpoint=args.checkpoint,
         fallback_to_config=args.fallback_to_config)
+
+    if args.tag_text_embeddings_override is not None:
+        n = override_tag_text_embeddings(
+            [pano_model, sat_model], args.tag_text_embeddings_override)
+        print(f"Overrode tag text embeddings on {n} extractor(s) -> "
+              f"{args.tag_text_embeddings_override}")
 
     # Determine effective use_cached_extractors. With --disable_safa_cache,
     # treat everything as uncached so SAFA runs live on images.


### PR DESCRIPTION
- export_similarity_matrix: --tag_text_embeddings_override to repoint TagBundleExtractors at a superset embeddings pickle
- export_correspondence_similarity: fall back to sibling .npy when the recorded cost-matrix path is stale
- correspondence_explorer: /api/pano_lookup to explain why a searched pano isn't browsable