### PR TITLE
swag_patch_embedding: lazy-import the optional extractors

### DIFF
--- a/experimental/overhead_matching/swag/model/BUILD
+++ b/experimental/overhead_matching/swag/model/BUILD
@@ -111,20 +111,34 @@ py_library(
     requirement("torch"),
     requirement("torchvision"),
     requirement("msgspec"),
-    ":alphaearth_extractor",
     ":safa_extractor",
     ":tag_bundle_extractor",
     ":semantic_landmark_extractor",
     ":panorama_semantic_landmark_extractor",
     ":additional_panorama_extractors",
-    ":synthetic_landmark_extractor",
-    ":semantic_segment_extractor",
-    ":absolute_position_extractor",
     ":swag_config_types",
     ":swag_model_input_output",
     ":landmark_scheduler",
     "//common/torch:load_torch_deps",
   ]
+)
+
+# Extractors the factory in swag_patch_embedding.py imports lazily. Binaries
+# that instantiate these config kinds (AlphaEarth, SemanticSegment,
+# SyntheticLandmark, AbsolutePosition) must add this target (or the
+# individual libs) to their deps; the paper-release closure omits them.
+py_library(
+  name = "extractor_extras",
+  visibility = [
+    "//experimental/overhead_matching/swag:__subpackages__",
+    "//common/python:__subpackages__",
+  ],
+  deps = [
+    ":alphaearth_extractor",
+    ":semantic_segment_extractor",
+    ":synthetic_landmark_extractor",
+    ":absolute_position_extractor",
+  ],
 )
 
 py_test(

--- a/experimental/overhead_matching/swag/model/swag_patch_embedding.py
+++ b/experimental/overhead_matching/swag/model/swag_patch_embedding.py
@@ -8,8 +8,6 @@ from pathlib import Path
 from typing import Any
 from experimental.overhead_matching.swag.model.swag_model_input_output import (
     ModelInput, SemanticTokenExtractorOutput, FeatureMapExtractorOutput, ExtractorOutput)
-from experimental.overhead_matching.swag.model.semantic_segment_extractor import SemanticSegmentExtractor
-from experimental.overhead_matching.swag.model.alphaearth_extractor import AlphaEarthExtractor
 from experimental.overhead_matching.swag.model.semantic_landmark_extractor import SemanticLandmarkExtractor
 from experimental.overhead_matching.swag.model.panorama_semantic_landmark_extractor import (
     PanoramaSemanticLandmarkExtractor,
@@ -23,8 +21,6 @@ from experimental.overhead_matching.swag.model.tag_bundle_extractor import (
     OSMTagBundleExtractor, PanoramaTagBundleExtractor,
 )
 from torch.nn.init import xavier_uniform_
-from experimental.overhead_matching.swag.model.synthetic_landmark_extractor import SyntheticLandmarkExtractor
-from experimental.overhead_matching.swag.model.absolute_position_extractor import AbsolutePositionExtractor
 from experimental.overhead_matching.swag.model.swag_config_types import (
     FeatureMapExtractorConfig,
     DinoFeatureMapExtractorConfig,
@@ -95,13 +91,29 @@ def create_extractor(config: ExtractorConfig, auxiliary_info: dict[str, Any]):
         case PanoramaSemanticLandmarkExtractorConfig(): return PanoramaSemanticLandmarkExtractor(config, auxiliary_info[config.auxiliary_info_key])
         case PanoramaProperNounExtractorConfig(): return PanoramaProperNounExtractor(config, auxiliary_info[config.auxiliary_info_key])
         case PanoramaLocationTypeExtractorConfig(): return PanoramaLocationTypeExtractor(config, auxiliary_info[config.auxiliary_info_key])
-        case SemanticSegmentExtractorConfig(): return SemanticSegmentExtractor(config)
-        case SyntheticLandmarkExtractorConfig(): return SyntheticLandmarkExtractor(config)
-        case AbsolutePositionExtractorConfig(): return AbsolutePositionExtractor(config)
+        # The four extractors below are imported lazily so the paper-release
+        # code closure (which never instantiates them) does not carry their
+        # modules; consumers that use these config kinds must depend on
+        # :extractor_extras (or the individual extractor libs).
+        case SemanticSegmentExtractorConfig():
+            from experimental.overhead_matching.swag.model.semantic_segment_extractor import (
+                SemanticSegmentExtractor)
+            return SemanticSegmentExtractor(config)
+        case SyntheticLandmarkExtractorConfig():
+            from experimental.overhead_matching.swag.model.synthetic_landmark_extractor import (
+                SyntheticLandmarkExtractor)
+            return SyntheticLandmarkExtractor(config)
+        case AbsolutePositionExtractorConfig():
+            from experimental.overhead_matching.swag.model.absolute_position_extractor import (
+                AbsolutePositionExtractor)
+            return AbsolutePositionExtractor(config)
         case SafaExtractorConfig(): return SafaExtractor(config)
         case OSMTagBundleExtractorConfig(): return OSMTagBundleExtractor(config)
         case PanoramaTagBundleExtractorConfig(): return PanoramaTagBundleExtractor(config)
-        case AlphaEarthExtractorConfig(): return AlphaEarthExtractor(
+        case AlphaEarthExtractorConfig():
+            from experimental.overhead_matching.swag.model.alphaearth_extractor import (
+                AlphaEarthExtractor)
+            return AlphaEarthExtractor(
                 config, auxiliary_info[config.auxiliary_info_key])
     raise NotImplementedError(f"Unhandled Config Type: {config}")
 


### PR DESCRIPTION
The extractor factory in `swag_patch_embedding.py` imported every extractor at module top level, so the LOCI release's query-driven code sync (bazel dependency closure of the paper targets) carried AlphaEarth, SemanticSegment, SyntheticLandmark, and AbsolutePosition even though no paper model config uses them.

- The four imports move inside their `create_extractor()` match cases; the libs leave `swag_patch_embedding`'s BUILD deps.
- New `//experimental/overhead_matching/swag/model:extractor_extras` bundles them — any binary that instantiates these config kinds needs it (or the individual libs) in its deps. Nothing in-tree currently does: the only importers were this factory and the untargeted `plot_from_tensorboard.py`, and all in-tree configs/tests construct these extractors directly.
- Verified: all four extractor tests + `swag_patch_embedding_test` + `tag_bundle_extractor_test` pass; `:train` and `:export_similarity_matrix` build.

With this merged, the release closure drops 8 model files, the C++-free alphaearth registry pair, and the `@alphaearth_snippet` external.