### PR TITLE
Trim dev-only trainer deps; fix stale script defaults

### DIFF
--- a/experimental/overhead_matching/swag/model/BUILD
+++ b/experimental/overhead_matching/swag/model/BUILD
@@ -126,7 +126,7 @@ py_library(
 # Extractors the factory in swag_patch_embedding.py imports lazily. Binaries
 # that instantiate these config kinds (AlphaEarth, SemanticSegment,
 # SyntheticLandmark, AbsolutePosition) must add this target (or the
-# individual libs) to their deps; the paper-release closure omits them.
+# individual libs) to their deps.
 py_library(
   name = "extractor_extras",
   visibility = [

--- a/experimental/overhead_matching/swag/model/swag_patch_embedding.py
+++ b/experimental/overhead_matching/swag/model/swag_patch_embedding.py
@@ -91,10 +91,9 @@ def create_extractor(config: ExtractorConfig, auxiliary_info: dict[str, Any]):
         case PanoramaSemanticLandmarkExtractorConfig(): return PanoramaSemanticLandmarkExtractor(config, auxiliary_info[config.auxiliary_info_key])
         case PanoramaProperNounExtractorConfig(): return PanoramaProperNounExtractor(config, auxiliary_info[config.auxiliary_info_key])
         case PanoramaLocationTypeExtractorConfig(): return PanoramaLocationTypeExtractor(config, auxiliary_info[config.auxiliary_info_key])
-        # The four extractors below are imported lazily so the paper-release
-        # code closure (which never instantiates them) does not carry their
-        # modules; consumers that use these config kinds must depend on
-        # :extractor_extras (or the individual extractor libs).
+        # The four extractors below are imported lazily; consumers that
+        # instantiate these config kinds must depend on :extractor_extras
+        # (or the individual extractor libs).
         case SemanticSegmentExtractorConfig():
             from experimental.overhead_matching.swag.model.semantic_segment_extractor import (
                 SemanticSegmentExtractor)

--- a/experimental/overhead_matching/swag/scripts/BUILD
+++ b/experimental/overhead_matching/swag/scripts/BUILD
@@ -158,9 +158,9 @@ py_binary(
   srcs=["train.py"],
   visibility=["//common/python:__subpackages__", "//common/tools/lambda_cloud:__subpackages__"],
   deps=[
+    # :lr_sweep and :model_inspector are lazy-imported dev-only features
+    # (--lr_sweep / model capture); add them back here if you use those modes.
     ":logging_utils",
-    ":lr_sweep",
-    ":model_inspector",
     ":pairing",
     ":losses",
     ":distances",

--- a/experimental/overhead_matching/swag/scripts/download_osm_dumps.sh
+++ b/experimental/overhead_matching/swag/scripts/download_osm_dumps.sh
@@ -1,85 +1,42 @@
 #!/bin/bash
 
-# Download OpenStreetMap dumps for all US states from Geofabrik
+# Download the dated Geofabrik OSM extracts the paper's landmark tables and
+# rasterized-OSM tiles are derived from (one entry per benchmark region; the
+# region -> city mapping lives in
+# experimental/overhead_matching/baseline/dataset/city_pbf_map.py).
+# Geofabrik archives dated extracts as <region>-<YYMMDD>.osm.pbf.
 
-BASE_URL="https://download.geofabrik.de/north-america/us"
+BASE_URL="https://download.geofabrik.de"
 OUTPUT_DIR="/data/overhead_matching/datasets/osm_dumps"
 
-# Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 
-# List of US states
-STATES=(
-    "Alabama"
-    "Alaska"
-    "Arizona"
-    "Arkansas"
-    "California"
-    "Colorado"
-    "Connecticut"
-    "Delaware"
-    "Florida"
-    "Georgia"
-    "Hawaii"
-    "Idaho"
-    "Illinois"
-    "Indiana"
-    "Iowa"
-    "Kansas"
-    "Kentucky"
-    "Louisiana"
-    "Maine"
-    "Maryland"
-    "Massachusetts"
-    "Michigan"
-    "Minnesota"
-    "Mississippi"
-    "Missouri"
-    "Montana"
-    "Nebraska"
-    "Nevada"
-    "New Hampshire"
-    "New Jersey"
-    "New Mexico"
-    "New York"
-    "North Carolina"
-    "North Dakota"
-    "Ohio"
-    "Oklahoma"
-    "Oregon"
-    "Pennsylvania"
-    "Rhode Island"
-    "South Carolina"
-    "South Dakota"
-    "Tennessee"
-    "Texas"
-    "Utah"
-    "Vermont"
-    "Virginia"
-    "Washington"
-    "West Virginia"
-    "Wisconsin"
-    "Wyoming"
+DUMPS=(
+    "north-america/us/illinois-200101.osm.pbf"           # Chicago (train)
+    "north-america/us/washington-200101.osm.pbf"         # Seattle (calibration/val)
+    "north-america/us/new-york-200101.osm.pbf"           # New York
+    "north-america/us/massachusetts-260101.osm.pbf"      # Boston Snowy/Night, Framingham
+    "north-america/us/connecticut-250101.osm.pbf"        # Middletown
+    "north-america/us/california/norcal-220101.osm.pbf"  # San Francisco (Mapillary)
+    "north-america/us/florida-220101.osm.pbf"            # Fort Myers (post_hurricane_ian_sw)
+    "europe/netherlands-250101.osm.pbf"                  # Noordoostpolder, Veluwe
 )
 
-for state in "${STATES[@]}"; do
-    # Convert to lowercase and replace spaces with hyphens
-    state_slug=$(echo "$state" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
-
-    filename="${state_slug}-200101.osm.pbf"
-    url="${BASE_URL}/${filename}"
+for rel in "${DUMPS[@]}"; do
+    filename=$(basename "$rel")
+    url="${BASE_URL}/${rel}"
     output_path="${OUTPUT_DIR}/${filename}"
 
     if [[ -f "$output_path" ]]; then
-        echo "Skipping $state (already exists)"
+        echo "Skipping $filename (already exists)"
         continue
     fi
 
-    echo "Downloading $state..."
+    echo "Downloading $filename..."
     if wget -q --show-progress -O "$output_path" "$url"; then
-        echo "Downloaded $state successfully"
+        echo "Downloaded $filename successfully"
     else
-        echo "Failed to download $state"
+        echo "Failed to download $filename"
         rm -f "$output_path"  # Remove partial download
     fi
 done

--- a/experimental/overhead_matching/swag/scripts/lr_sweep.py
+++ b/experimental/overhead_matching/swag/scripts/lr_sweep.py
@@ -1,6 +1,5 @@
 import torch
 from pathlib import Path
-from dataclasses import dataclass
 import numpy as np
 import matplotlib
 matplotlib.use('Agg')  # Use non-interactive backend
@@ -10,17 +9,11 @@ from experimental.overhead_matching.swag.scripts.pairing import create_pairs, Pa
 from experimental.overhead_matching.swag.data import vigor_dataset
 
 
-@dataclass
-class LearningRateSweepConfig:
-    start_lr: float = 1.5e-7  # 0.1x burn-in LR
-    end_lr: float = 1.5e-1    # 100x burn-in LR
-    num_batches: int = 1000   # 10x more batches for fine resolution
-    burn_in_batches: int = 50
-    burn_in_lr: float = 1.5e-5
-
-
+# NOTE: LearningRateSweepConfig lives in train.py (it is part of the
+# trainer's config schema); this module is lazy-imported by train.py's
+# --lr_sweep mode and duck-types the config to avoid a circular import.
 def run_lr_sweep(
-        lr_sweep_config: LearningRateSweepConfig,
+        lr_sweep_config,  # train.LearningRateSweepConfig
         dataset,
         panorama_model,
         satellite_model,

--- a/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
+++ b/experimental/overhead_matching/swag/scripts/paper_convergence_plot.py
@@ -447,26 +447,29 @@ def main():
     parser.add_argument(
         "--output_dir",
         type=str,
-        default="/tmp/paper_plots",
+        required=True,
         help="Directory to save figures",
     )
     parser.add_argument(
         "--baseline_dir",
         type=str,
-        default="/data/overhead_matching/evaluation/results/260428_v6_safa_only_noise014",
-        help="Base directory for SAFA baseline results",
+        required=True,
+        help="Base directory for image-baseline (WAG) results, "
+             "containing <env>/<baseline_method>/ eval outputs",
     )
     parser.add_argument(
         "--ours_dir",
         type=str,
-        default="/data/overhead_matching/evaluation/results/260501_v6_safa_plus_norm_lm",
-        help="Base directory for our method results",
+        required=True,
+        help="Base directory for our method's results, "
+             "containing <env>/<ours_method>/ eval outputs",
     )
     parser.add_argument(
         "--osm_dir",
         type=str,
-        default="/data/overhead_matching/evaluation/results/260504_160045_osm_baseline",
-        help="Base directory for OSM baseline results (may cover only a subset of envs)",
+        default=None,
+        help="Base directory for OSM baseline results (may cover only a "
+             "subset of envs). Skipped if not set; requires --osm_method.",
     )
     parser.add_argument(
         "--seattle_results_dir",
@@ -478,20 +481,21 @@ def main():
     parser.add_argument(
         "--baseline_method",
         type=str,
-        default="safa_only",
+        required=True,
         help="Subdirectory name for baseline method within each city",
     )
     parser.add_argument(
         "--ours_method",
         type=str,
-        default="safa_plus_norm_lm",
+        required=True,
         help="Subdirectory name for our method within each city",
     )
     parser.add_argument(
         "--osm_method",
         type=str,
-        default="dinov3_osm",
-        help="Subdirectory name for OSM baseline method within each city",
+        default=None,
+        help="Subdirectory name for OSM baseline method within each city "
+             "(required when --osm_dir is set)",
     )
     parser.add_argument(
         "--env_dir_override",
@@ -532,8 +536,9 @@ def main():
     parser.add_argument(
         "--early_method",
         type=str,
-        default="early_fusion_attempt_v1",
-        help="Subdirectory name for the early-fusion method within each city",
+        default=None,
+        help="Subdirectory name for the early-fusion method within each city "
+             "(required when --early_dir is set)",
     )
     parser.add_argument(
         "--early_label",
@@ -582,6 +587,11 @@ def main():
              "for every env or loading throws.",
     )
     args = parser.parse_args()
+
+    if args.osm_dir and not args.osm_method:
+        raise SystemExit("--osm_method is required when --osm_dir is set")
+    if args.early_dir and not args.early_method:
+        raise SystemExit("--early_method is required when --early_dir is set")
 
     env_xlim_overrides: dict[str, float] = {}
     for spec in args.env_xlim:

--- a/experimental/overhead_matching/swag/scripts/train.py
+++ b/experimental/overhead_matching/swag/scripts/train.py
@@ -23,7 +23,6 @@ from experimental.overhead_matching.swag.model.landmark_scheduler import (
 )
 from experimental.overhead_matching.swag.scripts.logging_utils import (
     log_batch_metrics, log_embedding_stats, log_gradient_stats, log_validation_metrics, log_feature_counts)
-from experimental.overhead_matching.swag.scripts.model_inspector import ModelInspector
 from experimental.overhead_matching.swag.evaluation.retrieval_metrics import validation_metrics_from_similarity
 from typing import Union
 from dataclasses import dataclass, field
@@ -35,7 +34,6 @@ from contextlib import nullcontext
 import datetime
 import random
 import numpy as np
-from experimental.overhead_matching.swag.scripts.lr_sweep import LearningRateSweepConfig, run_lr_sweep
 
 
 def setup_reproducibility(seed: int | None) -> torch.Generator | None:
@@ -95,6 +93,18 @@ class LearningRateSchedule:
 
     warmup_factor: float
     num_warmup_epochs: int
+
+
+@dataclass
+class LearningRateSweepConfig:
+    """Config for the optional --lr_sweep mode. Lives here (not in
+    lr_sweep.py) because it is part of the trainer's config schema; the sweep
+    implementation in lr_sweep.py is imported lazily."""
+    start_lr: float = 1.5e-7  # 0.1x burn-in LR
+    end_lr: float = 1.5e-1    # 100x burn-in LR
+    num_batches: int = 1000   # 10x more batches for fine resolution
+    burn_in_batches: int = 50
+    burn_in_lr: float = 1.5e-5
 
 
 @dataclass
@@ -398,9 +408,10 @@ def train(config: TrainConfig,
             opt_config.num_epochs
         )
 
-    # Create model inspector if requested
+    # Create model inspector if requested (lazy import: debug-only feature)
     inspector = None
     if capture_model_data:
+        from experimental.overhead_matching.swag.scripts.model_inspector import ModelInspector
         inspector = ModelInspector(
             output_dir=output_dir,
             num_batches_to_capture=num_batches_to_capture)
@@ -780,8 +791,10 @@ def main(
     train_config.output_dir = output_dir
     train_config.tensorboard_output = tensorboard_output
 
-    # Run learning rate sweep if requested
+    # Run learning rate sweep if requested (lazy import: dev-only feature)
     if lr_sweep:
+        from experimental.overhead_matching.swag.scripts.lr_sweep import run_lr_sweep
+
         # Create default LR sweep config if not in train config
         if train_config.opt_config.lr_sweep_config is None:
             train_config.opt_config.lr_sweep_config = LearningRateSweepConfig()


### PR DESCRIPTION
Third release-audit cleanup pass:

- **train.py**: `ModelInspector` and `run_lr_sweep` are flag-gated dev features but were imported at module top level, keeping `model_inspector.py`/`lr_sweep.py` in the LOCI release closure. They're now lazy-imported inside their gates, and `LearningRateSweepConfig` moves into `train.py` (it's part of the trainer's config schema — `OptimizationConfig.lr_sweep_config`). `lr_sweep.py` duck-types the config to avoid a circular import. Both libs leave `:train`'s deps; anyone using `--lr_sweep` or model capture adds them back to their binary.
- **paper_convergence_plot.py**: the default paths pointed at May-era result dirs (`260428_v6_safa_only_noise014`, `260501_v6_safa_plus_norm_lm`, `260504_160045_osm_baseline`) with internal method names (`safa_only`, `safa_plus_norm_lm`, `dinov3_osm`, `early_fusion_attempt_v1`) — none match the final paper runs. All path/method defaults are removed: `--output_dir/--baseline_dir/--ours_dir/--baseline_method/--ours_method` are required; `--osm_dir/--early_dir` stay optional with validation requiring their method args. Display-label defaults (WAG/WAG+OSM/LOCI/LOCI-EF) are kept — they're current.
- **download_osm_dumps.sh**: downloaded all 50 US states at a single 2020 date; now fetches exactly the eight dated Geofabrik extracts behind the benchmark (illinois/washington/new-york @200101, massachusetts @260101, connecticut @250101, california/norcal @220101, florida @220101, netherlands @250101), matching `city_pbf_map.py`.

Verified: `:train`, `:paper_convergence_plot`, `:lr_sweep`, `:model_inspector` build; `losses_test`/`pairing_test`/`distances_test` pass.