### PR TITLE
Docs/docstring fixes for the code release + roster-based dataset discovery

### DIFF
--- a/experimental/overhead_matching/baseline/dataset/city_pbf_map.py
+++ b/experimental/overhead_matching/baseline/dataset/city_pbf_map.py
@@ -21,7 +21,7 @@ CITY_TO_PBF: dict[str, CityPbf] = {
     "Middletown":             CityPbf("connecticut-250101.osm.pbf",   "connecticut_250101_Middletown"),
     "SanFrancisco_mapillary": CityPbf("norcal-220101.osm.pbf",        "norcal_220101_SanFrancisco_mapillary"),
     "post_hurricane_ian_sw":  CityPbf("florida-220101.osm.pbf",       "florida_220101_post_hurricane_ian_sw"),
-    # Benchmark-v2 rural cities (flat layout, <vigor-root>/<City>/; replaced the retired Norway split).
+    # Benchmark-v2 rural cities (flat layout, <vigor-root>/<City>/).
     "netherlands_norr":       CityPbf("netherlands-250101.osm.pbf",   "netherlands_250101_netherlands_norr"),
     "netherlands_veluwe":     CityPbf("netherlands-250101.osm.pbf",   "netherlands_250101_netherlands_veluwe"),
 }

--- a/experimental/overhead_matching/swag/data/README.md
+++ b/experimental/overhead_matching/swag/data/README.md
@@ -11,4 +11,4 @@ Sign up for Google Earth Engine and use this [snippet](https://code.earthengine.
 
 ## Landmarks
 
-Run the `experimental/overhead_matching/swag/scripts:extract_landmarks_for_vigor_dataset` target and place the generated landmark file (landmarks.geojson) in the dataset directory next to the satellite and panorama folders.
+Run the `experimental/overhead_matching/swag/scripts:extract_landmarks_for_vigor_dataset` target and place the generated landmark table in a `landmarks/` subdirectory of the dataset (next to the satellite and panorama folders), named after the landmark version: `<dataset>/landmarks/<landmark_version>.feather` (the loader falls back to `<landmark_version>.geojson`). The version string is what `--landmark_version` selects at load time.

--- a/experimental/overhead_matching/swag/evaluation/CORRESPONDENCE_EVAL_README.md
+++ b/experimental/overhead_matching/swag/evaluation/CORRESPONDENCE_EVAL_README.md
@@ -33,6 +33,8 @@ Create Gemini-labeled landmark correspondence pairs for training the classifier.
 # Generate Gemini batch JSONL for a city
 bazel run //experimental/overhead_matching/swag/scripts:landmark_pairing_cli -- \
     --all --city Chicago --with_negatives \
+    --pano_v2_base /data/overhead_matching/datasets/semantic_landmark_embeddings/panov2_tuned_prompt \
+    --landmark_version v4_202001 \
     --generate_batch /tmp/chicago_correspondence_batch.jsonl \
     --thinking_level LOW
 ```
@@ -147,7 +149,7 @@ bazel run //experimental/overhead_matching/swag/scripts:train_landmark_correspon
     --config /tmp/correspondence_train.yaml
 ```
 
-**Output:** `best_model.pt` (~700KB, 173K parameters), trains in ~5 minutes on GPU.
+**Output:** `best_model.pt` (~700KB, 173K parameters), trains in ~90 s on an RTX 5090.
 
 **Evaluate per-city classification:**
 ```bash
@@ -169,7 +171,6 @@ PANO_V2_EXTRA=/data/overhead_matching/datasets/semantic_landmark_embeddings
 
 # Example: one city
 bazel run //experimental/overhead_matching/swag/scripts:export_correspondence_similarity -- \
-    --save_raw \
     --model_path $MODEL \
     --text_embeddings_path $TEXT_EMB \
     --dataset_path /data/overhead_matching/datasets/VIGOR/netherlands_norr \
@@ -200,6 +201,7 @@ bazel run //experimental/overhead_matching/swag/scripts:export_correspondence_si
     --from_raw /data/overhead_matching/datasets/VIGOR/netherlands_norr/correspondence_scores/v5_all_cities_raw.pt \
     --dataset_path /data/overhead_matching/datasets/VIGOR/netherlands_norr \
     --output_path /data/overhead_matching/datasets/VIGOR/netherlands_norr/similarity_matrices/correspondence_v5_hungarian_0.8.pt \
+    --compute_similarity \
     --method hungarian \
     --aggregation sum \
     --prob_threshold 0.8 \
@@ -232,6 +234,7 @@ for CITY_PATH in \
 
     echo "=== $CITY_NAME ==="
     $BINARY --from_raw "$RAW" --dataset_path "$CITY_PATH" --output_path "$OUT" \
+        --compute_similarity \
         --method hungarian --aggregation sum --prob_threshold 0.8 --uniqueness_weighted
 done
 ```
@@ -322,7 +325,7 @@ Compare aggregation methods, analyze per-panorama and per-landmark behavior:
 
 ```bash
 bazel run //common/python:marimo_server -- edit \
-    /home/ekf/code/robot-tag-matcher-9000/experimental/overhead_matching/swag/analysis/correspondence_fusion_explorer.py
+    experimental/overhead_matching/swag/analysis/correspondence_fusion_explorer.py
 ```
 
 ## File Locations

--- a/experimental/overhead_matching/swag/scripts/dataset_statistics.py
+++ b/experimental/overhead_matching/swag/scripts/dataset_statistics.py
@@ -142,10 +142,19 @@ def parse_osm_date(landmark_version: str) -> str | None:
         return f"20{digits[:2]}-{digits[2:4]}-{digits[4:6]}"
 
 
-# On-disk city dirs that are not part of the benchmark roster (unused splits
-# or, for SanFrancisco, a VIGOR split that only donates imagery to
-# SanFrancisco_mapillary).
-SKIP_CITIES = {"SanFrancisco", "Gap", "MiamiBeach", "post_hurricane_ian"}
+# The benchmark roster's Mapillary-sourced cities. Discovery is
+# inclusion-based: dataset dirs on disk that are not part of the release
+# roster (side experiments, or imagery-donor splits like SanFrancisco, which
+# only donates satellite imagery to SanFrancisco_mapillary) are never
+# picked up.
+MAPILLARY_CITIES = [
+    "Framingham",
+    "Middletown",
+    "netherlands_norr",
+    "netherlands_veluwe",
+    "post_hurricane_ian_sw",
+    "SanFrancisco_mapillary",
+]
 
 
 def discover_datasets(base: Path) -> list[DatasetConfig]:
@@ -162,28 +171,22 @@ def discover_datasets(base: Path) -> list[DatasetConfig]:
     if (base / "nightdrive" / "panorama").is_dir():
         configs.append(DatasetConfig("nightdrive", base / "nightdrive", "landmarks/boston.feather"))
 
-    # Mapillary-style cities: flat at the dataset root (current layout), with
-    # base/mapillary/ kept as a fallback for pre-flatten checkouts.
-    already = {c.name for c in configs}
-    scan_dirs = [base]
-    if (base / "mapillary").is_dir():
-        scan_dirs.append(base / "mapillary")
-    for scan in scan_dirs:
-        for loc_dir in sorted(scan.iterdir()):
-            if (not loc_dir.is_dir() or loc_dir.name in already
-                    or loc_dir.name in ("mapillary", "trash")
-                    or loc_dir.name in SKIP_CITIES
-                    or not (loc_dir / "panorama").is_dir()):
-                continue
-            landmarks_dir = loc_dir / "landmarks"
-            if not landmarks_dir.is_dir():
-                continue
-            feather_files = list(landmarks_dir.glob("*.feather"))
-            if not feather_files:
-                continue
-            landmark_file = f"landmarks/{feather_files[0].name}"
-            configs.append(DatasetConfig(f"{loc_dir.name}", loc_dir, landmark_file))
-            already.add(loc_dir.name)
+    # Mapillary-sourced cities: flat at the dataset root (current layout),
+    # with base/mapillary/ kept as a fallback for pre-flatten checkouts.
+    for city in MAPILLARY_CITIES:
+        for root in (base, base / "mapillary"):
+            loc_dir = root / city
+            if (loc_dir / "panorama").is_dir():
+                break
+        else:
+            continue
+        landmarks_dir = loc_dir / "landmarks"
+        if not landmarks_dir.is_dir():
+            continue
+        feather_files = sorted(landmarks_dir.glob("*.feather"))
+        if not feather_files:
+            continue
+        configs.append(DatasetConfig(city, loc_dir, f"landmarks/{feather_files[0].name}"))
 
     return configs
 

--- a/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
+++ b/experimental/overhead_matching/swag/scripts/export_correspondence_similarity.py
@@ -10,16 +10,16 @@ Usage:
     bazel run //experimental/overhead_matching/swag/scripts:export_correspondence_similarity -- \\
         --model_path /data/.../best_model.pt \\
         --text_embeddings_path /data/.../eval_text_embeddings.pkl \\
-        --dataset_path /data/overhead_matching/datasets/VIGOR/mapillary/MiamiBeach \\
-        --pano_v2_base /data/.../semantic_landmark_embeddings/mapillary \\
-        --output_path /tmp/miami_corr.pt \\
+        --dataset_path /data/overhead_matching/datasets/VIGOR/Middletown \\
+        --pano_v2_base /data/.../semantic_landmark_embeddings/panov2_tuned_prompt \\
+        --output_path /tmp/middletown_corr.pt \\
         --compute_similarity
 
 Load an existing raw artifact and re-run only the similarity-matrix step:
     bazel run //experimental/overhead_matching/swag/scripts:export_correspondence_similarity -- \\
-        --from_raw /tmp/miami_corr.pt \\
-        --dataset_path /data/overhead_matching/datasets/VIGOR/mapillary/MiamiBeach \\
-        --output_path /tmp/miami_corr.pt \\
+        --from_raw /tmp/middletown_corr.pt \\
+        --dataset_path /data/overhead_matching/datasets/VIGOR/Middletown \\
+        --output_path /tmp/middletown_corr.pt \\
         --compute_similarity
 """
 

--- a/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
+++ b/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
@@ -37,7 +37,6 @@ DISPLAY_NAMES = {
     "Middletown": "Middletown",
     "netherlands_norr": "Noordoostpolder",
     "netherlands_veluwe": "Veluwe",
-    "post_hurricane_ian": "Fort Myers",
     "post_hurricane_ian_sw": "Fort Myers",
     "SanFrancisco_mapillary": "San Francisco",
     "Seattle": "Seattle",

--- a/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
+++ b/experimental/overhead_matching/swag/scripts/precompute_value_embeddings.py
@@ -17,8 +17,8 @@ Usage:
 
     # From feather + pano_v2 (expand to new cities):
     bazel run ...precompute_value_embeddings -- \
-        --feather_dirs /data/.../VIGOR/mapillary/MiamiBeach /data/.../VIGOR/NewYork \
-        --pano_v2_base /data/.../semantic_landmark_embeddings/mapillary \
+        --feather_dirs /data/.../VIGOR/Middletown /data/.../VIGOR/NewYork \
+        --pano_v2_base /data/.../semantic_landmark_embeddings/panov2_tuned_prompt \
         --base_embeddings /data/.../eval_text_embeddings.pkl \
         --output /data/.../eval_text_embeddings_expanded.pkl
 

--- a/experimental/overhead_matching/swag/scripts/timing/benchmark_correspondence_scaling_ollama.py
+++ b/experimental/overhead_matching/swag/scripts/timing/benchmark_correspondence_scaling_ollama.py
@@ -5,10 +5,10 @@ the whole-stockpile landmark-correspondence task, then extrapolates the calls an
 wall-clock to match a whole city (Chicago by default).
 
 Usage:
-    bazel run //experimental/overhead_matching/swag/scripts:benchmark_correspondence_scaling_ollama -- \
+    bazel run //experimental/overhead_matching/swag/scripts/timing:benchmark_correspondence_scaling_ollama -- \
         --output_dir /tmp/corr_scaling/gemma3_27b \
         --candidate_fills 100,1000,5000,10000,20000 \
-        --pano_batch 10 --thinking both
+        --pano_batches 10 --thinking both
 
 The Gemma 3 family is not a native reasoning model, so "thinking on" is best-effort:
 we try ollama's think=True and fall back to a chain-of-thought system instruction

--- a/experimental/overhead_matching/swag/scripts/timing/correspondence_scaling_README.md
+++ b/experimental/overhead_matching/swag/scripts/timing/correspondence_scaling_README.md
@@ -26,7 +26,8 @@ extrapolates to per-landmark / per-panorama / full-city cost.
 1. Install ollama (https://ollama.com) and ensure the `ollama` binary is on PATH. The
    `gemma3:27b` weights (~17 GB) are pulled automatically on first run.
 2. The VIGOR dataset and pano_v2 embeddings must be present under
-   `/data/overhead_matching/datasets/` (see `data/README.md`).
+   `/data/overhead_matching/datasets/` (layout documented in the loci release
+   repo's `data_release/README.md` and `docs/dataset_creation.md`).
 
 ## Run
 
@@ -50,7 +51,7 @@ bazel run //experimental/overhead_matching/swag/scripts/timing:benchmark_corresp
 
 ## Reference results
 
-The sweep results behind the paper figures are stored at
+The sweep results behind the paper's reported timings are stored at
 `/data/overhead_matching/evaluation/timing/`:
 - `gemma3_27b_thinking_off_per_panorama.jsonl` — ~5.4 min / panorama
 - `gemma3_27b_thinking_on_cot_per_panorama.jsonl` — ~7.6 min / panorama

--- a/experimental/overhead_matching/swag/scripts/timing/measure_pipeline_latency.py
+++ b/experimental/overhead_matching/swag/scripts/timing/measure_pipeline_latency.py
@@ -8,7 +8,7 @@ observation finishes before the robot has moved farther than the filter's
 noise can absorb), not strict realtime. The local LLM and sentence encoder
 stand in for Gemini / Vertex text-embedding-005.
 
-Stages timed (see /home/erick/.claude/plans/this-isn-t-quite-right-eventual-tide.md):
+Stages timed:
   1. pano_encode       - pano_model forward on one pano image
   2. ollama             - single-shot Ollama call on 4 yaw pinhole images
   3. sentence_embed    - local SBERT on any novel text values from stage 2
@@ -22,7 +22,7 @@ that isn't load-bearing for the per-step wall clock claim).
 
 Usage:
     # With Ollama running at localhost:11434
-    bazel run //experimental/overhead_matching/swag/scripts:measure_pipeline_latency -- \\
+    bazel run //experimental/overhead_matching/swag/scripts/timing:measure_pipeline_latency -- \\
         --num-samples 5 --warmup 1 \\
         --city Chicago \\
         --dataset-path /data/overhead_matching/datasets/VIGOR/Chicago \\


### PR DESCRIPTION
Cleanups found while auditing the LOCI release repo against the final arXiv manuscript. All are doc/docstring-level except the last item, which changes how `dataset_statistics.py` discovers datasets.

## Docstring / README fixes
- **`measure_pipeline_latency.py`**: remove a leaked personal plan path (`/home/erick/.claude/plans/...`) from the docstring; fix the usage bazel target (`scripts/timing:`, not `scripts:`).
- **`benchmark_correspondence_scaling_ollama.py`**: docstring used `--pano_batch` (real flag: `--pano_batches`) and the wrong target path.
- **`swag/data/README.md`**: landmark tables go in `<dataset>/landmarks/<landmark_version>.feather` (with `.geojson` fallback), not `landmarks.geojson` at the dataset root — matches what `vigor_dataset.py` actually loads.
- **`correspondence_scaling_README.md`**: fix a dangling `data/README.md` reference; the Gemma numbers back the paper's reported timings, not figures.
- **`CORRESPONDENCE_EVAL_README.md`**:
  - Stage 0 example was missing the `required=True` args `--pano_v2_base` / `--landmark_version`.
  - Stage 3 example used a nonexistent `--save_raw` flag (raw export is the default).
  - Stage 4 examples omitted `--compute_similarity`, without which the script loads raw scores and exits writing nothing.
  - Training time: ~5 min → ~90 s (RTX 5090), matching the paper.
  - Fusion-explorer marimo path was an absolute path into a stale `robot-tag-matcher-9000` worktree; now repo-relative.
- **`precompute_value_embeddings.py` / `export_correspondence_similarity.py`**: modernize docstring examples (flat VIGOR layout, release cities, `panov2_tuned_prompt` base).
- **`city_pbf_map.py` / `paper_convergence_plot.py`**: drop a retired-environment comment and a leftover `post_hurricane_ian` display-name alias.

## Roster-based dataset discovery
`dataset_statistics.py` previously auto-scanned `datasets/VIGOR/` for anything with `panorama/` + `landmarks/*.feather` and relied on a `SKIP_CITIES` denylist to keep non-release dirs (side experiments; the `SanFrancisco` imagery-donor split) out of the paper's dataset table. Discovery is now inclusion-based via an explicit `MAPILLARY_CITIES` roster, so stray on-disk dirs are never picked up. Feather selection is now `sorted()` (deterministic), and the pre-flatten `mapillary/` fallback is preserved per-city. Verified all 11 roster cities resolve on `/data`.

The LOCI release repo mirrors these files byte-identically, so the next release sync after merging is a no-op.